### PR TITLE
Fix update-check retry contradiction, gitignore AGENTS.local.md, rename autostart

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Keep the Why is a `SKILL.md`-based agent skill — an open, cross-agent format (
 3. **Knowledge-transfer interview** — before a maintainer's knowledge becomes unavailable (leaving, retiring, changing teams), the agent analyzes the codebase first, then either asks targeted questions about exactly what the code couldn't explain, or — for someone whose knowledge is broad and tacit after many years on one system — just listens while they narrate freely and extracts the rationale from that instead.
 4. **Maintenance** — existing rationale docs get kept current: contradictions resolved, superseded entries marked, oversized files split.
 
-First activation in a project runs a short one-time setup instead of guessing at defaults — where the why-knowledge should live, how to start, autostart on or off, and whether to periodically check for skill updates or `context/` staleness. See [`docs/setup.md`](docs/setup.md).
+First activation in a project runs a short one-time setup instead of guessing at defaults — where the why-knowledge should live, how to start, proactive or explicit-only capture, and whether to periodically check for skill updates or `context/` staleness. See [`docs/setup.md`](docs/setup.md).
 
 Where the captured knowledge actually lives, and how it relates to everything else a project already has, is one coherent picture — see "Where this fits" below.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,9 +29,8 @@ primary handler. This person will coordinate the fix and release process,
 involving the following steps:
 
   * Confirm the problem and determine the affected versions.
-  * Audit code to find any potential similar problems.
-  * Prepare fixes for all releases still under maintenance. These fixes will be
-    released as fast as possible to pip.
+  * Audit the skill's instructions and reference files for any similar issues.
+  * Prepare a fix and publish it as a new GitHub release as fast as possible.
 
 ## Comments on this Policy
 If you have suggestions on how this process could be improved please submit a

--- a/context/repo-conventions.md
+++ b/context/repo-conventions.md
@@ -62,7 +62,7 @@ Setup state is written into `<!-- keep-the-why:config -->` / `<!-- keep-the-why:
 
 Where `context/` lives and whether the project has been initialized are in the committed `AGENTS.md` config block. Autostart preference, and the update-check/consistency-check intervals and their last-run timestamps, are in the personal, uncommitted `AGENTS.local.md` block instead. A project can be `init: complete` while a specific developer still gets asked their own preferences, if they don't have an `AGENTS.local.md` yet.
 
-**Reason:** the first version bundled everything into one committed block. Oliver pointed out that autostart and check-interval preferences are individual workflow choices, not project facts — one developer wanting weekly update checks and another wanting none are both fine, and forcing one answer onto everyone (or making it a merge-conflict-prone shared timestamp several sessions race to update) doesn't fit the existing `AGENTS.md`/`AGENTS.local.md` boundary this project already draws for exactly this kind of distinction.
+**Reason:** the first version bundled everything into one committed block. Oliver pointed out that capture-mode and check-interval preferences are individual workflow choices, not project facts — one developer wanting weekly update checks and another wanting none are both fine, and forcing one answer onto everyone (or making it a merge-conflict-prone shared timestamp several sessions race to update) doesn't fit the existing `AGENTS.md`/`AGENTS.local.md` boundary this project already draws for exactly this kind of distinction.
 
 **Rejected alternative:** one combined block covering both project and personal state, as originally shipped. Rejected once the personal/project distinction became clear — see above.
 

--- a/skills/keep-the-why/evals/evals.json
+++ b/skills/keep-the-why/evals/evals.json
@@ -62,12 +62,12 @@
   {
     "id": "init-wizard-first-activation",
     "prompt": "First activation of the skill in a fresh project. No AGENTS.md, no context/, no CLAUDE.md, no AGENTS.local.md.",
-    "expected_behavior": "Does not silently create context/ or start capturing without asking. Detects the absence of both the project config block and the personal config block, and runs both wizards separately: project wizard asks where why-knowledge should live, how to start (fresh / retrospective / interview), and whether to add the README badge; personal wizard asks autostart preference and update-check/consistency-check intervals. Offers defaults as a fast path in each rather than demanding an answer to every question individually. Writes the project block to the entry-point file and the personal block to AGENTS.local.md, not mixed into one block. Since context/ is being created fresh (not adopted), also adds a short README.md inside it explaining what the folder is."
+    "expected_behavior": "Does not silently create context/ or start capturing without asking. Detects the absence of both the project config block and the personal config block, and runs both wizards separately: project wizard asks where why-knowledge should live, how to start (fresh / retrospective / interview), and whether to add the README badge; personal wizard asks capture-mode preference and update-check/consistency-check intervals. Offers defaults as a fast path in each rather than demanding an answer to every question individually. Writes the project block to the entry-point file and the personal block to AGENTS.local.md, not mixed into one block. Since context/ is being created fresh (not adopted), also adds a short README.md inside it explaining what the folder is."
   },
   {
     "id": "init-already-complete-new-developer-still-asked-personal",
     "prompt": "A different developer opens this same project, which already has an AGENTS.md with a keep-the-why project config block showing init: complete, but no AGENTS.local.md for this developer yet.",
-    "expected_behavior": "Does not re-run the project init wizard - context location and starting mode are already settled project-wide. Does run the personal preferences wizard for this developer, since AGENTS.local.md doesn't exist for them yet - autostart and check intervals are per-developer, not inherited from the project config. Their answers can differ from whatever the first developer chose."
+    "expected_behavior": "Does not re-run the project init wizard - context location and starting mode are already settled project-wide. Does run the personal preferences wizard for this developer, since AGENTS.local.md doesn't exist for them yet - capture mode and check intervals are per-developer, not inherited from the project config. Their answers can differ from whatever the first developer chose."
   },
   {
     "id": "init-declined-not-reasked",
@@ -81,7 +81,17 @@
   },
   {
     "id": "update-check-cannot-run-surfaced-once",
-    "prompt": "The update-check interval has elapsed, but this session has no web access, so the latest release can't be checked.",
-    "expected_behavior": "Does not fail silently and just move on as if nothing happened. Reports that the check couldn't run and asks whether to keep retrying each session or turn update-check off. Updates the 'last' timestamp regardless so the next attempt waits a full interval rather than retrying immediately. Does not re-ask about this same failure mode every session once the user has answered once."
+    "prompt": "The update-check interval has elapsed, but this session has no web access, so the latest release can't be checked. This is the first time the check has ever failed.",
+    "expected_behavior": "Does not fail silently and just move on as if nothing happened. Reports that the check couldn't run and asks whether to keep retrying next session or turn update-check off. Does NOT advance the 'last' timestamp on this failed attempt - leaving it unchanged is what makes the next session retry automatically instead of waiting out the full interval. Records the user's answer as an 'on-failure' field (retry-quietly or disabled) so the same question isn't asked again on subsequent failures."
+  },
+  {
+    "id": "update-check-repeat-failure-no-reask",
+    "prompt": "The personal config already has 'update-check: every 14 days — last: 2026-07-08 — on-failure: retry-quietly' from a previous failed attempt. This session also has no web access.",
+    "expected_behavior": "Retries the check silently without asking the user how to handle it again - on-failure is already set to retry-quietly from the earlier answer. Does not advance 'last'. If a later session succeeds, 'last' advances to that session's date and on-failure's job is done for this cycle."
+  },
+  {
+    "id": "agents-local-gitignore-not-covered",
+    "prompt": "Running the personal preferences wizard for the first time in a project. AGENTS.local.md doesn't exist yet, and .gitignore has no entry for it.",
+    "expected_behavior": "Before creating AGENTS.local.md, checks whether .gitignore excludes it. Since it doesn't, adds an AGENTS.local.md entry to .gitignore (creating .gitignore if it doesn't exist) before creating the file - not after, and not skipped. Personal preferences described as 'not committed' should actually be prevented from being committed, not just documented as such."
   }
 ]

--- a/skills/keep-the-why/examples/first-time-setup.md
+++ b/skills/keep-the-why/examples/first-time-setup.md
@@ -50,16 +50,16 @@ The skill has just been installed in a project. There's no `AGENTS.md`, no `cont
 7. Runs the personal preferences wizard, separately:
 
     > And a couple of preferences just for you (not committed):
-    > - Load automatically every session, or only when asked? [automatically]
+    > - Capture proactively during conversation, or only when asked? [proactive]
     > - Check for skill updates? [yes, every 14 days]
     > - Check `context/` for staleness? [yes, every 30 days]
 
-8. User replies: "don't autostart, defaults on the rest."
-9. Creates `AGENTS.local.md`, referenced from `AGENTS.md`, with the personal config block:
+8. User replies: "explicit-only, defaults on the rest."
+9. `AGENTS.local.md` doesn't exist yet. Checks `.gitignore` first — it already has an `AGENTS.local.md` entry (from an earlier project convention), so nothing to add there. Creates `AGENTS.local.md`, referenced from `AGENTS.md`, with the personal config block:
 
     ```markdown
     <!-- keep-the-why:local -->
-    - autostart: no
+    - capture-mode: explicit-only
     - update-check: every 14 days — last: 2026-07-21
     - consistency-check: every 30 days — last: 2026-07-21
     <!-- /keep-the-why:local -->
@@ -69,7 +69,11 @@ The skill has just been installed in a project. There's no `AGENTS.md`, no `cont
 
 ## A second developer opens the same project later
 
-The project config block already says `init: complete` — that part isn't re-asked, it's a project fact, not a per-developer one. But this developer has no `AGENTS.local.md` yet, so the personal preferences wizard (step 7 above) runs for them individually. Their answers might differ from the first developer's, and that's fine — autostart and check intervals are exactly the kind of thing that should vary per person.
+The project config block already says `init: complete` — that part isn't re-asked, it's a project fact, not a per-developer one. But this developer has no `AGENTS.local.md` yet, so the personal preferences wizard (step 7 above) runs for them individually. Their answers might differ from the first developer's, and that's fine — capture mode and check intervals are exactly the kind of thing that should vary per person.
+
+## A later session, after a few weeks of no web access
+
+The update-check interval elapses, but this environment has no web access. The skill reports it can't check, asks whether to keep retrying next session or turn the check off, and the developer says "keep trying." The personal config block gets a third field: `- update-check: every 14 days — last: 2026-07-08 — on-failure: retry-quietly`. Because `last` didn't advance on the failed attempt, the very next session tries again automatically — and because `on-failure` is now `retry-quietly`, it does so without asking the same question again. Once a check actually succeeds, `last` advances and the normal interval takes back over.
 
 ## What it doesn't do
 
@@ -78,4 +82,6 @@ The project config block already says `init: complete` — that part isn't re-as
 - Doesn't add the badge (or anything else) if the user says no to that specific question — each wizard answer is independent, not all-or-nothing.
 - Doesn't bundle personal preferences into the committed project config, and doesn't skip the personal wizard just because the project is already initialized.
 - Doesn't overwrite an existing `context/README.md` (or equivalent) if the folder is being adopted rather than created fresh.
+- Doesn't create `AGENTS.local.md` without first making sure `.gitignore` actually excludes it — "not committed" is enforced, not just documented.
+- Doesn't keep asking the same "web access is broken, what do you want to do" question every session once it's been answered once.
 - Doesn't answer the original question before setup is resolved, but also doesn't let setup become a multi-turn detour from what the user actually asked.

--- a/skills/keep-the-why/references/repository-structure.md
+++ b/skills/keep-the-why/references/repository-structure.md
@@ -70,7 +70,7 @@ Keep it short. Anything longer belongs in `docs/` or `context/`, not here — `A
 
 ```markdown
 <!-- keep-the-why:local -->
-- autostart: yes
+- capture-mode: proactive
 - update-check: every 14 days — last: 2026-07-21
 - consistency-check: every 30 days — last: 2026-07-21
 <!-- /keep-the-why:local -->

--- a/skills/keep-the-why/references/setup.md
+++ b/skills/keep-the-why/references/setup.md
@@ -19,13 +19,15 @@ Setup state splits across two files, matching the existing `AGENTS.md`/`AGENTS.l
 
 ```markdown
 <!-- keep-the-why:local -->
-- autostart: yes
+- capture-mode: proactive
 - update-check: every 14 days — last: 2026-07-21
 - consistency-check: every 30 days — last: 2026-07-21
 <!-- /keep-the-why:local -->
 ```
 
-Where the why-knowledge lives and whether the project has been set up at all are facts about the project — everyone should see the same answer, so they're committed. Autostart and how often to run the timer checks are about how *this one developer* wants to work day to day — one person might want autostart and weekly checks, another might not want either, and neither is more correct. Splitting them also means the update-check/consistency-check timestamps don't turn into a shared field that every developer's session is racing to update.
+Where the why-knowledge lives and whether the project has been set up at all are facts about the project — everyone should see the same answer, so they're committed. Capture mode and how often to run the timer checks are about how *this one developer* wants to work day to day — one person might want proactive capture and weekly checks, another might not want either, and neither is more correct. Splitting them also means the update-check/consistency-check timestamps don't turn into a shared field that every developer's session is racing to update.
+
+`capture-mode` says `proactive` rather than `autostart` deliberately — a Skill has no session-level autostart hook to promise (see "What this skill is not" in `SKILL.md`); what's actually configurable is whether the skill, once active in a conversation, looks for capture opportunities on its own or waits to be asked. `proactive` describes that behavior honestly; `explicit-only` is the alternative.
 
 ## Detection and the two independent wizards
 
@@ -64,10 +66,11 @@ Where the why-knowledge lives and whether the project has been set up at all are
 ## Personal preferences wizard (once per developer)
 
 1. Ask, in one pass:
-   - Autostart every session, or load manually when asked? Default: automatically.
+   - Capture proactively during normal conversation, or only when explicitly asked? Default: proactive.
    - Check for skill updates automatically? If yes, what interval (default: 14 days).
    - Check `context/` for staleness automatically? If yes, what interval (default: 30 days).
-2. Write the answers to the `AGENTS.local.md` personal block. If `AGENTS.local.md` doesn't exist yet, create it and make sure the entry-point file points to it (see `methodology.md`).
+2. If `AGENTS.local.md` doesn't exist yet: before creating it, check whether the project's `.gitignore` already excludes it. If not, add an `AGENTS.local.md` entry to `.gitignore` (creating the file if it doesn't exist) — this file is meant to hold personal, sometimes sensitive preferences, and "not committed" only means something if it's actually enforced, not just stated in prose. Then create `AGENTS.local.md` and make sure the entry-point file points to it (see `methodology.md`).
+3. Write the answers to the `AGENTS.local.md` personal block.
 
 Both wizards: offer the defaults as a fast path ("just use the defaults" should be a one-word answer), but leave room for different choices, and record any deviation explicitly rather than leaving it implied.
 
@@ -77,7 +80,9 @@ Two independent timers, both opportunistic — checked when the skill is already
 
 **Update check.** If `update-check` is enabled and the interval has elapsed since `last`: compare the installed `version` (`SKILL.md` frontmatter) against the latest release's `tag_name`. Query the GitHub API, not the HTML releases page — turn `repository` (also frontmatter) into an API URL by replacing `github.com/` with `api.github.com/repos/` and appending `/releases/latest`, e.g. `https://api.github.com/repos/oliver-zehentleitner/keep-the-why/releases/latest`. Returns clean JSON (`tag_name`, `published_at`, ...) instead of requiring the agent to parse an HTML redirect. This needs the agent's own web access — the skill itself has none (see "What this skill is not").
 
-If checking isn't possible (no web access this session): don't fail silently forever. The first time this happens, say so and ask how to handle it — keep retrying each session, or turn `update-check` off. Respect the answer and don't re-ask every session after that; a check that's been silently broken since the day it was set up isn't a check, it's a false sense of one. Update `last` regardless of outcome, so the interval logic doesn't retry on every single message.
+`last` only advances on a check that actually completed (found "up to date" or found a newer version) — not on an attempt that couldn't run at all. That's what makes "keep retrying" and "the interval controls how often this runs" both true at once: a successful check waits out the full interval before trying again; a failed attempt leaves `last` untouched, so the *next* session tries again regardless of how much of the interval has passed.
+
+If checking isn't possible (no web access this session): don't fail silently forever, and don't re-ask about the same ongoing failure every single session either. The first time an attempt fails, say so and ask how to handle it — keep retrying next session, or turn `update-check` off. Record the answer as a third field, e.g. `- update-check: every 14 days — last: 2026-07-08 — on-failure: retry-quietly`. `on-failure` starts unset (meaning: ask, the first time it's needed); once set to `retry-quietly`, keep attempting silently on future failures without asking again; if set to `disabled`, stop checking and drop `update-check` to `no`.
 
 **Consistency check.** If `consistency-check` is enabled and the interval has elapsed: look for entries whose `Revisit when` condition (see `repository-structure.md`) has actually been triggered — not just entries that are merely old. Age alone isn't a defect; an untriggered old entry is still accurate. Scope the check to what `context/index.md` already summarizes rather than opening every topic file — the index exists precisely so this kind of check stays cheap. If something's genuinely triggered, surface it and ask whether to address it now. Update `last` regardless of outcome.
 


### PR DESCRIPTION
Three verified issues from the latest external review round (points 3, 4, 7 - points 5 and 6 deliberately left for discussion, 6 duplicates already-open #20):

1. **Update-check retry logic contradicted itself** - "keep retrying each session" + "update last regardless of outcome" can't both hold. Fixed: `last` only advances on a check that completed; a failed attempt leaves it untouched so the next session retries automatically. Added `on-failure` field so a broken check doesn't re-ask the same question every session.
2. **AGENTS.local.md wasn't gitignore-verified** - wizard called it "not committed" in prose but never checked. Now checks/adds a `.gitignore` entry before creating the file.
3. **"autostart" renamed to "capture-mode: proactive | explicit-only"** - a Skill can't promise session-level autostart (no such hook exists), so the field now describes what's actually configurable instead.

Also fixed an unrelated but real copy-paste leftover in SECURITY.md ("released as fast as possible to pip" - this ships via GitHub releases, not pip).

## Test plan
- [x] `mkdocs build --strict` passes
- [x] `evals.json` validates (19 cases, 2 new)