### PR TITLE
Rework opening hook sentence for instant value, not mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Keep a Changelog records what changed. Keep the Why preserves why it changed.
 
-**Keep the Why** is a repo-native agent skill that captures the reasoning behind a codebase as a byproduct of working with your agent — so it stops re-suggesting rejected approaches, gives better answers, speeds up onboarding, and makes legacy projects tractable again.
+**Keep the Why** is a repo-native agent skill that captures the reasoning behind a codebase as a byproduct of working with your agent — so it stops re-suggesting rejected approaches, gives better answers, speeds up onboarding, and makes legacy projects tractable again. It works continuously as you develop, or retrospectively on an existing repo, capturing architecture decisions, rejected alternatives, workarounds, incident learnings, and operational constraints that the code alone can't explain.
 
 **The payoff:** this makes a project genuinely portable between developers and cuts onboarding time — a new hire, or an AI agent that's never touched the codebase before, doesn't have to track down whoever wrote the original code. And it's not limited to "why" questions: with that context loaded, your agent gives better answers and makes safer changes across the board — which is what actually makes a legacy project tractable again, instead of a black box only one person ever understood. "Ask Bob" stops being the fallback.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Keep a Changelog records what changed. Keep the Why preserves why it changed.
 
-**Keep the Why** is a repo-native agent skill that continuously captures — or retrospectively recovers — the reasoning behind a codebase: architecture decisions, rejected alternatives, workarounds, incident learnings, and operational constraints that the code alone can't explain.
+**Keep the Why** is a repo-native agent skill that captures the reasoning behind a codebase as a byproduct of working with your agent — so it stops re-suggesting rejected approaches, gives better answers, speeds up onboarding, and makes legacy projects tractable again.
 
 **The payoff:** this makes a project genuinely portable between developers and cuts onboarding time — a new hire, or an AI agent that's never touched the codebase before, doesn't have to track down whoever wrote the original code. And it's not limited to "why" questions: with that context loaded, your agent gives better answers and makes safer changes across the board — which is what actually makes a legacy project tractable again, instead of a black box only one person ever understood. "Ask Bob" stops being the fallback.
 

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,10 @@
 
 > A repo-native agent skill that captures the reasoning behind a codebase as a byproduct of
 > working with your agent — so it stops re-suggesting rejected approaches, gives better
-> answers, speeds up onboarding, and makes legacy projects tractable again.
+> answers, speeds up onboarding, and makes legacy projects tractable again. It works
+> continuously as you develop, or retrospectively on an existing repo, capturing architecture
+> decisions, rejected alternatives, workarounds, incident learnings, and operational
+> constraints that the code alone can't explain.
 
 The payoff: this makes a project genuinely portable between developers and cuts onboarding
 time. It's not limited to "why" questions either — with that context loaded, an agent gives

--- a/llms.txt
+++ b/llms.txt
@@ -1,8 +1,8 @@
 # Keep the Why
 
-> A repo-native agent skill that continuously captures — or retrospectively recovers — the
-> reasoning behind a codebase: architecture decisions, rejected alternatives, workarounds,
-> incident learnings, and operational constraints that the code alone can't explain.
+> A repo-native agent skill that captures the reasoning behind a codebase as a byproduct of
+> working with your agent — so it stops re-suggesting rejected approaches, gives better
+> answers, speeds up onboarding, and makes legacy projects tractable again.
 
 The payoff: this makes a project genuinely portable between developers and cuts onboarding
 time. It's not limited to "why" questions either — with that context loaded, an agent gives


### PR DESCRIPTION
## Summary

The opening sentence (README + llms.txt hero blockquote) led with mechanism and scope — accurate, but not a "get it in 3 seconds" hook. Replaced with the same short, payoff-first sentence settled on for the GitHub About field, so the same hook shows up everywhere someone first encounters the project.

Value first, then mechanism: the old intro's mechanism/scope detail (continuous capture / retrospective recovery, the categories of knowledge captured) follows immediately as a second sentence, rather than being dropped entirely to "How it works" further down — README (and llms.txt) can afford that second sentence where the character-constrained GitHub About field can't.

Payoff paragraph right after is untouched (Oliver explicitly didn't want that one changed).

Same short hook (without the mechanism sentence) still needs pasting into GitHub Settings > About > Description manually (no admin rights on this token):

> A repo-native agent skill that captures the reasoning behind a codebase as a byproduct of working with your agent — so it stops re-suggesting rejected approaches, gives better answers, speeds up onboarding, and makes legacy projects tractable again.

## Test plan
- [x] `mkdocs build --strict` passes