### PR TITLE
Fix lopsided TOC on Badge page

### DIFF
--- a/docs/badge.md
+++ b/docs/badge.md
@@ -4,7 +4,9 @@ Show that a project uses Keep the Why with a badge in its README:
 
 [![Keep the Why](https://keepthewhy.com/assets/badge.svg)](https://keepthewhy.com)
 
-The markdown is the same for every project — copy it as-is:
+The snippet is the same for every project — copy it as-is.
+
+## Markdown
 
 ```markdown
 [![Keep the Why](https://keepthewhy.com/assets/badge.svg)](https://keepthewhy.com)


### PR DESCRIPTION
Markdown section had no heading of its own, so it didn't show in the page's table of contents next to HTML. Both are H2 now.