### PR TITLE
Add agent-maintained-docs bridge before Install

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Michael Feathers' classic definition — legacy code is code without tests — c
 
 **What none of them does by itself: stay honest over time.** Tests get skipped under deadline pressure, docs rot, changelogs get forgotten mid-release, and rationale decays — one 2026 study found 23% of AI-generated decisions had stale supporting evidence within two months. Keep the Why doesn't solve that alone; it just gives "why" a place to live so it *can* be kept current, the same way a test suite only helps if it actually runs in CI. Keeping all of them honest over time (via CI checks, review habits, whatever fits the project) is a separate, necessary piece this project doesn't ship an opinion on yet.
 
+This isn't a new pattern, either. Docs and changelogs are already commonly kept current almost incidentally today, maintained by a skill or an agent alongside the actual work rather than as separate effort. Keep the Why brings that same low-effort, agent-maintained model to the one layer that couldn't be kept current this way before: the why.
+
 ## Install
 
 Clone into your agent's skills directory — the folder name must stay `keep-the-why`:


### PR DESCRIPTION
One new sentence-pair right before Install: docs/changelogs are already commonly agent-maintained today almost for free; Keep the Why extends that same pattern to the why layer. Note: this branches off main, not off PR #11 (the table expansion) - different part of the file, no conflict, can merge in either order.