### PR TITLE
Link the published article

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The idea of capturing AI-agent rationale isn't new, and this project doesn't cla
 - [Agent Decision Records](https://me2resh.com/) — a Claude Code skill for structured, checkpointed decision records. More deliberate and human-driven per entry; Keep the Why leans toward continuous, lower-friction capture during normal work.
 - Addy Osmani's `documentation-and-adrs` skill — a related Claude Code skill for capturing decisions and ADRs.
 
-Keep the Why's specific combination — continuous capture *and* retrospective recovery *and* code-guided interviews, organized as topic-indexed living docs rather than a shadow tree or one-file-per-decision, with no required external service — is the part that's different. Nothing here rules out combining approaches; several of these solve real, adjacent problems well. See the article (link once published) for the full comparison.
+Keep the Why's specific combination — continuous capture *and* retrospective recovery *and* code-guided interviews, organized as topic-indexed living docs rather than a shadow tree or one-file-per-decision, with no required external service — is the part that's different. Nothing here rules out combining approaches; several of these solve real, adjacent problems well. See [the article](https://blog.technopathy.club/keep-the-why-code-becomes-legacy-when-nobody-remembers-why) for the full comparison and the story behind why this exists.
 
 ## What this is not
 

--- a/llms.txt
+++ b/llms.txt
@@ -91,3 +91,4 @@ no required external service (no database, no MCP server).
 - SKILL.md: https://github.com/oliver-zehentleitner/keep-the-why/blob/main/skills/keep-the-why/SKILL.md
 - Docs: https://keepthewhy.com
 - Why this project is built this way: https://keepthewhy.com/context/repo-conventions/
+- Article — origin story and full comparison to prior art: https://blog.technopathy.club/keep-the-why-code-becomes-legacy-when-nobody-remembers-why


### PR DESCRIPTION
Replaces the "(link once published)" placeholder now that the article is live: https://blog.technopathy.club/keep-the-why-code-becomes-legacy-when-nobody-remembers-why