### PR TITLE
Split Status from Evidence, add Source/Verification, and a migration mechanism

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,3 +8,9 @@ This project uses Keep the Why (itself) to preserve the reasoning behind its own
 Read `context/index.md` before making non-trivial changes — naming, docs
 tooling, and repo structure have already been argued through once; check
 there before re-litigating or accidentally reverting a decision.
+
+<!-- keep-the-why:config -->
+- context: `context/`
+- init: complete
+- context-schema: 0.3.0
+<!-- /keep-the-why:config -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+### Added
+
+- `context/` entries now track **Status** (active, superseded, open, needs-review) separately from **Evidence** (confirmed, inferred, unknown) — previously "superseded" was mixed into the evidence classification as if it were a fourth confidence level, when it's really a different question (is this still current, vs. how well is it backed).
+- Optional **Source** and **Verification** fields for confirmed entries whose claim is worth tracing or could be checked against other evidence. A `contradicted` verification must explain what contradicts it, not just carry the label.
+- `context-schema` field in the project config block, tracking which version's `context/` entry format is in use — separate from the installed skill version, since not every release changes the format.
+- `references/migrations.md`: what changed and how to update existing `context/` entries, checked automatically when `context-schema` falls behind the installed version.
+- This `CHANGELOG.md` — the README already promised one in its "Where this fits" table; it just didn't exist.
+
 ## [0.2.0] - 2026-07-21
 
 ### Added

--- a/context/repo-conventions.md
+++ b/context/repo-conventions.md
@@ -3,7 +3,7 @@
 ## Automation tokens need the `workflow` OAuth scope to push workflow files
 
 **Status:** active, operational constraint (not a design choice)
-**Confirmed**
+**Evidence:** confirmed
 
 Any push that touches `.github/workflows/*.yml` is rejected by GitHub unless the pushing credential has the `workflow` OAuth scope — this is independent of the `repo` scope and applies to any token or bot/automation account that lacks it, not specific to this repo.
 
@@ -12,7 +12,7 @@ Any push that touches `.github/workflows/*.yml` is rejected by GitHub unless the
 ## The installable skill lives under `skills/keep-the-why/`, not at the repo root
 
 **Status:** active
-**Confirmed**
+**Evidence:** confirmed
 
 `SKILL.md`, `references/`, `examples/`, and `evals/` moved from the repo root into `skills/keep-the-why/`. Everything else (`docs/`, `mkdocs.yml`, `context/`, CI config) stays at the root — it's this project's own site and self-documentation, not part of what gets installed into someone else's project.
 
@@ -25,7 +25,7 @@ It also fixes a second, independent problem: cloning this whole repository into 
 ## Launch-readiness pass: SKILL.md trimmed, negative evals added, README reordered
 
 **Status:** active
-**Confirmed**
+**Evidence:** confirmed
 
 Four changes made together ahead of publishing to skill marketplaces: `SKILL.md` cut from ~2100 to ~1580 words (merged redundant rules, tightened the Record workflow step instead of restating rules 9/13 in full); six negative-case evals added (routine changes that shouldn't trigger the skill, an already-good doc structure that shouldn't be rebuilt, conflicting sources, a secret in an interview answer, a stale confirmed decision past its revisit trigger); README reordered so Install and a concrete Example come right after the pitch, with the longer "Problem" and "Where this fits" sections moved below instead of gating the actionable content; and social preview meta tags (Open Graph/Twitter card, pointing at the existing logo) added via a small `overrides/main.html` template.
 
@@ -36,7 +36,7 @@ Four changes made together ahead of publishing to skill marketplaces: `SKILL.md`
 ## Setup/init state is tracked opportunistically, not via a real background schedule
 
 **Status:** active
-**Confirmed**
+**Evidence:** confirmed
 
 The skill's periodic checks (update availability, `context/` staleness) run as an "elapsed time since last check" comparison evaluated whenever the skill is already active in a session — not a true OS-level scheduled job (`cron`, Task Scheduler) that wakes something up on its own.
 
@@ -47,7 +47,7 @@ The skill's periodic checks (update availability, `context/` staleness) run as a
 ## Config state lives in delimited blocks inside existing entry-point files, not a separate file
 
 **Status:** active
-**Confirmed**
+**Evidence:** confirmed
 
 Setup state is written into `<!-- keep-the-why:config -->` / `<!-- keep-the-why:local -->` blocks inside files the project already has a reason to read (`AGENTS.md` and `AGENTS.local.md`), not a dedicated state file.
 
@@ -58,7 +58,7 @@ Setup state is written into `<!-- keep-the-why:config -->` / `<!-- keep-the-why:
 ## Setup state splits across a project block and a personal block
 
 **Status:** active
-**Confirmed**
+**Evidence:** confirmed
 
 Where `context/` lives and whether the project has been initialized are in the committed `AGENTS.md` config block. Autostart preference, and the update-check/consistency-check intervals and their last-run timestamps, are in the personal, uncommitted `AGENTS.local.md` block instead. A project can be `init: complete` while a specific developer still gets asked their own preferences, if they don't have an `AGENTS.local.md` yet.
 
@@ -69,7 +69,7 @@ Where `context/` lives and whether the project has been initialized are in the c
 ## Update-check failures get surfaced once, not swallowed indefinitely
 
 **Status:** active
-**Confirmed**
+**Evidence:** confirmed
 
 If the update check can't run (no web access this session), the first failure is reported and the user is asked whether to keep retrying each session or turn the check off. Subsequent identical failures don't re-ask.
 

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -1,0 +1,1 @@
+{% include-markdown "../skills/keep-the-why/references/migrations.md" %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
   - Why I built this: why.md
   - Reference:
       - Setup: setup.md
+      - Migrations: migrations.md
       - Methodology: methodology.md
       - Repository structure: repository-structure.md
       - Continuous capture: continuous-capture.md

--- a/skills/keep-the-why/SKILL.md
+++ b/skills/keep-the-why/SKILL.md
@@ -24,12 +24,12 @@ Four modes, all part of the same job:
 ## Core rules
 
 1. **Never invent rationale.** If it can't be confirmed or reasonably inferred, say so — ask a focused question or mark it unknown, don't fill the gap with something plausible-sounding.
-2. Distinguish **confirmed** (stated by a maintainer or backed by authoritative evidence) from **inferred** (reasonably derived, not confirmed) from **unknown** (evidence doesn't support an answer). Classify at the level of the entry, not every sentence — split out a separate label only when part of an entry genuinely has different evidence than the rest.
+2. Classify every entry's **Evidence**: **confirmed** (stated by a maintainer or backed by authoritative evidence), **inferred** (reasonably derived, not confirmed), or **unknown** (evidence doesn't support an answer). This is a separate axis from Status (rule 7) — a superseded decision can still have been confirmed when it was current; being outdated and being well-evidenced are different questions. Classify at the level of the entry, not every sentence — split out a separate label only when part of an entry genuinely has different evidence than the rest. When a confirmed claim is worth tracing or could plausibly be checked against other evidence, add **Source** (who or what it came from — a maintainer interview, a commit, an issue) and **Verification**: corroborated, uncorroborated, or contradicted. A `contradicted` verification must say what contradicts it and why — the label alone isn't an explanation.
 3. Preserve the project's existing terminology and documentation conventions; don't impose a foreign vocabulary.
 4. Update existing topic files instead of creating duplicate or near-duplicate documents.
 5. Organize knowledge by *topic* (`auth.md`, `sync.md`), not mechanically by source file or by commit.
 6. **Treat a decision as having two halves: what was chosen, and what wasn't.** Actively look for the rejected alternative(s) and why they lost — don't just wait for one to surface. If genuinely nothing else was considered, say so explicitly. This doesn't mean manufacturing a comparison against something that was never a real candidate — a rejected alternative worth recording was genuinely in contention, not an earlier mistake corrected before it was ever a real fork. A project's current state can be its own starting point; it doesn't need a history of what it isn't to justify what it is.
-7. Mark superseded knowledge explicitly (e.g. `> Superseded 2026-03: see below`) instead of silently deleting project history.
+7. Track every entry's **Status**, separately from its Evidence: **active**, **superseded**, **open**, or **needs-review**. Mark superseded knowledge explicitly (e.g. `> Superseded 2026-03: see below`) instead of silently deleting project history — status changes as a project evolves, but the evidence for what was true at the time usually doesn't need to change with it.
 8. Keep `context/index.md` lean — detailed reasoning lives in topic files, loaded only when relevant. When a topic file grows large enough to be unwieldy, propose a split rather than letting it grow indefinitely.
 9. **Privacy and relevance extend beyond obvious secrets.** Don't store credentials, personal information, or private local details in anything meant to be committed — and don't record session narrative (who said what, how a conversation went) either. Never cite a person's other, unrelated projects or private matters as the source of a decision, even if that's literally how it happened — restate the reasoning on its own terms. If an entry only makes sense with that private context attached, make the entry itself more self-contained.
 10. Don't commit or publish documentation changes unless the user explicitly asks for it.
@@ -46,6 +46,8 @@ Before anything else, check for two independent config blocks: a project one (`A
 
 If the timer check finds the update-check interval elapsed: compare the installed `version` (frontmatter above) against the latest release at `repository` (frontmatter above) — don't rely on `references/setup.md` alone for this, the source of truth is right here so the check still works even if that reference file was never loaded. If the check can't run (no web access), don't fail silently forever — say so once and ask whether to keep retrying or turn it off.
 
+Also compare the project config's `context-schema` against the installed `version`. If `context-schema` is behind, check `references/migrations.md` for what changed in between and, if anything applies to existing `context/` entries, discuss with the user whether to migrate now or next session — don't migrate silently, and don't forget to ask again later if deferred. Once caught up (or confirmed nothing applied), advance `context-schema` to match.
+
 ### 1. Inspect
 
 Read `AGENTS.md` and existing project documentation before doing anything else. Adapt to conventions already in use — don't create a parallel structure next to one that already works (see `references/repository-structure.md`).
@@ -56,7 +58,7 @@ Look for signs that rationale is missing: code that looks surprising, redundant,
 
 ### 3. Classify the evidence
 
-For every candidate: confirmed, inferred, unknown, or superseded (rule 2). Not optional — it's what keeps the output trustworthy.
+For every candidate, two separate calls: Evidence (confirmed, inferred, or unknown — rule 2) and Status (active, superseded, open, or needs-review — rule 7). Not optional — it's what keeps the output trustworthy.
 
 ### 4. Ask, or listen
 
@@ -112,6 +114,7 @@ Full rationale: `references/methodology.md`. Concrete layout: `references/reposi
 Load these only when the situation calls for them — keep this file lean:
 
 - `references/setup.md` — first activation in a project: detecting whether it's already set up, running the init wizard, and the per-session timer checks afterward.
+- `references/migrations.md` — when `context-schema` is behind the installed version: what changed and how to bring existing `context/` entries up to date.
 - `references/methodology.md` — reasoning behind the docs/context split and the index+topic-files structure.
 - `references/repository-structure.md` — before introducing or restructuring a documentation layout.
 - `references/continuous-capture.md` — deciding what's worth capturing during normal development.

--- a/skills/keep-the-why/evals/evals.json
+++ b/skills/keep-the-why/evals/evals.json
@@ -56,8 +56,8 @@
   },
   {
     "id": "negative-stale-confirmed-decision",
-    "prompt": "context/sync.md says (Confirmed, 2024-01, Revisit when: the sync protocol changes) that snapshots must load before buffered events. The sync protocol was rewritten last month.",
-    "expected_behavior": "Recognizes the Revisit when condition has been triggered and flags the entry as needing re-verification rather than treating it as still confirmed. Does not silently carry the old rationale forward or silently rewrite it without checking whether it still applies."
+    "prompt": "context/sync.md says (Status: active, Evidence: confirmed, Source: maintainer interview 2024-01, Revisit when: the sync protocol changes) that snapshots must load before buffered events. The sync protocol was rewritten last month.",
+    "expected_behavior": "Recognizes the Revisit when condition has been triggered and flags the entry as needing re-verification rather than treating it as still confirmed. Does not silently carry the old rationale forward or silently rewrite it without checking whether it still applies. Status and Evidence are separate fields - re-verification affects whether the Evidence still holds, not necessarily the Status by itself."
   },
   {
     "id": "init-wizard-first-activation",
@@ -93,5 +93,25 @@
     "id": "agents-local-gitignore-not-covered",
     "prompt": "Running the personal preferences wizard for the first time in a project. AGENTS.local.md doesn't exist yet, and .gitignore has no entry for it.",
     "expected_behavior": "Before creating AGENTS.local.md, checks whether .gitignore excludes it. Since it doesn't, adds an AGENTS.local.md entry to .gitignore (creating .gitignore if it doesn't exist) before creating the file - not after, and not skipped. Personal preferences described as 'not committed' should actually be prevented from being committed, not just documented as such."
+  },
+  {
+    "id": "context-schema-behind-offers-migration",
+    "prompt": "The project's AGENTS.md config block shows context-schema: 0.2.0. The installed skill version is 0.3.0, which changed the context/ entry format (Status split from Evidence).",
+    "expected_behavior": "Notices context-schema is behind the installed version during the setup check, checks references/migrations.md, finds the 0.3.0 entry applies, and explains what changed before asking whether to migrate existing context/ entries now or next session - does not migrate silently, and does not skip the check just because the project's project-level init is already complete."
+  },
+  {
+    "id": "context-schema-missing-backfilled",
+    "prompt": "The project's AGENTS.md config block has no context-schema field at all - it was set up before this field existed.",
+    "expected_behavior": "Backfills context-schema to 0.2.0 (the last version before any context/ format change) rather than treating the missing field as an error or leaving it unset, then proceeds with the normal behind/current comparison against the installed version."
+  },
+  {
+    "id": "migration-insufficient-info-marked-unknown",
+    "prompt": "Migrating an old context/ entry that only says 'Superseded' with no separate confirmed/inferred/unknown marker ever recorded, to the new Status/Evidence format.",
+    "expected_behavior": "Sets Status: superseded (that part is clear from the original marker). Does not guess an Evidence value that was never actually recorded - sets Evidence: unknown and flags the entry for review instead of inventing a plausible-sounding confirmed or inferred label."
+  },
+  {
+    "id": "verification-contradicted-needs-explanation",
+    "prompt": "Recording a Verification: contradicted for a context/ entry.",
+    "expected_behavior": "Never records 'Verification: contradicted' as a bare label. Always includes what specifically contradicts the claim and why (e.g. a conflicting source, a code inspection result) in the same entry - the label alone doesn't explain anything and isn't useful to the next reader."
   }
 ]

--- a/skills/keep-the-why/examples/continuous-development.md
+++ b/skills/keep-the-why/examples/continuous-development.md
@@ -15,7 +15,8 @@ Mid-session, working on a Python service. The retry logic for an external API ca
     ## Retry mechanism (updated 2026-07-10)
 
     **Status:** active
-    **Confirmed** (stated directly by the user during the change)
+    **Evidence:** confirmed
+    **Source:** stated directly by the user during the change
 
     Order submission retries now use idempotency keys instead of blind
     retry-on-timeout.

--- a/skills/keep-the-why/examples/legacy-project.md
+++ b/skills/keep-the-why/examples/legacy-project.md
@@ -18,8 +18,9 @@ Does not immediately produce a confident-sounding architecture overview covering
     ## Session handling
 
     **Status:** active
-    **Inferred** (from code structure and a 2019 commit message referencing
-    "the mobile client issue" — original ticket not accessible)
+    **Evidence:** inferred
+    **Source:** code structure and a 2019 commit message referencing
+    "the mobile client issue" — original ticket not accessible
 
     Sessions appear to be validated twice: once at the gateway, once in
     the service itself. This looks redundant.

--- a/skills/keep-the-why/references/migrations.md
+++ b/skills/keep-the-why/references/migrations.md
@@ -1,0 +1,39 @@
+# Migrations
+
+What changed in each version that affects the *format* of existing `context/` entries, and how to bring them up to date. Not every release needs an entry here — most changes affect the skill's own behavior, not what's already written in a project's `context/`. See `setup.md` for how and when this file gets consulted.
+
+Entries below assume 0.2.0 as the starting point — nothing before it tracked a `context-schema` at all, and 0.2.0 itself introduced no `context/` entry format change.
+
+## 0.3.0 — Evidence split from Status
+
+**What changed:** `context/` entries previously classified evidence as one of confirmed, inferred, unknown, *or* superseded — treating "superseded" as if it were a fourth evidence level. It isn't: whether a decision is still current (Status) and how well it's evidenced (Evidence) are independent questions. A superseded decision can have been thoroughly confirmed when it was still active. Also added: an optional Source/Verification pair for confirmed entries whose claim is worth tracing or could be checked against other evidence.
+
+**New fields (see `SKILL.md` rules 2 and 7):**
+
+- **Status:** active | superseded | open | needs-review
+- **Evidence:** confirmed | inferred | unknown *(unchanged values, now its own field)*
+- **Source** and **Verification** (corroborated | uncorroborated | contradicted) — optional, only add where there's a real answer, per the proportionality principle. A `contradicted` verification must explain what contradicts it.
+
+**Migrating an existing entry:**
+
+1. If it currently has a single `Confirmed` / `Inferred` / `Unknown` marker with no mention of being superseded → that value becomes **Evidence**. Add **Status: active**.
+2. If it currently says `Superseded` (with or without a separate confirmed/inferred/unknown marker) → **Status: superseded**. If an evidence value was recorded alongside it, keep it as **Evidence**. If not, set **Evidence: unknown** and flag the entry for review — don't guess what the original evidence level was.
+3. Don't add **Source**/**Verification** retroactively just because the fields now exist — only add them where there's a genuine answer (rule 12's proportionality gate applies here too).
+4. `Superseded` annotations already in prose (e.g. `> Superseded 2026-03: see below`) don't need to be rewritten — that's still how supersession gets recorded; **Status: superseded** is the structured counterpart for anything that also carries an Evidence/Status header.
+
+**Example — before:**
+
+```markdown
+**Status:** active
+**Confirmed** (2026-03-14, via maintainer interview)
+```
+
+**Example — after:**
+
+```markdown
+**Status:** active
+**Evidence:** confirmed
+**Source:** maintainer interview, 2026-03-14
+```
+
+(Verification omitted here — nothing to corroborate or contradict this against; adding it would be filler, not signal.)

--- a/skills/keep-the-why/references/repository-structure.md
+++ b/skills/keep-the-why/references/repository-structure.md
@@ -99,8 +99,8 @@ Keep entries to one line each. This file exists so an agent can decide what to l
 ## Snapshot-before-buffer ordering
 
 **Status:** active
-**Confirmed** (2026-03-14, via maintainer interview)
-**Evidence:** incident postmortem 2025-11, `incidents.md`
+**Evidence:** confirmed
+**Source:** maintainer interview, 2026-03-14; incident postmortem 2025-11, `incidents.md`
 **Revisit when:** the sync protocol or snapshot mechanism changes
 
 The sync step always waits for a full snapshot before applying any
@@ -118,7 +118,17 @@ right and the incident showed it wasn't actually needed if ordering
 was enforced instead.
 ```
 
-Not every entry needs every field, but treat the decision as a fork, not a single point: what was chosen, and what specifically was rejected and why. The status/confirmed-or-inferred markers and the rejected-alternative are the two things worth keeping even in a minimal entry — the rejected alternative especially, since "we chose X" without "we didn't choose Y, because Z" is usually the less useful half of the story. It's what prevents the next person (or agent) from re-deriving or re-breaking the same thing (see Core rule 6 in `SKILL.md`).
+Not every entry needs every field, but treat the decision as a fork, not a single point: what was chosen, and what specifically was rejected and why. Status, Evidence, and the rejected-alternative are the things worth keeping even in a minimal entry — the rejected alternative especially, since "we chose X" without "we didn't choose Y, because Z" is usually the less useful half of the story. It's what prevents the next person (or agent) from re-deriving or re-breaking the same thing (see Core rule 6 in `SKILL.md`). Status and Evidence are independent (Core rules 2 and 7) — a `superseded` entry can still show `confirmed` for what was true while it was active.
+
+**Verification**, when there's something concrete to check a confirmed claim against, goes the same place Source does:
+
+```markdown
+**Evidence:** confirmed
+**Source:** maintainer interview, 2026-03-14
+**Verification:** contradicted — the interview said retries max out at 3;
+the actual retry loop in `client.py` caps at 5. Flagged for re-confirmation,
+not silently corrected either way.
+```
 
 **Evidence** and **Revisit when** are worth adding once a decision has a concrete trigger for going stale (a dependency, a protocol version, an external constraint that could change). They're not mandatory fields for everything — per the proportionality gate in `SKILL.md`, add them when there's a real answer, not as filler. This is also the mechanism for the "rationale decays" risk named in the README: a **Revisit when** condition gives a future reader (or agent) something concrete to check, rather than just hoping someone remembers to re-verify.
 

--- a/skills/keep-the-why/references/setup.md
+++ b/skills/keep-the-why/references/setup.md
@@ -12,8 +12,11 @@ Setup state splits across two files, matching the existing `AGENTS.md`/`AGENTS.l
 <!-- keep-the-why:config -->
 - context: `context/`
 - init: complete
+- context-schema: 0.2.0
 <!-- /keep-the-why:config -->
 ```
+
+`context-schema` tracks which version's `context/` entry format is in use — separate from the installed skill `version`, because not every skill release changes the format (see "Context schema and migrations" below).
 
 **Personal config**, in `AGENTS.local.md`, not committed, one per developer:
 
@@ -39,7 +42,7 @@ Where the why-knowledge lives and whether the project has been set up at all are
 
 ## Project init wizard (once per project)
 
-1. Create or update the entry-point file with the project config block.
+1. Create or update the entry-point file with the project config block, including `context-schema` set to the currently installed skill `version` (frontmatter in `SKILL.md`) — a freshly created or newly adopted `context/` is up to date with the current format by definition, nothing to migrate.
 2. Ask, in one pass:
    - Where should the why-knowledge live? Default `context/`; anything else is fine.
    - How do you want to start: capture from now on only, work through existing history now (retrospective recovery), sit down for an interview now, or some combination?
@@ -89,3 +92,16 @@ If checking isn't possible (no web access this session): don't fail silently for
 **Consistency check.** If `consistency-check` is enabled and the interval has elapsed: look for entries whose `Revisit when` condition (see `repository-structure.md`) has actually been triggered — not just entries that are merely old. Age alone isn't a defect; an untriggered old entry is still accurate. Scope the check to what `context/index.md` already summarizes rather than opening every topic file — the index exists precisely so this kind of check stays cheap. If something's genuinely triggered, surface it and ask whether to address it now. Update `last` regardless of outcome.
 
 Keep both checks quiet when there's nothing to report. The point is catching real drift, not adding a second source of noise on top of the problem this skill exists to solve.
+
+## Context schema and migrations (every session, not interval-gated)
+
+Unlike the two timers above, this isn't opportunistic on an elapsed interval — it's a plain version comparison, checked every session:
+
+1. Compare the project config's `context-schema` against the installed skill `version`.
+2. **Missing entirely** (a project set up before this field existed): backfill it to `0.2.0` — the last version before any `context/` entry format changed — then continue to step 3 as normal.
+3. **`context-schema` equal to or ahead of `version`** → nothing to do.
+4. **`context-schema` behind `version`** → check `references/migrations.md` for entries between the two. If none apply to existing `context/` content, just advance `context-schema` to match `version`. If some do apply: explain what changed and what migrating would involve, then ask whether to do it now or next session.
+   - **Now** → apply the migration steps from `migrations.md` to the affected `context/` entries, then advance `context-schema` to `version`.
+   - **Later** → leave `context-schema` as is and ask again next session; don't silently drop the question, and don't nag about it more than once per session either.
+
+When a migration touches an existing entry that doesn't have enough information to fill in a new field confidently (e.g. an old entry marked only "Superseded" with no separate Evidence value recorded) — don't guess. Set the new field to `unknown` and flag the entry for review, consistent with rule 1.


### PR DESCRIPTION
Implements the two points we deliberately deferred from the last review round (5 and 6), plus the rollout mechanism we discussed to go with them.

## What changed

- **Status split from Evidence** (point 5): `context/` entries previously listed `confirmed, inferred, unknown, or superseded` as if all four were the same kind of thing. They're not - Status (active/superseded/open/needs-review) and Evidence (confirmed/inferred/unknown) are independent axes. A superseded decision can still have been confirmed when it was current.
- **Source/Verification for confirmed entries** (point 6): optional fields for confirmed claims worth tracing or checking against other evidence. `Verification: contradicted` must explain what contradicts it - never a bare label.
- **context-schema + migrations.md**: tracks which version's `context/` format is in use, separate from the installed skill version (not every release changes the format). When behind, the setup check looks up `references/migrations.md` and discusses migrating with the user - now or next session, never silently.

## Real bug found while migrating our own repo

Migrated `context/repo-conventions.md` (7 entries) to the new format and hit a genuine naming collision: the existing topic-file template already used `Evidence:` to mean "supporting evidence / related files," which now collides with the new Evidence axis. Renamed that field to `Source` - which is what it actually was.

## Test plan
- [x] `mkdocs build --strict` passes
- [x] `evals.json` validates (23 cases, 5 new)
- [x] Migrated this repo's own `context/` entries as a live test of the new format and the migration reasoning