### PR TITLE
Remove width attribute from context README logo

### DIFF
--- a/skills/keep-the-why/examples/first-time-setup.md
+++ b/skills/keep-the-why/examples/first-time-setup.md
@@ -26,7 +26,7 @@ The skill has just been installed in a project. There's no `AGENTS.md`, no `cont
 5. `context/` doesn't exist yet, so creates it with a short `README.md` inside (GitHub renders this automatically when someone browses the folder):
 
     ```markdown
-    <img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why" width="200">
+    <img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why">
 
     # Context
 

--- a/skills/keep-the-why/references/setup.md
+++ b/skills/keep-the-why/references/setup.md
@@ -45,7 +45,7 @@ Where the why-knowledge lives and whether the project has been set up at all are
 3. If the why-knowledge folder is being created fresh (not an existing folder being adopted), add a short `README.md` inside it:
 
     ```markdown
-    <img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why" width="200">
+    <img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why">
 
     # Context
 


### PR DESCRIPTION
Follow-up to PR #37 - the fix landed on that branch after it had already merged, so it never made it into main.