### PR TITLE
Create context/README.md during init, with logo

### DIFF
--- a/skills/keep-the-why/SKILL.md
+++ b/skills/keep-the-why/SKILL.md
@@ -94,6 +94,7 @@ project/
 ├── docs/                # HOW to use, operate, test, deploy — human-facing, agent-readable too
 │   └── index.md
 └── context/             # WHY the project is the way it is
+    ├── README.md        # short, for anyone landing here cold (GitHub renders it automatically)
     ├── index.md         # lean index — the load-bearing file for keeping agent context efficient
     ├── architecture.md
     └── ...               # one file per topic, not per source file, not per decision

--- a/skills/keep-the-why/evals/evals.json
+++ b/skills/keep-the-why/evals/evals.json
@@ -62,7 +62,7 @@
   {
     "id": "init-wizard-first-activation",
     "prompt": "First activation of the skill in a fresh project. No AGENTS.md, no context/, no CLAUDE.md, no AGENTS.local.md.",
-    "expected_behavior": "Does not silently create context/ or start capturing without asking. Detects the absence of both the project config block and the personal config block, and runs both wizards separately: project wizard asks where why-knowledge should live, how to start (fresh / retrospective / interview), and whether to add the README badge; personal wizard asks autostart preference and update-check/consistency-check intervals. Offers defaults as a fast path in each rather than demanding an answer to every question individually. Writes the project block to the entry-point file and the personal block to AGENTS.local.md, not mixed into one block."
+    "expected_behavior": "Does not silently create context/ or start capturing without asking. Detects the absence of both the project config block and the personal config block, and runs both wizards separately: project wizard asks where why-knowledge should live, how to start (fresh / retrospective / interview), and whether to add the README badge; personal wizard asks autostart preference and update-check/consistency-check intervals. Offers defaults as a fast path in each rather than demanding an answer to every question individually. Writes the project block to the entry-point file and the personal block to AGENTS.local.md, not mixed into one block. Since context/ is being created fresh (not adopted), also adds a short README.md inside it explaining what the folder is."
   },
   {
     "id": "init-already-complete-new-developer-still-asked-personal",

--- a/skills/keep-the-why/examples/first-time-setup.md
+++ b/skills/keep-the-why/examples/first-time-setup.md
@@ -17,13 +17,28 @@ The skill has just been installed in a project. There's no `AGENTS.md`, no `cont
     > - Add the Keep the Why badge to README.md? [yes]
 
 3. User replies: "defaults."
-4. Adds the badge to `README.md`, near the existing badges:
+4. Adds the badge to `README.md`, as the last badge after the existing ones:
 
     ```markdown
     [![Keep the Why](https://keepthewhy.com/assets/badge.svg)](https://keepthewhy.com)
     ```
 
-5. Creates `AGENTS.md` with a short pointer section and the project config block:
+5. `context/` doesn't exist yet, so creates it with a short `README.md` inside (GitHub renders this automatically when someone browses the folder):
+
+    ```markdown
+    <img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why" width="200">
+
+    # Context
+
+    Why this project is built the way it is — architecture decisions,
+    rejected alternatives, workarounds, and reasoning the code alone
+    can't show. Captured and kept current by the [Keep the
+    Why](https://keepthewhy.com) agent skill.
+
+    Not usage docs — see `docs/` for that. Start with `index.md`.
+    ```
+
+6. Creates `AGENTS.md` with a short pointer section and the project config block:
 
     ```markdown
     <!-- keep-the-why:config -->
@@ -32,15 +47,15 @@ The skill has just been installed in a project. There's no `AGENTS.md`, no `cont
     <!-- /keep-the-why:config -->
     ```
 
-6. Runs the personal preferences wizard, separately:
+7. Runs the personal preferences wizard, separately:
 
     > And a couple of preferences just for you (not committed):
     > - Load automatically every session, or only when asked? [automatically]
     > - Check for skill updates? [yes, every 14 days]
     > - Check `context/` for staleness? [yes, every 30 days]
 
-7. User replies: "don't autostart, defaults on the rest."
-8. Creates `AGENTS.local.md`, referenced from `AGENTS.md`, with the personal config block:
+8. User replies: "don't autostart, defaults on the rest."
+9. Creates `AGENTS.local.md`, referenced from `AGENTS.md`, with the personal config block:
 
     ```markdown
     <!-- keep-the-why:local -->
@@ -50,11 +65,11 @@ The skill has just been installed in a project. There's no `AGENTS.md`, no `cont
     <!-- /keep-the-why:local -->
     ```
 
-9. Only then answers the original question about the retry logic — using retrospective recovery on just that piece of code, since "fresh start" was chosen, not a full-history pass.
+10. Only then answers the original question about the retry logic — using retrospective recovery on just that piece of code, since "fresh start" was chosen, not a full-history pass.
 
 ## A second developer opens the same project later
 
-The project config block already says `init: complete` — that part isn't re-asked, it's a project fact, not a per-developer one. But this developer has no `AGENTS.local.md` yet, so the personal preferences wizard (step 6 above) runs for them individually. Their answers might differ from the first developer's, and that's fine — autostart and check intervals are exactly the kind of thing that should vary per person.
+The project config block already says `init: complete` — that part isn't re-asked, it's a project fact, not a per-developer one. But this developer has no `AGENTS.local.md` yet, so the personal preferences wizard (step 7 above) runs for them individually. Their answers might differ from the first developer's, and that's fine — autostart and check intervals are exactly the kind of thing that should vary per person.
 
 ## What it doesn't do
 
@@ -62,4 +77,5 @@ The project config block already says `init: complete` — that part isn't re-as
 - Doesn't turn either wizard into a long interrogation — one message each, sensible defaults, "defaults" as a valid one-word answer.
 - Doesn't add the badge (or anything else) if the user says no to that specific question — each wizard answer is independent, not all-or-nothing.
 - Doesn't bundle personal preferences into the committed project config, and doesn't skip the personal wizard just because the project is already initialized.
+- Doesn't overwrite an existing `context/README.md` (or equivalent) if the folder is being adopted rather than created fresh.
 - Doesn't answer the original question before setup is resolved, but also doesn't let setup become a multi-turn detour from what the user actually asked.

--- a/skills/keep-the-why/references/repository-structure.md
+++ b/skills/keep-the-why/references/repository-structure.md
@@ -15,6 +15,7 @@ project/
 │   ├── testing.md
 │   └── troubleshooting.md
 └── context/
+    ├── README.md              # short, GitHub renders it when someone browses the folder cold
     ├── index.md
     ├── architecture.md
     ├── <topic>.md            # one per recurring theme, named for the theme, not the file it touches

--- a/skills/keep-the-why/references/setup.md
+++ b/skills/keep-the-why/references/setup.md
@@ -41,9 +41,25 @@ Where the why-knowledge lives and whether the project has been set up at all are
 2. Ask, in one pass:
    - Where should the why-knowledge live? Default `context/`; anything else is fine.
    - How do you want to start: capture from now on only, work through existing history now (retrospective recovery), sit down for an interview now, or some combination?
-   - Add the Keep the Why badge to this project's `README.md`? If yes, insert `[![Keep the Why](https://keepthewhy.com/assets/badge.svg)](https://keepthewhy.com)` near the top, alongside any other badges — same snippet for every project, see `keepthewhy.com/badge/`.
-3. Run whichever starting mode was chosen.
-4. If declined entirely, write `init: declined` and stop — no further project-level questions, ever, unless asked again. (The personal wizard below is independent and can still run.)
+   - Add the Keep the Why badge to this project's `README.md`? If yes, insert `[![Keep the Why](https://keepthewhy.com/assets/badge.svg)](https://keepthewhy.com)` as the *last* badge in the existing badge row — same snippet for every project, see `keepthewhy.com/badge/`. If there's no existing badge row yet, it's the only one, at the top.
+3. If the why-knowledge folder is being created fresh (not an existing folder being adopted), add a short `README.md` inside it:
+
+    ```markdown
+    <img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why" width="200">
+
+    # Context
+
+    Why this project is built the way it is — architecture decisions,
+    rejected alternatives, workarounds, and reasoning the code alone
+    can't show. Captured and kept current by the [Keep the
+    Why](https://keepthewhy.com) agent skill.
+
+    Not usage docs — see `docs/` for that. Start with `index.md`.
+    ```
+
+    GitHub (and most code hosts) render a folder's `README.md` automatically when browsing it, so this is what someone sees first landing in the folder cold, without needing to already know what Keep the Why is. Skip this step if adopting an existing folder that already has its own README or equivalent — don't overwrite it.
+4. Run whichever starting mode was chosen.
+5. If declined entirely, write `init: declined` and stop — no further project-level questions, ever, unless asked again. (The personal wizard below is independent and can still run.)
 
 ## Personal preferences wizard (once per developer)
 


### PR DESCRIPTION
Oliver's idea: GitHub renders a folder's README.md automatically when browsing it, so context/ (which otherwise only has topic files and index.md) has nothing explaining what it is to someone landing there cold without prior Keep the Why knowledge. Init wizard now creates a short README.md there too - a couple sentences, the logo (https://keepthewhy.com/assets/logo.png), and a link to keepthewhy.com - but only when creating context/ fresh, not when adopting an existing folder (don't overwrite).

Updated both structure diagrams, the first-time-setup example, and the init-wizard eval.

## Test plan
- [x] `mkdocs build --strict` passes
- [x] `evals.json` validates (17 cases)

Found and fixed a real build issue: a literal `[index.md](index.md)` markdown link inside the example template (meant as illustrative text inside a fenced code block) was still caught by mkdocs' strict-mode link checker as a broken real link. Switched to a plain code span.