### PR TITLE
Document npx skills add as an install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,15 @@ Where the captured knowledge actually lives, and how it relates to everything el
 
 ## Install
 
-**Recommended — [GitHub CLI](https://cli.github.com/) (`gh` v2.90.0+):**
+**Recommended — [skills CLI](https://skills.sh/) (via `npx`, needs Node.js):**
+
+```bash
+npx skills add oliver-zehentleitner/keep-the-why
+```
+
+Prompts for which of its 70+ supported agents (Claude Code, Codex, OpenCode, and more) and scope to install for, then symlinks or copies the skill package in. Also listed on [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why).
+
+**Also recommended — [GitHub CLI](https://cli.github.com/) (`gh` v2.90.0+):**
 
 ```bash
 gh skill install oliver-zehentleitner/keep-the-why
@@ -29,7 +37,7 @@ gh skill install oliver-zehentleitner/keep-the-why
 
 Prompts for which agent and scope (project or personal) to install for. This installs just the skill package (`skills/keep-the-why/`), not the whole repo — no docs/, mkdocs config, or CI files end up in your project.
 
-**Fallback — manual clone**, if `gh skill install` isn't available. The skill lives under `skills/keep-the-why/` in this repo, not at the root, so clone to a scratch location and copy just that folder rather than cloning straight into your agent's skills directory (cloning the whole repo there would nest an embedded git repository inside yours, and pull in unrelated project files):
+**Fallback — manual clone**, if neither of the above is available. The skill lives under `skills/keep-the-why/` in this repo, not at the root, so clone to a scratch location and copy just that folder rather than cloning straight into your agent's skills directory (cloning the whole repo there would nest an embedded git repository inside yours, and pull in unrelated project files):
 
 ```bash
 git clone https://github.com/oliver-zehentleitner/keep-the-why.git /tmp/keep-the-why

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,7 +2,17 @@
 
 Keep the Why is a `SKILL.md` file, following the open, cross-agent skill format — not tied to one vendor. No build step, no external service, no database, no MCP server.
 
-## Recommended: GitHub CLI
+## Recommended: skills CLI
+
+With [`skills`](https://skills.sh/) (runs via `npx`, requires Node.js, no separate install step):
+
+```bash
+npx skills add oliver-zehentleitner/keep-the-why
+```
+
+Prompts for which of its 70+ supported agents (Claude Code, Codex, OpenCode, and more) and scope (project or personal) to install for, then installs via symlink or copy, your choice. Also listed on [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why).
+
+## Also recommended: GitHub CLI
 
 With [`gh`](https://cli.github.com/) v2.90.0 or later:
 
@@ -42,7 +52,7 @@ Start a new session afterward so the skill is picked up.
 
 ## Updating
 
-Re-run `gh skill install oliver-zehentleitner/keep-the-why`, or repeat the manual clone-and-copy steps above — a plain `git pull` doesn't work if you copied the folder out of a scratch clone rather than cloning directly into place.
+Re-run `npx skills add oliver-zehentleitner/keep-the-why` or `gh skill install oliver-zehentleitner/keep-the-why`, or repeat the manual clone-and-copy steps above — a plain `git pull` doesn't work if you copied the folder out of a scratch clone rather than cloning directly into place.
 
 ## Verifying it loaded
 

--- a/llms.txt
+++ b/llms.txt
@@ -18,7 +18,13 @@ License: MIT — free for commercial and private use. No paid license, no subscr
 
 ## Quick Start
 
-Recommended, with GitHub CLI v2.90.0+:
+Recommended, with the skills CLI (via `npx`, needs Node.js):
+
+```bash
+npx skills add oliver-zehentleitner/keep-the-why
+```
+
+Also recommended, with GitHub CLI v2.90.0+:
 
 ```bash
 gh skill install oliver-zehentleitner/keep-the-why
@@ -30,7 +36,7 @@ into your agent's skills directory:
 
 ```bash
 git clone https://github.com/oliver-zehentleitner/keep-the-why.git /tmp/keep-the-why
-cp -r /tmp/keep-the-why/skills/keep-the-why .claude/skills/keep-the-why
+cp -r /tmp/keep-the-why/skills/keep-the-why <target-directory>/keep-the-why
 rm -rf /tmp/keep-the-why
 ```
 


### PR DESCRIPTION
## Summary
This content was written earlier but pushed to `review-followups` after PR #17 had already merged, so it never landed on `main`. Re-applying cleanly here.

- Documents `npx skills add oliver-zehentleitner/keep-the-why` (vercel-labs skills CLI / skills.sh) as a recommended install method alongside `gh skill install`, in README, docs/installation.md, and llms.txt.
- Links the skill's skills.sh listing page.
- Fixes a leftover hardcoded `.claude/skills/keep-the-why` path in llms.txt's manual-clone fallback to match the generic `<target-directory>` placeholder already used in installation.md.