### PR TITLE
Add HTML alternative to badge snippet

### DIFF
--- a/docs/badge.md
+++ b/docs/badge.md
@@ -11,3 +11,11 @@ The markdown is the same for every project — copy it as-is:
 ```
 
 Paste it wherever the other badges live, usually near the top of `README.md`.
+
+## HTML
+
+For anywhere Markdown isn't an option (a plain HTML page, a platform that strips Markdown, or a spot where you need more control over layout):
+
+```html
+<a href="https://keepthewhy.com"><img alt="Keep the Why" src="https://keepthewhy.com/assets/badge.svg"></a>
+```


### PR DESCRIPTION
For places Markdown isn't an option - a plain <a><img> equivalent of the same badge.