### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,23 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-23
+
 ### Added
 
 - `context/` entries now track **Status** (active, superseded, open, needs-review) separately from **Evidence** (confirmed, inferred, unknown) — previously "superseded" was mixed into the evidence classification as if it were a fourth confidence level, when it's really a different question (is this still current, vs. how well is it backed).
 - Optional **Source** and **Verification** fields for confirmed entries whose claim is worth tracing or could be checked against other evidence. A `contradicted` verification must explain what contradicts it, not just carry the label.
 - `context-schema` field in the project config block, tracking which version's `context/` entry format is in use — separate from the installed skill version, since not every release changes the format.
 - `references/migrations.md`: what changed and how to update existing `context/` entries, checked automatically when `context-schema` falls behind the installed version.
+- A developer can personally decline being asked about one specific `context-schema` migration (`migration-prompt: <version> declined` in `AGENTS.local.md`) without affecting the project or any other developer.
+- Continuous capture now includes the abandoned change as its own signal: starting to modify or remove something, then stopping after discovering why it shouldn't be touched — reasoning that would otherwise leave no trace, since nothing gets committed.
 - This `CHANGELOG.md` — the README already promised one in its "Where this fits" table; it just didn't exist.
+- `CONTRIBUTING.md` gained a pre-PR checklist (which files to check for staleness on a change) and a release checklist.
+
+### Changed
+
+- The proportionality gate (rule 12) sharpened with a concrete example pair ("prevents a breaking API change" earns an entry, "formats the code more nicely" doesn't) and now explicitly allows a quick yes/no question when it's genuinely unclear whether something is worth documenting — asking isn't a violation of staying low-effort.
+- README and `llms.txt` now state directly that a `context/` update ships in the same commit or PR as the code it explains — reviewed and versioned the same way, no separate system to trust or keep in sync.
 
 ## [0.2.0] - 2026-07-21
 
@@ -54,6 +64,7 @@ Initial release.
 - Logo, wordmark, and favicon.
 - `context/repo-conventions.md`, dogfooding the skill on its own repository from day one.
 
-[Unreleased]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/oliver-zehentleitner/keep-the-why/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,20 +27,22 @@ For any change to the skill's rules, workflow, or reference docs, check whether 
 
 1. `skills/keep-the-why/SKILL.md` — Core Rules, Workflow, Reference file list
 2. The affected `skills/keep-the-why/references/*.md` files
-3. `skills/keep-the-why/evals/evals.json` — does the change need a new case, or invalidate an existing one? Validate with `python3 -c "import json; print(len(json.load(open('skills/keep-the-why/evals/evals.json'))))"`
-4. `docs/*.md` — include-wrapper pages and `mkdocs.yml` nav, if a reference file is new
-5. `README.md` — if the change affects something described or promised there
-6. `llms.txt` — if the change affects the Core Concept or payoff, not just implementation detail
-7. `CHANGELOG.md` — add a line under `[Unreleased]`
-8. `context/repo-conventions.md` — if the change itself was a non-obvious decision worth dogfooding
-9. `mkdocs build --strict` before committing — catches broken links and nav mistakes
+3. **`skills/keep-the-why/references/migrations.md`** — if the change alters the *format* of existing `context/` entries (new/renamed/restructured fields), add a migration entry in the same PR, not later at release time. Most changes don't touch the format at all; skip this when they don't.
+4. `skills/keep-the-why/evals/evals.json` — does the change need a new case, or invalidate an existing one? Validate with `python3 -c "import json; print(len(json.load(open('skills/keep-the-why/evals/evals.json'))))"`
+5. `docs/*.md` — include-wrapper pages and `mkdocs.yml` nav, if a reference file is new
+6. `README.md` — if the change affects something described or promised there
+7. `llms.txt` — if the change affects the Core Concept or payoff, not just implementation detail
+8. `CHANGELOG.md` — add a line under `[Unreleased]`
+9. `context/repo-conventions.md` — if the change itself was a non-obvious decision worth dogfooding
+10. `mkdocs build --strict` before committing — catches broken links and nav mistakes
 
 ## Release checklist (maintainer)
 
 1. Bump `version` in `skills/keep-the-why/SKILL.md` frontmatter
 2. Update the `Version:` line in `llms.txt` to match
 3. In `CHANGELOG.md`, rename `[Unreleased]` to `[x.y.z] - YYYY-MM-DD` and add a fresh empty `[Unreleased]` above it
-4. Tag `vX.Y.Z` and push the tag — the `GH Release` workflow creates the release and moves the `latest` tag automatically
-5. If the release changed the `context/` entry format: bump this repo's own `context-schema` in `AGENTS.md` and add an entry to `skills/keep-the-why/references/migrations.md` if existing entries need migrating
+4. **Verify `skills/keep-the-why/references/migrations.md` already covers every `context/` format change since the last release** — this should already be true if step 3 of the pre-PR checklist was followed each time, but check before tagging, not after. This is the one that must never be found out of sync retroactively.
+5. If this repo's own `context-schema` (in `AGENTS.md`) is behind the version just released and something in `migrations.md` applies to `context/repo-conventions.md`: migrate it now, dogfooding the same process a user would go through
+6. Tag `vX.Y.Z` and push the tag — the `GH Release` workflow creates the release and moves the `latest` tag automatically
 
 Oliver runs this personally, or asks the assisting agent to run it on his explicit request for a specific version — never triggered on its own initiative just because a PR merged.

--- a/llms.txt
+++ b/llms.txt
@@ -18,7 +18,7 @@ Because it's just Markdown in the repo, a `context/` update ships in the same co
 the code change it explains — reviewed the same way, versioned the same way, no separate
 system to trust or keep in sync.
 
-Version: 0.2.0.
+Version: 0.3.0.
 
 ## Authorship & License
 

--- a/skills/keep-the-why/SKILL.md
+++ b/skills/keep-the-why/SKILL.md
@@ -2,7 +2,7 @@
 name: keep-the-why
 description: Preserves or recovers the reasoning behind a codebase - architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain. Use when implementing or reviewing a non-trivial change involving a design decision, workaround, incident fix, operational constraint, rejected alternative, or changed assumption; when documenting an existing or legacy codebase; during onboarding or a maintainer handover; or when interviewing a developer before their knowledge is lost (e.g. before they leave or retire). Identifies what the code cannot explain, asks focused questions instead of generic ones, and maintains concise, topic-based, version-controlled documentation readable by both humans and AI agents.
 license: MIT
-version: 0.2.0
+version: 0.3.0
 repository: https://github.com/oliver-zehentleitner/keep-the-why
 ---
 


### PR DESCRIPTION
## Summary
- Version bump: `SKILL.md` and `llms.txt` 0.2.0 → 0.3.0
- CHANGELOG.md: `[Unreleased]` → `[0.3.0] - 2026-07-23`, backfilled with entries missing since the last sync (abandoned-change capture, migration-prompt personal decline, quick-question clarification to rule 12, git-native highlight, CONTRIBUTING.md checklists), fresh empty `[Unreleased]` above

`context-schema` in this repo's own `AGENTS.md` is already `0.3.0` (set ahead of time) — now equal to the installed version, nothing further to do there.

Once merged: tag `v0.3.0` and push the tag to trigger the `GH Release` workflow (creates the release, moves `latest`).

## Test plan
- [x] `mkdocs build --strict` passes
- [x] evals.json valid (28 cases)