### PR TITLE
Add llms.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Keep a Changelog records what changed. Keep the Why preserves why it changed.
 
 **Keep the Why** is a repo-native agent skill that continuously captures — or retrospectively recovers — the reasoning behind a codebase: architecture decisions, rejected alternatives, workarounds, incident learnings, and operational constraints that the code alone can't explain.
 
-Website: [https://keepthewhy.com](https://keepthewhy.com/)
+Website: [https://keepthewhy.com](https://keepthewhy.com/) · [llms.txt](https://keepthewhy.com/llms.txt) for AI agents/assistants looking up this project
 
 ## The problem
 

--- a/context/compatibility.md
+++ b/context/compatibility.md
@@ -25,3 +25,14 @@ README, `docs/installation.md`, and `docs/faq.md` list specific agent names — 
 **Rejected alternative:** leave DeepWiki as an implied example under the generic "wiki generator" category without naming it, on the theory that the general claim already covers it. Rejected for the same reason the broader agent list was expanded: a named example a reader recognizes ("oh, DeepWiki, I've used that") is more convincing and more useful than an abstract category they have to map onto tools themselves.
 
 **Kept honest:** the FAQ entry also states the one real limitation found during the earlier verification — DeepWiki re-synthesizes content into its own wiki in its own voice, so it may not preserve the confirmed/inferred/superseded distinctions this project relies on. Not overclaiming compatibility here follows the same discipline as Core rule 1.
+
+## `llms.txt` at both the repo root and the site root
+
+**Status:** active
+**Confirmed**
+
+An `llms.txt` file exists at the repo root (for tools browsing the repo directly) and is duplicated into `docs/llms.txt` so the built site serves it at `https://keepthewhy.com/llms.txt` (mkdocs copies non-Markdown files in `docs/` straight through to the built site). README links to it.
+
+**Reason:** `llms.txt` is a proposed convention (llmstxt.org) for giving AI agents/assistants a concise, structured summary of a project without needing to crawl and parse full HTML or an entire repo — a short, purpose-built file for LLM consumption specifically. It's a separate, established open standard from the Agent Skills/SKILL.md format this project's install table already covers; this file exists for tools that just want a quick summary, not to install or run anything.
+
+**Rejected alternative:** keep the content in only one location and symlink or reference it from the other. Rejected because the two consumption paths have fixed, non-negotiable path expectations (GitHub always resolves repo-root files; the llms.txt convention specifically expects the file at a site's root) that a symlink can't satisfy for both a git checkout and a deployed static site simultaneously — this is a case where duplication is the direct consequence of two independent path conventions, not a routing mistake (contrast with the file-routing guidance in `scope.md`, which is about content that has one true home and shouldn't be copied elsewhere).

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,71 @@
+# Keep the Why
+
+> A repo-native agent skill that continuously captures — or retrospectively recovers — the
+> reasoning behind a codebase: architecture decisions, rejected alternatives, workarounds,
+> incident learnings, and operational constraints that the code alone can't explain.
+
+Because "ask Bob" is not documentation. Keep a Changelog records what changed; Keep the Why
+preserves why it changed. Complements tests, docs, README, and Keep a Changelog rather than
+replacing any of them — see "Where this fits" in the README.
+
+Version: 0.1.0.
+
+## Authorship & License
+
+Author / Maintainer: Oliver Zehentleitner (https://github.com/oliver-zehentleitner)
+License: MIT — free for commercial and private use. No paid license, no subscription, no commercial tier.
+
+## Quick Start
+
+Install as an agent skill — the folder name must stay `keep-the-why`:
+
+```bash
+git clone https://github.com/oliver-zehentleitner/keep-the-why.git .claude/skills/keep-the-why
+```
+
+Compatible with Claude Code, Codex CLI, Gemini CLI, GitHub Copilot, Cursor, Windsurf,
+Antigravity, Amp, Cline, Goose, Roo Code, OpenCode, Trae, Factory, JetBrains Junie, Warp, and
+other tools supporting the open Agent Skills format. Full paths per agent: see Installation below.
+
+## Core Concept
+
+Four modes, one underlying mechanism (classify evidence as confirmed / inferred / unknown; ask
+only what evidence can't resolve):
+
+- Continuous capture — record rationale as it comes up during normal development
+- Retrospective recovery — reconstruct rationale from an existing or legacy repository
+- Knowledge-transfer interview — recover a departing developer's knowledge before it's lost
+- Maintenance — keep existing rationale current, mark superseded entries, split oversized files
+
+Produces, inside the project using the skill:
+- `AGENTS.md` — lean entry point, pointers only
+- `docs/` — how to use, operate, test, deploy
+- `context/` — why the project is the way it is, organized by topic
+- `AGENTS.local.md` — personal/local notes, not committed
+
+## Not a Green Field
+
+Related prior art: Architecture Decision Records, the AGENTS.md standard, git-why, Agent
+Decision Records, Addy Osmani's `documentation-and-adrs` skill. Keep the Why's distinguishing
+combination: continuous capture *and* retrospective recovery *and* code-guided interviews,
+organized as topic-indexed living docs rather than a shadow tree or one-file-per-decision, with
+no required external service (no database, no MCP server).
+
+## Common Mistakes
+
+- Don't treat this as a replacement for tests, docs, README, or a changelog — it covers only the
+  "why" layer; see "Where this fits" in the README.
+- Don't invent rationale when evidence doesn't support an answer — mark it "unknown" instead of
+  guessing.
+- Don't create a new topic file in `context/` when an existing one on the same subject should be
+  updated instead.
+- Don't ask generic interview questions — analyze the repository first, then ask about
+  specifically what the code couldn't explain.
+
+## Docs
+
+- Repo: https://github.com/oliver-zehentleitner/keep-the-why
+- AGENTS.md (for AI agents working on this repo): https://github.com/oliver-zehentleitner/keep-the-why/blob/main/AGENTS.md
+- SKILL.md: https://github.com/oliver-zehentleitner/keep-the-why/blob/main/SKILL.md
+- Docs: https://keepthewhy.com
+- Why this project is built this way: https://keepthewhy.com/context/naming/ (and the other pages under "Why this project is built this way")

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,71 @@
+# Keep the Why
+
+> A repo-native agent skill that continuously captures — or retrospectively recovers — the
+> reasoning behind a codebase: architecture decisions, rejected alternatives, workarounds,
+> incident learnings, and operational constraints that the code alone can't explain.
+
+Because "ask Bob" is not documentation. Keep a Changelog records what changed; Keep the Why
+preserves why it changed. Complements tests, docs, README, and Keep a Changelog rather than
+replacing any of them — see "Where this fits" in the README.
+
+Version: 0.1.0.
+
+## Authorship & License
+
+Author / Maintainer: Oliver Zehentleitner (https://github.com/oliver-zehentleitner)
+License: MIT — free for commercial and private use. No paid license, no subscription, no commercial tier.
+
+## Quick Start
+
+Install as an agent skill — the folder name must stay `keep-the-why`:
+
+```bash
+git clone https://github.com/oliver-zehentleitner/keep-the-why.git .claude/skills/keep-the-why
+```
+
+Compatible with Claude Code, Codex CLI, Gemini CLI, GitHub Copilot, Cursor, Windsurf,
+Antigravity, Amp, Cline, Goose, Roo Code, OpenCode, Trae, Factory, JetBrains Junie, Warp, and
+other tools supporting the open Agent Skills format. Full paths per agent: see Installation below.
+
+## Core Concept
+
+Four modes, one underlying mechanism (classify evidence as confirmed / inferred / unknown; ask
+only what evidence can't resolve):
+
+- Continuous capture — record rationale as it comes up during normal development
+- Retrospective recovery — reconstruct rationale from an existing or legacy repository
+- Knowledge-transfer interview — recover a departing developer's knowledge before it's lost
+- Maintenance — keep existing rationale current, mark superseded entries, split oversized files
+
+Produces, inside the project using the skill:
+- `AGENTS.md` — lean entry point, pointers only
+- `docs/` — how to use, operate, test, deploy
+- `context/` — why the project is the way it is, organized by topic
+- `AGENTS.local.md` — personal/local notes, not committed
+
+## Not a Green Field
+
+Related prior art: Architecture Decision Records, the AGENTS.md standard, git-why, Agent
+Decision Records, Addy Osmani's `documentation-and-adrs` skill. Keep the Why's distinguishing
+combination: continuous capture *and* retrospective recovery *and* code-guided interviews,
+organized as topic-indexed living docs rather than a shadow tree or one-file-per-decision, with
+no required external service (no database, no MCP server).
+
+## Common Mistakes
+
+- Don't treat this as a replacement for tests, docs, README, or a changelog — it covers only the
+  "why" layer; see "Where this fits" in the README.
+- Don't invent rationale when evidence doesn't support an answer — mark it "unknown" instead of
+  guessing.
+- Don't create a new topic file in `context/` when an existing one on the same subject should be
+  updated instead.
+- Don't ask generic interview questions — analyze the repository first, then ask about
+  specifically what the code couldn't explain.
+
+## Docs
+
+- Repo: https://github.com/oliver-zehentleitner/keep-the-why
+- AGENTS.md (for AI agents working on this repo): https://github.com/oliver-zehentleitner/keep-the-why/blob/main/AGENTS.md
+- SKILL.md: https://github.com/oliver-zehentleitner/keep-the-why/blob/main/SKILL.md
+- Docs: https://keepthewhy.com
+- Why this project is built this way: https://keepthewhy.com/context/naming/ (and the other pages under "Why this project is built this way")


### PR DESCRIPTION
## Summary
- Added `llms.txt` at the repo root, following the same convention used across your other projects (concise, LLM-oriented project summary per llmstxt.org)
- Mirrored into `docs/llms.txt` so it's served at https://keepthewhy.com/llms.txt once deployed
- Linked from README

## Test plan
- [ ] Check `llms.txt` reads well and doesn't overclaim anything
- [ ] After merge + deploy, confirm https://keepthewhy.com/llms.txt resolves