### PR TITLE
Color nav section headings with logo purple

### DIFF
--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -1,0 +1,12 @@
+/* Color the top-level nav section headings (e.g. "Reference", "Examples") —
+   not individual page links, just the non-clickable group labels. */
+.md-nav__item--section > .md-nav__link,
+.md-nav__item--section > .md-nav__link .md-ellipsis {
+  color: #845bed;
+}
+
+/* Same heading repeated at the top of the expanded section panel. */
+.md-nav--secondary .md-nav__title,
+.md-nav:not(.md-nav--primary) > .md-nav__title:not([for="__drawer"]) {
+  color: #845bed;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,9 @@ plugins:
   - search
   - include-markdown
 
+extra_css:
+  - assets/extra.css
+
 exclude_docs: |
   context/naming.md
 


### PR DESCRIPTION
## Summary
- Added `docs/assets/extra.css`, wired via `extra_css` in mkdocs.yml
- Targets `.md-nav__item--section > .md-nav__link` (verified against actual built HTML) so only section group labels ("Reference", "Examples", "Why this project is built this way") get colored, not individual page links
- Color `#845bed` sampled directly from `docs/assets/icon-transparent.png`

## Test plan
- [ ] Could not screenshot locally (no headless browser available in this environment) - please eyeball the sidebar once deployed to confirm it looks right