### PR TITLE
Add floating 'latest' tag support to install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ Where the captured knowledge actually lives, and how it relates to everything el
 
 ## Install
 
-`main` is active development, not guaranteed release-ready — pin to the [latest tag](https://github.com/oliver-zehentleitner/keep-the-why/releases/latest) instead of tracking it directly. Shown below pinned to `v0.1.0`; see [`docs/installation.md`](docs/installation.md) for the unpinned form and full detail.
+`main` is active development, not guaranteed release-ready — pin to `latest` instead of tracking it directly (moved automatically by CI to the newest release; use an exact [tag](https://github.com/oliver-zehentleitner/keep-the-why/releases) instead for full reproducibility). See [`docs/installation.md`](docs/installation.md) for the unpinned form and full detail.
 
 **Recommended — [skills CLI](https://skills.sh/) (via `npx`, needs Node.js):**
 
 ```bash
-npx skills add https://github.com/oliver-zehentleitner/keep-the-why/tree/v0.1.0/skills/keep-the-why
+npx skills add https://github.com/oliver-zehentleitner/keep-the-why/tree/latest/skills/keep-the-why
 ```
 
 Prompts for which of its 70+ supported agents (Claude Code, Codex, OpenCode, and more) and scope to install for, then symlinks or copies the skill package in. Also listed on [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why).
@@ -43,7 +43,7 @@ Prompts for which of its 70+ supported agents (Claude Code, Codex, OpenCode, and
 **Also recommended — [GitHub CLI](https://cli.github.com/) (`gh` v2.90.0+):**
 
 ```bash
-gh skill install oliver-zehentleitner/keep-the-why keep-the-why@v0.1.0
+gh skill install oliver-zehentleitner/keep-the-why keep-the-why@latest
 ```
 
 Prompts for which agent and scope (project or personal) to install for. This installs just the skill package (`skills/keep-the-why/`), not the whole repo — no docs/, mkdocs config, or CI files end up in your project.
@@ -51,7 +51,7 @@ Prompts for which agent and scope (project or personal) to install for. This ins
 **Fallback — manual clone**, if neither of the above is available. The skill lives under `skills/keep-the-why/` in this repo, not at the root, so clone to a scratch location and copy just that folder rather than cloning straight into your agent's skills directory (cloning the whole repo there would nest an embedded git repository inside yours, and pull in unrelated project files):
 
 ```bash
-git clone --branch v0.1.0 https://github.com/oliver-zehentleitner/keep-the-why.git /tmp/keep-the-why
+git clone --branch latest https://github.com/oliver-zehentleitner/keep-the-why.git /tmp/keep-the-why
 cp -r /tmp/keep-the-why/skills/keep-the-why <target-directory>/keep-the-why
 rm -rf /tmp/keep-the-why
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,7 +9,7 @@ Before installing anything that runs inside an agent, know what you're actually 
 - **No executable code.** The skill package (`skills/keep-the-why/`) is instructions only — `SKILL.md`, `references/*.md`, `examples/*.md`, `evals/evals.json`. No scripts, no binaries.
 - **No network access of its own.** There's nothing to run, so there's nothing that calls out anywhere. Whatever network access exists is your agent's own, not something this skill adds.
 - **No external services.** No database, no MCP server, no account, no API key.
-- **Install a tagged release, not `main`.** `main` is where active development happens and isn't guaranteed release-ready at any given moment — installing without pinning tracks it directly. The current release: [latest tag](https://github.com/oliver-zehentleitner/keep-the-why/releases/latest). Every install method below shows how to pin to it.
+- **Install a tagged release, not `main`.** `main` is where active development happens and isn't guaranteed release-ready at any given moment — installing without pinning tracks it directly. A `latest` tag always points to the newest release, moved automatically by CI whenever one ships. Every install method below shows how to pin to it (or to an exact version, for full reproducibility).
 - **Updating is explicit**, never automatic — see "Updating" below.
 
 None of that substitutes for actually reading `SKILL.md` yourself before installing — see "Recommended: GitHub CLI" below for `gh skill preview`, which lets you do exactly that.
@@ -19,10 +19,10 @@ None of that substitutes for actually reading `SKILL.md` yourself before install
 With [`skills`](https://skills.sh/) (runs via `npx`, requires Node.js, no separate install step), pinned to a release via a GitHub tree URL:
 
 ```bash
-npx skills add https://github.com/oliver-zehentleitner/keep-the-why/tree/v0.1.0/skills/keep-the-why
+npx skills add https://github.com/oliver-zehentleitner/keep-the-why/tree/latest/skills/keep-the-why
 ```
 
-Replace `v0.1.0` with whatever the [latest tag](https://github.com/oliver-zehentleitner/keep-the-why/releases/latest) is. The plain shorthand form tracks `main` directly instead:
+Replace `latest` with an exact [tag](https://github.com/oliver-zehentleitner/keep-the-why/releases) (e.g. `v0.1.0`) to pin to a specific version instead of always the newest. The plain shorthand form tracks `main` directly instead:
 
 ```bash
 npx skills add oliver-zehentleitner/keep-the-why
@@ -41,10 +41,10 @@ gh skill preview oliver-zehentleitner/keep-the-why keep-the-why
 GitHub's own guidance: skills aren't verified by GitHub and may contain prompt injections, hidden instructions, or malicious scripts — inspect before installing. Keep the Why ships instructions only, no executable scripts. Then, pinned to a release:
 
 ```bash
-gh skill install oliver-zehentleitner/keep-the-why keep-the-why@v0.1.0
+gh skill install oliver-zehentleitner/keep-the-why keep-the-why@latest
 ```
 
-Replace `v0.1.0` with whatever the [latest tag](https://github.com/oliver-zehentleitner/keep-the-why/releases/latest) is (`--pin v0.1.0` works the same way, as a flag instead of a suffix). Dropping the version tracks `main` directly:
+Replace `latest` with an exact [tag](https://github.com/oliver-zehentleitner/keep-the-why/releases) (e.g. `v0.1.0`) to pin to a specific version instead of always the newest (`--pin latest` / `--pin v0.1.0` work the same way, as a flag instead of a suffix). Dropping the version tracks `main` directly:
 
 ```bash
 gh skill install oliver-zehentleitner/keep-the-why keep-the-why
@@ -57,12 +57,12 @@ Either form prompts for which agent and scope (project or personal) to install f
 If neither CLI is available. The skill lives under `skills/keep-the-why/`, not at the repo root — clone to a scratch location and copy just that folder, rather than cloning the whole repo straight into your agent's skills directory (which would nest an embedded git repository inside yours and pull in docs/, mkdocs config, and CI files you don't need). Pinned to a release:
 
 ```bash
-git clone --branch v0.1.0 https://github.com/oliver-zehentleitner/keep-the-why.git /tmp/keep-the-why
+git clone --branch latest https://github.com/oliver-zehentleitner/keep-the-why.git /tmp/keep-the-why
 cp -r /tmp/keep-the-why/skills/keep-the-why <target-directory>/keep-the-why
 rm -rf /tmp/keep-the-why
 ```
 
-Replace `v0.1.0` with whatever the [latest tag](https://github.com/oliver-zehentleitner/keep-the-why/releases/latest) is. Dropping `--branch v0.1.0` clones `main` directly instead.
+Replace `latest` with an exact [tag](https://github.com/oliver-zehentleitner/keep-the-why/releases) (e.g. `v0.1.0`) to pin to a specific version instead of always the newest. Dropping `--branch latest` clones `main` directly instead.
 
 The folder name must stay `keep-the-why` (has to match `name` in the frontmatter). `<target-directory>` is whichever agent's skills directory applies:
 
@@ -84,7 +84,7 @@ Start a new session afterward so the skill is picked up.
 
 ## Updating
 
-Re-run whichever install command you used the first time, with the new version if you're pinning — check the [latest tag](https://github.com/oliver-zehentleitner/keep-the-why/releases/latest) first. A plain `git pull` doesn't work if you copied the folder out of a scratch clone rather than cloning directly into place.
+Re-run whichever install command you used the first time. If you pinned to `latest`, that's enough — it always resolves to the newest release. If you pinned to an exact version, swap in the new tag. A plain `git pull` doesn't work if you copied the folder out of a scratch clone rather than cloning directly into place.
 
 ## Verifying it loaded
 

--- a/llms.txt
+++ b/llms.txt
@@ -23,16 +23,21 @@ License: MIT — free for commercial and private use. No paid license, no subscr
 
 ## Quick Start
 
+`main` is active development, not guaranteed release-ready — pin to `latest` instead of tracking
+it directly. A `latest` tag always points to the newest release, moved automatically by CI. Use
+an exact tag (e.g. `v0.1.0`) instead for full reproducibility; see the releases page:
+https://github.com/oliver-zehentleitner/keep-the-why/releases
+
 Recommended, with the skills CLI (via `npx`, needs Node.js):
 
 ```bash
-npx skills add oliver-zehentleitner/keep-the-why
+npx skills add https://github.com/oliver-zehentleitner/keep-the-why/tree/latest/skills/keep-the-why
 ```
 
 Also recommended, with GitHub CLI v2.90.0+:
 
 ```bash
-gh skill install oliver-zehentleitner/keep-the-why
+gh skill install oliver-zehentleitner/keep-the-why keep-the-why@latest
 ```
 
 Fallback (manual clone) — the skill lives under `skills/keep-the-why/` in this repo, not at the
@@ -40,7 +45,7 @@ root, so clone to a scratch location and copy just that folder rather than cloni
 into your agent's skills directory:
 
 ```bash
-git clone https://github.com/oliver-zehentleitner/keep-the-why.git /tmp/keep-the-why
+git clone --branch latest https://github.com/oliver-zehentleitner/keep-the-why.git /tmp/keep-the-why
 cp -r /tmp/keep-the-why/skills/keep-the-why <target-directory>/keep-the-why
 rm -rf /tmp/keep-the-why
 ```


### PR DESCRIPTION
Pushed a 'latest' tag now (-> v0.1.0). Install examples use it instead of a hardcoded version so docs never go stale between releases. Exact-version pinning still documented as the alternative. Needs a release.yml change (separate, for manual paste-in) to keep 'latest' moving automatically going forward.