### PR TITLE
Wire up logo and favicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Keep the Why
+<img src="docs/assets/logo.png" alt="Keep the Why — because &quot;ask Bob&quot; is not documentation." width="600">
 
-Because "ask Bob" is not documentation.
+# Keep the Why
 
 Keep a Changelog records what changed. Keep the Why preserves why it changed.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,8 @@ repo_name: oliver-zehentleitner/keep-the-why
 
 theme:
   name: material
+  logo: assets/wordmark.png
+  favicon: assets/favicon.png
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default


### PR DESCRIPTION
## Summary
- `theme.logo`/`theme.favicon` set in mkdocs.yml (wordmark for the sidebar slot — the full logo.png with tagline is too wide/busy there)
- README hero uses the full logo.png (already has the tagline baked in, so removed the separate text line to avoid duplication)

## Test plan
- [ ] Check the sidebar logo and favicon render correctly once deployed
- [ ] Confirm the README image displays properly on GitHub