### PR TITLE
Sync docs for the two workflow fixes, clarify context-schema wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+### Fixed
+
+- `release.yml`'s `checkout` didn't pin to the `workflow_dispatch` tag input, so a manual dispatch could package whatever commit the workflow happened to run from instead of the requested tag. Now pins `ref:` explicitly, and "Move latest tag" moves it to that same tag rather than an implicit `HEAD`.
+- `context-schema`'s definition in `setup.md` read like an independent format-version number, which is how an external review initially (mis)understood it. Reworded: it's the latest skill version this project's `context/` has been checked and migrated against, not a second versioning axis.
+
+### Added
+
+- `.github/workflows/validate-skill.yml`: validates `SKILL.md` against the Agent Skills spec (`skills-ref validate`) and that `evals.json` is well-formed JSON, on every push to `main` and every PR.
+
 ## [0.3.1] - 2026-07-23
 
 ### Fixed

--- a/context/repo-conventions.md
+++ b/context/repo-conventions.md
@@ -88,3 +88,14 @@ Every release advances this repo's own `context-schema` (in this file's config b
 **Reason:** during the 0.3.1 release, `context-schema` was left at `0.3.0` because nothing in `migrations.md` applied to the 0.3.0→0.3.1 gap — but "nothing to migrate" and "don't advance the number" are different things. Leaving it behind made a later external review flag it as if the skill's own schema-comparison logic were broken, when the actual bug was simpler: the release process itself skipped the catch-up step that `setup.md`'s existing behind-case logic already calls for.
 
 **Rejected alternative:** a separate `metadata.context-schema` field in `SKILL.md`, decoupled from `metadata.version`, so schema and release versioning could drift independently. Rejected — the existing single-version-axis model (check for applicable migrations, advance the number whether or not anything applied) already does everything a second version field would, without a second number to keep in sync.
+
+## `release.yml`'s checkout pins the actual release tag, not the workflow's trigger ref
+
+**Status:** active
+**Evidence:** confirmed
+
+The `GH Release` workflow's `checkout` step explicitly sets `ref: ${{ github.event.inputs.tag || github.ref }}`, and "Move latest tag" moves `latest` to that same resolved tag rather than an implicit `HEAD`.
+
+**Reason:** `actions/checkout@v4` without an explicit `ref` checks out whatever triggered the workflow. For the normal tag-push trigger that's already correct (the trigger ref *is* the tag). For a manual `workflow_dispatch` run with a typed-in tag input, though, the trigger ref is whatever branch the dispatch was run from — not necessarily the tag someone typed into the input box. Without pinning `ref` explicitly, a manual dispatch could package and release the wrong commit under the requested tag's name. Caught by external review; we'd only ever used the tag-push path in practice, so it hadn't surfaced.
+
+**Rejected alternative:** leave it as-is, reasoning that we never actually use manual dispatch. Rejected — the input field existing at all implies it's meant to work correctly, and a latent bug that only bites on a rarely-used path is still worth fixing once known.

--- a/skills/keep-the-why/references/setup.md
+++ b/skills/keep-the-why/references/setup.md
@@ -16,7 +16,7 @@ Setup state splits across two files, matching the existing `AGENTS.md`/`AGENTS.l
 <!-- /keep-the-why:config -->
 ```
 
-`context-schema` tracks which version's `context/` entry format is in use — separate from the installed skill's `metadata.version` (SKILL.md frontmatter), because not every skill release changes the format (see "Context schema and migrations" below).
+`context-schema` records the latest skill version this project's `context/` has been checked and migrated against — not an independent format-version number of its own. It's still tracked separately from the installed skill's `metadata.version` (SKILL.md frontmatter) because a release can bump `metadata.version` without changing the `context/` entry format at all — in that case `context-schema` simply advances to match, with nothing to migrate (see "Context schema and migrations" below).
 
 **Personal config**, in `AGENTS.local.md`, not committed, one per developer:
 


### PR DESCRIPTION
## Summary

- CHANGELOG.md: catches up `release.yml` and the new `validate-skill.yml` (both pushed directly by Oliver — workflow file changes need the `workflow` OAuth scope this token doesn't have).
- `context/repo-conventions.md`: new entry dogfooding the `release.yml` checkout-ref fix.
- `setup.md`: sharpens `context-schema`'s definition — a second external review pass initially misread it as an independent format-version number. Clarified: it's the latest skill version this project's `context/` has been checked and migrated against, deliberately coupled to `metadata.version`, not a second version axis. The reviewer's own suggested phrasing informed this.

## Test plan
- [x] `mkdocs build --strict` passes
- [x] evals.json unchanged, still valid (31 cases)