### PR TITLE
Sync docs before 0.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,30 +4,26 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
-### Fixed
-
-- The consistency check's `Revisit when` search was hardcoded to `context/*.md` — a leftover from the previous fix that didn't account for a project choosing a different why-knowledge location or splitting it into subsystem subdirectories. Now greps recursively under whatever the project config's `context:` value actually is.
-- This repo's own `context-schema` was left at `0.3.0` after the `0.3.1` release, even though nothing in `migrations.md` applied to that gap — the release checklist only mentioned advancing `context-schema` when a migration was needed, not also when nothing was. Fixed the checklist wording and caught this repo's own `context-schema` up to `0.3.1` (see `context/repo-conventions.md`).
-- `docs/installation.md` still referenced the pre-0.3.1 top-level `version:` frontmatter field instead of `metadata.version`.
-
-### Added
-
-- `docs/installation.md` and `llms.txt` now state explicitly that updating the skill itself (new `metadata.version`, frontmatter shape changes) is independent of `context-schema`/migrations — a release only asks something of a project when the `context/` entry format actually changes.
-- New eval case covering the fixed consistency-check path bug: a project with `context:` pointing somewhere other than the default `context/`.
-
 ## [0.3.1] - 2026-07-23
 
 ### Fixed
 
 - `version` and `repository` moved from top-level frontmatter fields into `metadata:` (`metadata.version`, `metadata.repository`) in `SKILL.md` — the Agent Skills spec documents `metadata` as the place for custom properties; top-level custom fields aren't part of the spec.
-- The consistency check couldn't actually find triggered `Revisit when` conditions — it was scoped to `context/index.md`, which by design only holds one-line summaries, not the conditions themselves. Now greps `context/*.md` directly for `**Revisit when:**` lines and only opens files that match.
+- The consistency check couldn't actually find triggered `Revisit when` conditions — it was scoped to `context/index.md`, which by design only holds one-line summaries, not the conditions themselves. Rescoped to grep recursively under the project config's `context:` location for `**Revisit when:**` lines and only open files that match, instead of a hardcoded `context/*.md`.
 - A project whose `context-schema` is *ahead* of the installed skill's version was treated the same as "up to date." Now surfaced explicitly (older skill on a newer project) with a recommendation to update, instead of silently proceeding as if there were nothing to check.
 - `repository-structure.md` said "Evidence and Revisit when are not mandatory fields" — contradicted Core rule 2 (Evidence is mandatory for every entry) and the file's own earlier statement. Should have said Verification, not Evidence; fixed, and Core rule 7 now states explicitly that a triggered Revisit when sets Status to needs-review without resetting Evidence.
 - **Source** was described as tied to confirmed claims only (Core rule 2), but the legacy-project example used it with `Evidence: inferred`. Source is now documented as useful at any Evidence level; Verification remains the field for checking a claim against other evidence.
 - The project init wizard's normative steps had the entry-point config block written before the setup questions were asked — reversed from the worked example, which asks first. Reordered to match.
 - Update-check version comparison now explicitly calls for stripping a leading `v` and comparing semantically (`0.9.0` < `0.10.0`), not as strings.
 - `on-failure: retry-quietly` is cleared after a successful update check instead of persisting indefinitely, so a later unrelated failure asks again rather than staying silently suppressed.
+- This repo's own `context-schema` was left at `0.3.0` even though nothing in `migrations.md` applied to the gap from `0.3.0` — the release checklist only mentioned advancing `context-schema` when a migration was needed, not also when nothing was. Fixed the checklist wording and caught this repo's own `context-schema` up to `0.3.1` (see `context/repo-conventions.md`).
+- `docs/installation.md` referenced the pre-restructuring top-level `version:` frontmatter field instead of `metadata.version`.
 - Dogfooding fixes in this repo's own `context/`: `repo-conventions.md` had a Status value outside the defined enum, and referenced the pre-rename "Autostart preference" instead of `capture-mode`; `context/index.md` undersold `repo-conventions.md` as "operational notes" when it documents process and tooling decisions.
+
+### Added
+
+- `docs/installation.md` and `llms.txt` now state explicitly that updating the skill itself (new `metadata.version`, frontmatter shape changes) is independent of `context-schema`/migrations — a release only asks something of a project when the `context/` entry format actually changes.
+- New eval cases: `context-schema` ahead of the installed skill, semver-aware update-check comparison, and the consistency check respecting a non-default configured `context:` path.
 
 ## [0.3.0] - 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ All notable changes to this project are documented here. Format follows [Keep a 
 - This repo's own `context-schema` was left at `0.3.0` after the `0.3.1` release, even though nothing in `migrations.md` applied to that gap — the release checklist only mentioned advancing `context-schema` when a migration was needed, not also when nothing was. Fixed the checklist wording and caught this repo's own `context-schema` up to `0.3.1` (see `context/repo-conventions.md`).
 - `docs/installation.md` still referenced the pre-0.3.1 top-level `version:` frontmatter field instead of `metadata.version`.
 
+### Added
+
+- `docs/installation.md` and `llms.txt` now state explicitly that updating the skill itself (new `metadata.version`, frontmatter shape changes) is independent of `context-schema`/migrations — a release only asks something of a project when the `context/` entry format actually changes.
+- New eval case covering the fixed consistency-check path bug: a project with `context:` pointing somewhere other than the default `context/`.
+
 ## [0.3.1] - 2026-07-23
 
 ### Fixed

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -88,6 +88,8 @@ Re-run whichever install command you used the first time. If you pinned to `late
 
 Start a new session afterward, same as a fresh install — a session already in progress keeps whatever `SKILL.md` it already loaded and won't pick up the update mid-conversation. To confirm the update actually took, check the `metadata.version` field in your installed `skills/keep-the-why/SKILL.md`, or ask your agent to report it.
 
+This is separate from whether your project's own `context/` needs anything done to it. Updating the skill replaces its own files wholesale — nothing to do on your side just because a release changed how `SKILL.md` describes itself internally. A release only asks something of your project when it changes the *format* of `context/` entries, tracked via `context-schema` in your `AGENTS.md` — see `setup.md` and `migrations.md`. The two are independent: a release can update the skill's own frontmatter shape (as `0.3.1` did) without touching `context-schema` at all.
+
 ## Verifying it loaded
 
 Start a session in a project where the skill is installed and ask something that should trigger it, e.g. "why does this workaround exist, and can you document it?" If it doesn't seem to activate, double-check that `SKILL.md` sits directly inside the skill folder (not nested deeper) and that the folder name matches `name: keep-the-why` in the frontmatter exactly.

--- a/llms.txt
+++ b/llms.txt
@@ -81,9 +81,12 @@ First activation in a project runs a one-time setup: a project wizard (where `co
 starting mode, README badge) and a separate personal wizard (proactive vs. explicit-only
 capture, update-check/consistency-check intervals) — see https://keepthewhy.com/setup/. When a
 later skill update changes the `context/` entry format, a `context-schema` version tracked in
-the project's config is compared against the installed skill version and, if behind, offers a
-migration — see https://keepthewhy.com/migrations/. A developer can personally decline being
-asked about one specific migration without affecting the project or anyone else on it.
+the project's config is compared against the installed skill's `metadata.version` and, if
+behind, offers a migration — see https://keepthewhy.com/migrations/. A developer can personally
+decline being asked about one specific migration without affecting the project or anyone else
+on it. Updating the skill itself (new `metadata.version`, new frontmatter shape, etc.) is
+independent of this — it only asks something of a project when the `context/` entry format
+actually changes.
 
 Produces, inside the project using the skill:
 - `AGENTS.md` — lean entry point, pointers only, plus a small machine-readable config block

--- a/skills/keep-the-why/evals/evals.json
+++ b/skills/keep-the-why/evals/evals.json
@@ -148,5 +148,10 @@
     "id": "update-check-version-comparison-is-semantic",
     "prompt": "The installed skill's metadata.version is '0.9.0'. The update check's API response has tag_name 'v0.10.0'.",
     "expected_behavior": "Strips the leading 'v' from the tag and compares the versions semantically, recognizing 0.10.0 is newer than 0.9.0 - not a naive string or floating-point comparison that would wrongly treat 0.9.0 as larger than 0.10.0, and not treating 'v0.10.0' != '0.9.0' as a meaningless mismatch."
+  },
+  {
+    "id": "consistency-check-respects-configured-context-path",
+    "prompt": "The project config block has 'context: `docs/why/`' (not the default `context/`). The consistency-check interval has elapsed.",
+    "expected_behavior": "Scopes the Revisit when search to docs/why/ (the configured location), not a hardcoded context/ directory that doesn't exist in this project. Searches recursively in case the project has split it into subsystem subdirectories."
   }
 ]


### PR DESCRIPTION
## Summary
- `docs/installation.md` + `llms.txt`: clarify that updating the skill itself is independent of `context-schema`/migrations — answers the question of whether an existing project needs to touch its `AGENTS.md` because of the 0.3.1 frontmatter restructuring (it doesn't).
- New eval case for the consistency-check configured-path fix (PR #52), which shipped without one.
- **Correction:** v0.3.1 was never actually tagged/released — only the version numbers in files were bumped ahead of time. `main` is still on the v0.3.0 release. Folded CHANGELOG's `[Unreleased]` into `[0.3.1]`, since everything since v0.3.0 (eight review fixes, round 2, this sync) is one release.

Once merged: tag `v0.3.1` and push the tag. No further version bump needed, files are already at 0.3.1.

## Test plan
- [x] `mkdocs build --strict` passes
- [x] evals.json valid (31 cases)