### PR TITLE
Consolidate file-routing story in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,26 +25,22 @@ Keep the Why is a `SKILL.md`-based agent skill — an open, cross-agent format (
 3. **Knowledge-transfer interview** — before a maintainer's knowledge becomes unavailable (leaving, retiring, changing teams), the agent analyzes the codebase first, then either asks targeted questions about exactly what the code couldn't explain, or — for someone whose knowledge is broad and tacit after many years on one system — just listens while they narrate freely and extracts the rationale from that instead.
 4. **Maintenance** — existing rationale docs get kept current: contradictions resolved, superseded entries marked, oversized files split.
 
-Captured knowledge lives in the repository itself, in two layers:
-
-- `docs/` — how to use, operate, and test the project (human-facing, agent-readable too).
-- `context/` — why the project is the way it is, organized by topic and indexed to stay efficient to load into an agent's context window.
-
-Full methodology: [`references/methodology.md`](https://github.com/oliver-zehentleitner/keep-the-why/blob/main/references/methodology.md). Concrete layout: [`references/repository-structure.md`](https://github.com/oliver-zehentleitner/keep-the-why/blob/main/references/repository-structure.md).
+Where the captured knowledge actually lives, and how it relates to everything else a project already has, is one coherent picture — see "Where this fits" below.
 
 ## Where this fits
 
-Anti-legacy isn't one practice, it's several — complementary, not competing. A project missing any one of them still has a real gap:
+Anti-legacy is one coherent group of files, not a single practice: each answers a different question, has a clear and non-overlapping scope, and knowing which is which is what keeps you from ending up with duplicates. A project missing any one of them still has a real gap:
 
-| Practice | Answers | Artifact |
+| File | Answers | Artifact |
 |---|---|---|
 | README | "What is this, and should I care?" | `README.md` |
 | `docs/` | "How do I use or operate this?" | usage docs |
+| `CONTRIBUTING.md` | "How do I contribute to this?" | contribution guide |
 | Tests | "Did I just break something?" | test suite |
 | [Keep a Changelog](https://keepachangelog.com/) | "What changed, release by release?" | `CHANGELOG.md` |
 | **Keep the Why** (`context/`) | "Why is it built this way?" | `context/` |
 
-Michael Feathers' classic definition — legacy code is code without tests — covers only the Tests row. A project can have full test coverage and still be legacy in every practical sense if nobody can explain why any of it works the way it does. None of these substitutes for another, and this list isn't necessarily closed — treat it as the practices that combat a codebase becoming inaccessible over time, not a general OSS-hygiene checklist (things like a license or a contribution guide matter too, just for different reasons — legal clarity and process, not comprehension).
+Michael Feathers' classic definition — legacy code is code without tests — covers only the Tests row. A project can have full test coverage and still be legacy in every practical sense if nobody can explain why any of it works the way it does. None of these substitutes for another: contribution process belongs in `CONTRIBUTING.md`, not `context/`; rationale belongs in `context/`, not scattered into a README that's supposed to stay a quick pitch. Once you know which question you're answering, you know exactly which file it goes in — see [`references/repository-structure.md`](https://github.com/oliver-zehentleitner/keep-the-why/blob/main/references/repository-structure.md) for the fuller routing table (also covering `AGENTS.md` and `AGENTS.local.md`, which are entry points rather than knowledge topics in this same sense). Full methodology behind the `docs/`/`context/` split specifically: [`references/methodology.md`](https://github.com/oliver-zehentleitner/keep-the-why/blob/main/references/methodology.md).
 
 **What none of them does by itself: stay honest over time.** Tests get skipped under deadline pressure, docs rot, changelogs get forgotten mid-release, and rationale decays — one 2026 study found 23% of AI-generated decisions had stale supporting evidence within two months. Keep the Why doesn't solve that alone; it just gives "why" a place to live so it *can* be kept current, the same way a test suite only helps if it actually runs in CI. Keeping all of them honest over time (via CI checks, review habits, whatever fits the project) is a separate, necessary piece this project doesn't ship an opinion on yet.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -3,8 +3,8 @@
 **Is this affiliated with Keep a Changelog?**
 No. The name is a deliberate homage to [keepachangelog.com](https://keepachangelog.com/) — same naming pattern, same spirit of "a lightweight open convention, not a platform" — but there's no official relationship and no shared code or governance.
 
-**Does this replace the README, tests, docs, or a changelog?**
-No — see the README's "Where this fits" table (on the [Overview](index.md) page). Keep the Why only covers the "why" layer. The README, usage docs, tests, and Keep a Changelog each answer a different question and none of them is optional just because you have the others.
+**Does this replace the README, docs, CONTRIBUTING.md, tests, or a changelog?**
+No — see the README's "Where this fits" table (on the [Overview](index.md) page). Keep the Why only covers the "why" layer. Each of the others answers a different question and none of them is optional just because you have the others.
 
 **How is this different from an ADR (Architecture Decision Record)?**
 ADRs are typically human-authored, written at a discrete decision point, one file per decision, and treated as frozen once accepted. Keep the Why is continuous and agent-authored from the conversation itself, organized by topic rather than by decision, and entries are living — updated and marked superseded rather than replaced by a new file. See [Methodology](methodology.md) for the full reasoning.

--- a/references/methodology.md
+++ b/references/methodology.md
@@ -2,7 +2,7 @@
 
 ## Scope: one of several practices, not a replacement for the others
 
-Keep the Why only covers the "why" layer. It deliberately doesn't try to replace a README (what is this, should I care?), tests (did this change break something?), usage docs (how do I run/operate this?), or [Keep a Changelog](https://keepachangelog.com/) (what changed, release by release?) — see the README's "Where this fits" table. A project that adopts Keep the Why but drops its test suite hasn't gotten less legacy, just legacy in a different dimension. Keep the reasoning below scoped accordingly: it's about the `docs`/`context` split specifically, not documentation strategy in general.
+Keep the Why only covers the "why" layer. It deliberately doesn't try to replace a README (what is this, should I care?), usage docs (how do I run/operate this?), `CONTRIBUTING.md` (how do I contribute?), tests (did this change break something?), or [Keep a Changelog](https://keepachangelog.com/) (what changed, release by release?) — see the README's "Where this fits" table. A project that adopts Keep the Why but drops its test suite hasn't gotten less legacy, just legacy in a different dimension. Keep the reasoning below scoped accordingly: it's about the `docs`/`context` split specifically, not documentation strategy in general.
 
 ## Two layers: docs vs. context
 


### PR DESCRIPTION
## Summary
- Merged the scattered "two layers" mention + 5-row table + "license/contribution guide" aside into one table in "Where this fits"
- Added `CONTRIBUTING.md` as its own row (clear scope, same logic as the others)
- Cross-referenced `references/repository-structure.md` for the fuller routing table (AGENTS.md/AGENTS.local.md included there)
- Updated methodology.md and faq.md to match

## Test plan
- [ ] Read through "How it works" → "Where this fits" and confirm it reads as one coherent story now, not three expanding mentions