### PR TITLE
Frame capture as a byproduct, sharpen no-magic stance, fourth cost

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Keep a Changelog records what changed. Keep the Why preserves why it changed.
 
 **The payoff:** this makes a project genuinely portable between developers and cuts onboarding time — a new hire, or an AI agent that's never touched the codebase before, doesn't have to track down whoever wrote the original code. And it's not limited to "why" questions: with that context loaded, your agent gives better answers and makes safer changes across the board — which is what actually makes a legacy project tractable again, instead of a black box only one person ever understood. "Ask Bob" stops being the fallback.
 
+Documentation is normally extra work that happens after the code is done — reload the reasoning from memory, write it down again, file it somewhere else: a wiki, an ADR, a PR description nobody reopens. That's exactly why it so often doesn't happen. When an agent is already how you work — deciding, weighing trade-offs, explaining itself in the same conversation that produces the change — the reasoning shows up for free, as a byproduct of that conversation, not separate effort. Keep the Why's actual job is narrower than it sounds: don't let that reasoning get thrown away.
+
 Website: [https://keepthewhy.com](https://keepthewhy.com/) · [llms.txt](https://keepthewhy.com/llms.txt) for AI agents/assistants looking up this project
 
 ## How it works
@@ -93,11 +95,12 @@ and get the real answer instead of reverse-engineering it from the diff. See [`e
 
 ## The problem
 
-Important project knowledge gets created in conversation — with a teammate, or with an AI coding agent — and then evaporates once the conversation ends. The code shows *what* was built. It rarely shows *why*. Tests preserve expected behavior; they don't preserve the reasoning behind it — a project can be fully tested and still hard to maintain because nobody can explain why any of it works the way it does. Missing reasoning costs you in three concrete ways:
+Important project knowledge gets created in conversation — with a teammate, or with an AI coding agent — and then evaporates once the conversation ends. The code shows *what* was built. It rarely shows *why*. Tests preserve expected behavior; they don't preserve the reasoning behind it — a project can be fully tested and still hard to maintain because nobody can explain why any of it works the way it does. Missing reasoning costs you in four concrete ways:
 
 - **Re-debate** — the same architecture question gets re-litigated because nobody remembers it was already settled.
 - **Silent regression** — someone "cleans up" a workaround that looks unnecessary, not knowing it's the fix for a bug that then comes back.
 - **Onboarding stall** — new contributors (human or AI) don't touch code they don't understand, so progress slows out of caution.
+- **Repeated agent mistakes** — a fresh AI session, with no memory of the last one, proposes or re-implements something already tried and rejected, because nothing on disk records that it was.
 
 ## Where this fits
 
@@ -136,7 +139,7 @@ Also listed among the tools and further reading in the [Architecture Decision Re
 
 ## What this is not
 
-- Not a guarantee. Quality depends on what gets captured and how disciplined that stays — nothing here is enforced.
+- Not a guarantee, and not magic. No tool prevents knowledge from decaying on its own — anything claiming an agent fully replaces the thinking, pruning, and questioning that keeps documentation honest is overselling. This doesn't replace that discipline; it lowers the friction of applying it enough to make it practical to sustain in the first place.
 - Not a replacement for tests. Tests tell you what broke; this tells you why it was built that way.
 - Not a claim that all lost knowledge is recoverable. Sometimes the honest answer is "unknown."
 

--- a/llms.txt
+++ b/llms.txt
@@ -18,6 +18,14 @@ Because it's just Markdown in the repo, a `context/` update ships in the same co
 the code change it explains — reviewed the same way, versioned the same way, no separate
 system to trust or keep in sync.
 
+Documentation is normally extra work that happens after the code is done — reload the
+reasoning from memory, write it down again, file it somewhere else. That's why it so often
+doesn't happen. When an agent is already how you work, the reasoning shows up for free, as a
+byproduct of the conversation that produces the change — Keep the Why's job is not letting it
+get thrown away, not creating separate documentation effort. It isn't magic, though: no tool
+prevents knowledge from decaying on its own. This lowers the friction of the discipline that
+keeps documentation honest; it doesn't replace it.
+
 Version: 0.3.1.
 
 ## Authorship & License


### PR DESCRIPTION
## Summary

Prompted by feedback Oliver liked from a conversation with Gemini about what makes this approach elegant.

- README + llms.txt: new paragraph stating directly why this is low-friction — traditional docs are extra work after the fact (reload reasoning, write it down, file it elsewhere), which is exactly why it usually doesn't happen. When an agent is already the work mode, the reasoning surfaces for free as a byproduct of that conversation.
- README "What this is not": sharpened "not a guarantee" into an explicit no-magic stance — no tool prevents knowledge decay on its own; this lowers the friction of the discipline that keeps docs honest, it doesn't replace it.
- README "The problem": fourth cost item — an AI agent with no memory between sessions repeatedly proposing or re-implementing something already tried and rejected, distinct from a human doing the same (silent regression).

Still open (flagged, not yet done): weaving a compact version into `SKILL.md`'s `description` field — that field's job is trigger-matching, not marketing, so wanted a explicit go-ahead first.

## Test plan
- [x] `mkdocs build --strict` passes