### PR TITLE
Color the top-level nav title too

### DIFF
--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -7,6 +7,12 @@
 
 /* Same heading repeated at the top of the expanded section panel. */
 .md-nav--secondary .md-nav__title,
-.md-nav:not(.md-nav--primary) > .md-nav__title:not([for="__drawer"]) {
+.md-nav:not(.md-nav--primary) > .md-nav__title {
+  color: #845bed;
+}
+
+/* The very first nav heading: the site title ("Keep the Why") above the
+   drawer's nav tree, next to the wordmark logo. */
+.md-nav__title[for="__drawer"] {
   color: #845bed;
 }


### PR DESCRIPTION
The section-header CSS from the previous PR deliberately excluded `.md-nav__title[for="__drawer"]` (the site title next to the wordmark logo at the top of the sidebar) — that's exactly the heading you meant. Added it with the same purple.