### PR TITLE
Badge goes last in the badge row, not just 'near the top'

### DIFF
--- a/docs/badge.md
+++ b/docs/badge.md
@@ -12,7 +12,7 @@ The snippet is the same for every project — copy it as-is.
 [![Keep the Why](https://keepthewhy.com/assets/badge.svg)](https://keepthewhy.com)
 ```
 
-Paste it wherever the other badges live, usually near the top of `README.md`.
+Paste it near the top of `README.md`, as the *last* badge if there are others already — keeps it out of the way of badges that carry more load-bearing information (build status, license, version).
 
 ## HTML
 

--- a/skills/keep-the-why/examples/first-time-setup.md
+++ b/skills/keep-the-why/examples/first-time-setup.md
@@ -17,7 +17,7 @@ The skill has just been installed in a project. There's no `AGENTS.md`, no `cont
     > - Add the Keep the Why badge to README.md? [yes]
 
 3. User replies: "defaults."
-4. Adds the badge to `README.md`, near the existing badges:
+4. Adds the badge to `README.md`, as the last badge after the existing ones:
 
     ```markdown
     [![Keep the Why](https://keepthewhy.com/assets/badge.svg)](https://keepthewhy.com)

--- a/skills/keep-the-why/references/setup.md
+++ b/skills/keep-the-why/references/setup.md
@@ -41,7 +41,7 @@ Where the why-knowledge lives and whether the project has been set up at all are
 2. Ask, in one pass:
    - Where should the why-knowledge live? Default `context/`; anything else is fine.
    - How do you want to start: capture from now on only, work through existing history now (retrospective recovery), sit down for an interview now, or some combination?
-   - Add the Keep the Why badge to this project's `README.md`? If yes, insert `[![Keep the Why](https://keepthewhy.com/assets/badge.svg)](https://keepthewhy.com)` near the top, alongside any other badges — same snippet for every project, see `keepthewhy.com/badge/`.
+   - Add the Keep the Why badge to this project's `README.md`? If yes, insert `[![Keep the Why](https://keepthewhy.com/assets/badge.svg)](https://keepthewhy.com)` as the *last* badge in the existing badge row — same snippet for every project, see `keepthewhy.com/badge/`. If there's no existing badge row yet, it's the only one, at the top.
 3. Run whichever starting mode was chosen.
 4. If declined entirely, write `init: declined` and stop — no further project-level questions, ever, unless asked again. (The personal wizard below is independent and can still run.)
 


### PR DESCRIPTION
Consistent with how this repo's own README already does it (Keep the Why badge is last after Release/License/Link Check/Read the Docs/Telegram) - stated explicitly now in the init wizard, the example, and docs/badge.md instead of the vaguer 'near the top.'