### PR TITLE
Link Node.js install instead of the deprecated npm/npx repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Where the captured knowledge actually lives, and how it relates to everything el
 
 `main` is active development, not guaranteed release-ready — pin to `latest` instead of tracking it directly (moved automatically by CI to the newest release; use an exact [tag](https://github.com/oliver-zehentleitner/keep-the-why/releases) instead for full reproducibility). See [`docs/installation.md`](docs/installation.md) for the unpinned form and full detail.
 
-**Recommended — [skills CLI](https://skills.sh/) (via `npx`, needs Node.js):**
+**Recommended — [skills CLI](https://skills.sh/) (via `npx`, needs [Node.js](https://nodejs.org/en/download) — `npx` ships with it, nothing extra to install):**
 
 ```bash
 npx skills add https://github.com/oliver-zehentleitner/keep-the-why/tree/latest/skills/keep-the-why

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,7 +16,7 @@ None of that substitutes for actually reading `SKILL.md` yourself before install
 
 ## Recommended: skills CLI
 
-With [`skills`](https://skills.sh/) (runs via `npx`, requires Node.js, no separate install step), pinned to a release via a GitHub tree URL:
+With [`skills`](https://skills.sh/) (runs via `npx`, requires [Node.js](https://nodejs.org/en/download) — `npx` ships with it, no separate install step), pinned to a release via a GitHub tree URL:
 
 ```bash
 npx skills add https://github.com/oliver-zehentleitner/keep-the-why/tree/latest/skills/keep-the-why

--- a/llms.txt
+++ b/llms.txt
@@ -28,7 +28,8 @@ it directly. A `latest` tag always points to the newest release, moved automatic
 an exact tag (e.g. `v0.1.0`) instead for full reproducibility; see the releases page:
 https://github.com/oliver-zehentleitner/keep-the-why/releases
 
-Recommended, with the skills CLI (via `npx`, needs Node.js):
+Recommended, with the skills CLI (via `npx`, needs Node.js: https://nodejs.org/en/download —
+`npx` ships with it, nothing extra to install):
 
 ```bash
 npx skills add https://github.com/oliver-zehentleitner/keep-the-why/tree/latest/skills/keep-the-why


### PR DESCRIPTION
Checked github.com/npm/npx before linking it - explicitly marked deprecated, npx is now part of npm core, and its own README still shows the outdated \`npm install -g npx\` instruction for the old standalone package. Linked nodejs.org instead in all three places that mention the Node.js requirement (README, installation.md, llms.txt) - npx ships bundled with npm >=5.2 / Node >=8.2, so installing Node.js is the actually correct fix for someone who doesn't have npx yet.