### PR TITLE
Add Badge page

### DIFF
--- a/docs/badge.md
+++ b/docs/badge.md
@@ -1,0 +1,13 @@
+# Badge
+
+Show that a project uses Keep the Why with a badge in its README:
+
+[![Keep the Why](https://keepthewhy.com/assets/badge.svg)](https://keepthewhy.com)
+
+The markdown is the same for every project — copy it as-is:
+
+```markdown
+[![Keep the Why](https://keepthewhy.com/assets/badge.svg)](https://keepthewhy.com)
+```
+
+Paste it wherever the other badges live, usually near the top of `README.md`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ exclude_docs: |
 nav:
   - Overview: index.md
   - Installation: installation.md
+  - Badge: badge.md
   - FAQ: faq.md
   - Why I built this: why.md
   - Reference:


### PR DESCRIPTION
New docs page (linked in nav after Installation) explaining how to add the Keep the Why badge to a README - single copy-paste snippet, same for every project, in a fenced code block for the automatic copy button.