### PR TITLE
Add free-narration technique to interview mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Keep the Why is a `SKILL.md`-based agent skill — an open, cross-agent format (
 
 1. **Continuous capture** — during normal development, the agent notices rationale worth keeping and records it alongside the code as it happens.
 2. **Retrospective recovery** — pointed at an existing or legacy repository, the agent reconstructs what it can from git history, issues, and code, and is explicit about what it couldn't.
-3. **Knowledge-transfer interview** — before a maintainer's knowledge becomes unavailable (leaving, retiring, changing teams), the agent analyzes the codebase first and then asks targeted questions about exactly what the code couldn't explain.
+3. **Knowledge-transfer interview** — before a maintainer's knowledge becomes unavailable (leaving, retiring, changing teams), the agent analyzes the codebase first, then either asks targeted questions about exactly what the code couldn't explain, or — for someone whose knowledge is broad and tacit after many years on one system — just listens while they narrate freely and extracts the rationale from that instead.
 4. **Maintenance** — existing rationale docs get kept current: contradictions resolved, superseded entries marked, oversized files split.
 
 Captured knowledge lives in the repository itself, in two layers:

--- a/SKILL.md
+++ b/SKILL.md
@@ -18,7 +18,7 @@ Four modes, all part of the same job:
 
 1. **Continuous capture** — during normal development, notice when the current conversation contains rationale worth keeping (a decision, a rejected alternative, a workaround, an incident, a constraint) and record it alongside the code.
 2. **Retrospective recovery** — given an existing or legacy repository, find the decisions the code cannot explain by itself, and reconstruct as much as possible from code, git history, issues, and existing docs.
-3. **Knowledge-transfer interview** — when a maintainer's knowledge is about to become unavailable (leaving, retiring, changing teams), analyze the repository first, then ask that person specifically about the gaps analysis couldn't fill.
+3. **Knowledge-transfer interview** — when a maintainer's knowledge is about to become unavailable (leaving, retiring, changing teams), analyze the repository first, then either ask that person specifically about the gaps analysis couldn't fill, or — when their knowledge is broad and tacit rather than narrowly scoped, e.g. someone who has maintained one system for many years — just listen while they narrate freely and extract rationale from that instead. See `references/interview-playbook.md` for both techniques.
 4. **Maintenance** — keep existing rationale documentation current: resolve contradictions, mark superseded entries, merge duplicates, split files that have grown too large for efficient agent context loading.
 
 ## Core rules
@@ -62,14 +62,16 @@ Look for signs that rationale is missing:
 
 For every candidate piece of knowledge: is it confirmed, inferred, unknown, or superseded? See rule 2. This classification is not optional — it's what keeps the output trustworthy.
 
-### 4. Ask (when in interview or retrospective mode)
+### 4. Ask, or listen (when in interview or retrospective mode)
 
-Only ask what the evidence genuinely can't answer. Ask specifically, not generically.
+Default: only ask what the evidence genuinely can't answer, and ask specifically, not generically.
 
 - Weak: "Please explain the synchronization component."
 - Better: "Why does the sync step wait for the snapshot before applying buffered events?"
 
-A generic questionnaire produces generic, low-value answers. A targeted question — grounded in something specific the agent already found and couldn't explain — gets the actual reasoning. See `references/interview-playbook.md`.
+A generic questionnaire usually produces generic, low-value answers. A targeted question — grounded in something specific the agent already found and couldn't explain — gets the actual reasoning.
+
+Exception: when the knowledge holder's understanding is broad and tacit rather than narrowly scoped — most often someone who has maintained one system for many years — a scripted question list can suppress recall instead of helping it. There, open with an invitation to narrate freely instead of a specific question, listen without redirecting the story, and extract decision-forks from what comes up organically. Cross-check against the gap list afterward and close what's still missing with targeted questions. See `references/interview-playbook.md` for both techniques.
 
 ### 5. Record
 

--- a/context/scope.md
+++ b/context/scope.md
@@ -58,3 +58,14 @@ The README positions Keep the Why as one of several practices (README, `docs/`, 
 **Reason:** an earlier pass of `context/docs-engine.md` and `context/repo-conventions.md` named a specific unrelated private project as the source of the original (later replaced) documentation tooling choice, and several entries quoted conversational messages verbatim. Both leaked information that has nothing to do with this project and wasn't objectively relevant to a future reader trying to understand *this* codebase — it was development-session narrative, not project rationale. Rewritten to state the technical reasoning on its own terms.
 
 **Rejected alternative:** keep the fuller narrative for transparency/authenticity, since it's an accurate record of how the decision actually happened. Rejected because accuracy about the session isn't the same as relevance to the project — Core rule 11 now states this distinction explicitly so it isn't re-learned the same way again.
+
+## `context/naming.md` exists but is excluded from the public site's navigation and build
+
+**Status:** active
+**Confirmed**
+
+`context/naming.md` (the naming history: Backstory and Anti-Legacy considered and rejected before Keep the Why) stays in the repository — it's genuine project history and the file-level content is unchanged — but it's excluded from the built site (`mkdocs.yml`'s `exclude_docs`) and removed from the "Why this project is built this way" navigation, rather than published alongside the other context pages.
+
+**Reason:** naming/branding rationale is a different category from the technical "why is the code built this way" content the rest of `context/` covers, and doesn't need to be surfaced in the polished public site the same way. It's still reachable by anyone browsing the repository directly on GitHub — this isn't a deletion, just a decision about what the published site foregrounds.
+
+**Rejected alternative:** delete `context/naming.md` outright, or leave it in the nav unchanged. Neither fit: deleting it would contradict this project's own principle of marking history rather than erasing it (Core rule 8); leaving it in the public nav is what got reconsidered in the first place.

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -28,5 +28,10 @@
     "id": "index-stays-lean",
     "prompt": "The context/sync.md file has grown to cover initial sync, incremental updates, conflict resolution, and three different incidents — it's over 400 lines now.",
     "expected_behavior": "Recognizes the file has grown large enough to hurt agent-context efficiency and proposes a split (e.g. sync-initial-load.md, sync-incremental-updates.md, sync-conflict-resolution.md) with context/index.md updated to point to the new files, rather than continuing to append indefinitely to one file."
+  },
+  {
+    "id": "free-narration-interview",
+    "prompt": "A developer who has maintained our 15-year-old core banking backend for her entire tenure is willing to sit down and talk through the system for a couple of hours before she leaves. Capture what comes up.",
+    "expected_behavior": "Does not open with a scripted question list. Runs retrospective analysis first for later cross-checking, then opens with an invitation to narrate freely rather than a specific question. Does not redirect tangents back to a prepared agenda. Extracts decision-forks (chosen/rejected/why) from the flowing narration into normal topic-organized context/ entries, not a raw transcript. After the session, cross-checks against the gap list and proposes short targeted follow-up questions only for what free narration didn't cover."
   }
 ]

--- a/examples/developer-handover.md
+++ b/examples/developer-handover.md
@@ -1,6 +1,8 @@
 # Example: developer handover (interview mode)
 
-## Situation
+Two variants of the same mode, depending on the knowledge holder and how they communicate best — see "Two techniques" in `references/interview-playbook.md`.
+
+## Variant A: targeted questions
 
 **User:** "Our lead developer retires next month. Prepare an interview based on the areas of the repository only she understands."
 
@@ -34,3 +36,24 @@ Priority 3 (nice to have, lower urgency):
 
 - Doesn't ask the retiring developer to re-explain things already clear from the code — that wastes limited time.
 - Doesn't treat the interview as a one-shot dump; if scope is large, it's fine to prioritize and accept that lower-priority items may not get covered before the deadline.
+
+## Variant B: free narration
+
+**Situation:** a developer has maintained a core system — say, 15 years on the same banking backend, built in the 90s — for their entire tenure. Their knowledge is broad, tacit, and not organized around specific gaps; a targeted question list would force them to guess what's being asked about instead of just telling what they know.
+
+**User:** "She's willing to just sit down and talk through the system for a couple of hours. Capture what comes up."
+
+## What the skill does
+
+1. Still runs retrospective analysis first, but uses the gap list to prioritize and cross-check afterward, not to script the conversation.
+2. Opens with an invitation, not a question: "Tell me about this system — start wherever makes sense to you."
+3. Lets the conversation run without redirecting it toward the gap list. A tangent about a payment format from a system that was decommissioned a decade ago might be exactly where the rationale for a still-active workaround surfaces.
+4. Extracts decision-forks as they come up in the narration — what was tried, what was chosen, what was rejected, why — using the normal `context/` entry structure, not a transcript.
+5. Asks a clarifying follow-up only to pin down something ambiguous or confirm a claim, not to steer the story back to a prepared agenda.
+6. After the session, checks the gap list against what got covered. Anything still open becomes a short, targeted follow-up — Variant A's approach, applied to what's left — rather than another open-ended session.
+
+## What it doesn't do
+
+- Doesn't interrupt every few minutes to redirect toward "more relevant" topics — that's exactly the instinct that suppresses the tangents where tacit knowledge tends to surface.
+- Doesn't skip the gap-list cross-check afterward just because the conversation felt thorough; free narration reliably covers some things well and misses others, same as any interview technique.
+- Doesn't produce a single giant "transcript" topic file — extracted content still gets routed into the normal topic-organized `context/` structure, same as any other capture.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,9 @@ plugins:
   - search
   - include-markdown
 
+exclude_docs: |
+  context/naming.md
+
 nav:
   - Overview: index.md
   - Installation: installation.md
@@ -44,7 +47,6 @@ nav:
       - Legacy project: examples/legacy-project.md
       - Developer handover: examples/developer-handover.md
   - "Why this project is built this way":
-      - Naming: context/naming.md
       - Docs engine: context/docs-engine.md
       - Repo conventions: context/repo-conventions.md
       - Scope: context/scope.md

--- a/references/interview-playbook.md
+++ b/references/interview-playbook.md
@@ -2,11 +2,29 @@
 
 For knowledge-transfer interviews — most commonly used before a maintainer leaves, retires, or moves off a project, but applicable any time a specific person is the last remaining source for something the code can't explain.
 
-## The core rule: analyze first, ask second
+## Analysis always comes first
 
-Never open with a generic "tell me about this system" questionnaire. Run retrospective analysis first (`retrospective-analysis.md`) to build a gap list, then interview against that specific list. This does two things: it respects the interviewee's time (they're not re-explaining what's already obvious from the code), and it produces much higher-value answers, because the questions are concrete enough to trigger specific memories instead of vague summaries.
+Run retrospective analysis (`retrospective-analysis.md`) to build a gap list before the interview, regardless of which technique below is used for the conversation itself. It's what makes prioritization possible when time is short, and it's what a free-narration session gets checked against afterward to find what still needs a targeted follow-up.
 
-## Prioritizing what to ask
+## Two techniques, chosen by the interviewee and the gaps — not always the same one
+
+**Targeted questions** — the default when the gaps are specific and narrow, or time is short. Ask about something specific and observed, not a category. Never open with a generic "tell me about this system" questionnaire when this technique is the right fit — a scripted, specific question gets a specific memory back; a vague one gets a vague summary.
+
+- Ask about something specific and observed, not a category. "Why does X wait for Y" beats "explain the sync system."
+- Where a rejected alternative is suspected (from a comment, an old branch, a commit that was reverted), ask about it directly: "Was Z considered instead? What happened?"
+- Where the answer might reveal a constraint that no longer applies, ask: "Is this still true today, or was it true when this was written?" Stale constraints that outlived their reason are common and worth flagging as candidates for re-evaluation, not just documenting as permanent.
+- Leave room for the interviewee to raise something not on the prepared list — the gap analysis is a starting point, not a script to follow rigidly.
+
+**Free narration** — a better fit when the knowledge is broad and tacit rather than narrowly scoped: someone who's maintained the same system, sometimes for decades, and whose understanding isn't organized around "what the code can't explain" the way a gap list is. A scripted question list can actually suppress recall here — the interviewee has to guess what's being asked about, instead of just telling the story their own way, and the most valuable detail often surfaces in a tangent that no specific question would have triggered. Open with something like "tell me about this system, start wherever you want" and let them talk.
+
+The agent's job during free narration is different from targeted questioning:
+
+- Don't interrupt the flow for minor clarifications — let tangents run; tacit knowledge often surfaces exactly in the tangents, not in direct answers to direct questions.
+- Extract decision-forks as they come up organically (what was tried, what was chosen, what was rejected, and why), using the same structure as any other entry — it's just being extracted from flowing narration instead of a directed answer.
+- Ask a clarifying follow-up only when something is genuinely ambiguous, or when a claim needs pinning down for the confirmed/inferred classification — not to redirect the story back to an agenda.
+- After the narration (or at a natural pause), cross-check what was covered against the gap list from analysis. Whatever wasn't covered becomes a targeted follow-up question afterward — the two techniques aren't mutually exclusive, and combining them (narrate first, then close remaining gaps with pointed questions) is usually stronger than either alone.
+
+## Prioritizing what to ask (targeted technique) or listen for (free narration)
 
 Time with a knowledge holder is usually limited. Prioritize gaps by:
 
@@ -15,13 +33,6 @@ Time with a knowledge holder is usually limited. Prioritize gaps by:
 3. **Decision weight** — architectural or structural choices that shaped a lot of what came after, versus small local workarounds.
 
 Low-risk, easily-reconstructible, low-weight gaps can wait or be skipped if time is short.
-
-## Question style
-
-- Ask about something specific and observed, not a category. "Why does X wait for Y" beats "explain the sync system."
-- Where a rejected alternative is suspected (from a comment, an old branch, a commit that was reverted), ask about it directly: "Was Z considered instead? What happened?"
-- Where the answer might reveal a constraint that no longer applies, ask: "Is this still true today, or was it true when this was written?" Stale constraints that outlived their reason are common and worth flagging as candidates for re-evaluation, not just documenting as permanent.
-- Leave room for the interviewee to raise something not on the prepared list — the gap analysis is a starting point, not a script to follow rigidly.
 
 ## After the interview
 


### PR DESCRIPTION
## Summary
- Interview mode now has two techniques: targeted questions (unchanged default) and free narration — for a knowledge holder whose understanding is broad and tacit rather than narrowly scoped, e.g. someone who's maintained one system for many years
- Updated SKILL.md, references/interview-playbook.md, examples/developer-handover.md (new Variant B), and evals/evals.json
- Separately: removed `context/naming.md` from the public site nav/build (kept in the repo, just not published) — see context/scope.md for why

## Test plan
- [ ] Skim references/interview-playbook.md's "Two techniques" section for tone/accuracy
- [ ] Confirm the naming.md exclusion is what you meant (currently: file stays in repo, excluded from built site only)