### PR TITLE
Add robots.txt with sitemap directive

### DIFF
--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://keepthewhy.com/sitemap.xml


### PR DESCRIPTION
No Disallow rules - allows everything, just points crawlers at the sitemap for discovery without a manual submission.