### PR TITLE
Add context/README.md, dogfooding the init-wizard step

### DIFF
--- a/context/README.md
+++ b/context/README.md
@@ -1,0 +1,7 @@
+<img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why">
+
+# Context
+
+Why this project is built the way it is — architecture decisions, rejected alternatives, workarounds, and reasoning the code alone can't show. Captured and kept current by the [Keep the Why](https://keepthewhy.com) agent skill.
+
+Not usage docs — see `docs/` for that. Start with `index.md`.


### PR DESCRIPTION
Following the same template skills/keep-the-why/references/setup.md now has the skill create for other projects. GitHub renders this automatically when browsing context/, matching why the step exists at all.