### PR TITLE
Fix broken license badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![GitHub Release](https://img.shields.io/github/release/oliver-zehentleitner/keep-the-why.svg?label=github)](https://github.com/oliver-zehentleitner/keep-the-why/releases)
 [![GitHub Downloads](https://img.shields.io/github/downloads/oliver-zehentleitner/keep-the-why/total?color=blue)](https://github.com/oliver-zehentleitner/keep-the-why/releases)
-[![License](https://img.shields.io/github/license/oliver-zehentleitner/keep-the-why.svg?color=blue)](https://oliver-zehentleitner.github.io/keep-the-why/license.html)
+[![License](https://img.shields.io/github/license/oliver-zehentleitner/keep-the-why.svg?color=blue)](https://github.com/oliver-zehentleitner/keep-the-why/blob/main/LICENSE)
 [![Link Check](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/link-check.yml/badge.svg)](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/link-check.yml)
 [![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://keepthewhy.com/)
 [![Telegram](https://img.shields.io/badge/community-telegram-41ab8c)](https://t.me/unicorndevs)


### PR DESCRIPTION
Link Check CI (just added) caught this: the README's License badge pointed to \`oliver-zehentleitner.github.io/keep-the-why/license.html\`, a page that never existed (verified: no license.html anywhere in docs/ or mkdocs.yml's nav). Points directly at the LICENSE file on GitHub instead.