### PR TITLE
Polish pass: trim redundancy, collapse install detail, rename section

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Keep a Changelog records what changed. Keep the Why preserves why it changed.
 
 **Keep the Why** is a repo-native agent skill that captures the reasoning behind a codebase as a byproduct of working with your agent — so it stops re-suggesting rejected approaches, gives better answers, speeds up onboarding, and makes legacy projects tractable again. It works continuously as you develop, or retrospectively on an existing repo, capturing architecture decisions, rejected alternatives, workarounds, incident learnings, and operational constraints that the code alone can't explain.
 
-**The payoff:** this makes a project genuinely portable between developers and cuts onboarding time — a new hire, or an AI agent that's never touched the codebase before, doesn't have to track down whoever wrote the original code. And it's not limited to "why" questions: with that context loaded, your agent gives better answers and makes safer changes across the board — which is what actually makes a legacy project tractable again, instead of a black box only one person ever understood. "Ask Bob" stops being the fallback.
+**The payoff, made concrete:** a new hire, or an AI agent that's never touched the codebase before, doesn't have to track down whoever wrote the original code — and doesn't just repeat what was already tried and rejected. The same context makes changes safer across the board, turning a legacy project back into something tractable instead of a black box only one person ever understood. "Ask Bob" stops being the fallback.
 
 Documentation is normally extra work that happens after the code is done — reload the reasoning from memory, write it down again, file it somewhere else: a wiki, an ADR, a PR description nobody reopens. That's exactly why it so often doesn't happen. When an agent is already how you work — deciding, weighing trade-offs, explaining itself in the same conversation that produces the change — the reasoning shows up for free, as a byproduct of that conversation, not separate effort. Keep the Why's actual job is narrower than it sounds: don't let that reasoning get thrown away.
 
@@ -36,15 +36,18 @@ Where the captured knowledge actually lives, and how it relates to everything el
 
 ## Install
 
-`main` is active development, not guaranteed release-ready — pin to `latest` instead of tracking it directly (moved automatically by CI to the newest release; use an exact [tag](https://github.com/oliver-zehentleitner/keep-the-why/releases) instead for full reproducibility). See [`docs/installation.md`](docs/installation.md) for the unpinned form and full detail.
+`main` is active development, not guaranteed release-ready — pin to `latest` instead of tracking it directly (moved automatically by CI to the newest release; use an exact [tag](https://github.com/oliver-zehentleitner/keep-the-why/releases) instead for full reproducibility).
 
-**Recommended — [skills CLI](https://skills.sh/) (via `npx`, needs [Node.js](https://nodejs.org/en/download) — `npx` ships with it, nothing extra to install):**
+**Recommended — [skills CLI](https://skills.sh/)** (via `npx`, needs [Node.js](https://nodejs.org/en/download) — `npx` ships with it, nothing extra to install):
 
 ```bash
 npx skills add https://github.com/oliver-zehentleitner/keep-the-why/tree/latest/skills/keep-the-why
 ```
 
-Prompts for which of its 70+ supported agents (Claude Code, Codex, OpenCode, and more) and scope to install for, then symlinks or copies the skill package in. Also listed on [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why).
+Prompts for which of its 70+ supported agents (Claude Code, Codex, OpenCode, and more) and scope to install for, then symlinks or copies the skill package in. Also listed on [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why). Start a new session afterward so the skill is picked up.
+
+<details markdown="1">
+<summary>Other install methods — GitHub CLI, manual clone, agent-specific paths</summary>
 
 **Also recommended — [GitHub CLI](https://cli.github.com/) (`gh` v2.90.0+):**
 
@@ -73,7 +76,11 @@ Where `<target-directory>` is your agent's skills directory — the folder name 
 
 Codex CLI, Antigravity, Amp, OpenCode, Warp, and more read the shared `.agents/skills/keep-the-why` path at project scope (Codex scans it from your current directory up to the repository root) and `~/.agents/skills/keep-the-why` personally — check whether yours does before falling back to a vendor path. Cline uses its own `.cline/skills/keep-the-why` (project) / `~/.cline/skills/keep-the-why` (personal) instead.
 
-Start a new session afterward so the skill is picked up. Also compatible with Windsurf, Goose, Roo Code, Trae, Factory, JetBrains Junie, and other tools supporting the open Agent Skills format — the directory convention varies, check your tool's own docs. Full details, including tools without a skill runtime at all: [`docs/installation.md`](docs/installation.md) or [https://keepthewhy.com/installation/](https://keepthewhy.com/installation/).
+Also compatible with Windsurf, Goose, Roo Code, Trae, Factory, JetBrains Junie, and other tools supporting the open Agent Skills format — the directory convention varies, check your tool's own docs.
+
+</details>
+
+Full install detail for every method, including tools without a skill runtime at all: [`docs/installation.md`](docs/installation.md) or [https://keepthewhy.com/installation/](https://keepthewhy.com/installation/).
 
 ## Example
 
@@ -123,7 +130,7 @@ Michael Feathers' classic definition — legacy code is code without tests — c
 
 This isn't a new pattern, either. Docs and changelogs are already commonly kept current almost incidentally today, maintained by a skill or an agent alongside the actual work rather than as separate effort. Keep the Why brings that same low-effort, agent-maintained model to the one layer that couldn't be kept current this way before: the why.
 
-## Not a green field
+## Related work
 
 The idea of capturing AI-agent rationale isn't new, and this project doesn't claim otherwise. Related work:
 

--- a/llms.txt
+++ b/llms.txt
@@ -7,10 +7,11 @@
 > decisions, rejected alternatives, workarounds, incident learnings, and operational
 > constraints that the code alone can't explain.
 
-The payoff: this makes a project genuinely portable between developers and cuts onboarding
-time. It's not limited to "why" questions either — with that context loaded, an agent gives
-better answers and makes safer changes across the board, which is what actually makes a
-legacy project tractable again instead of a black box only one person ever understood.
+The payoff, made concrete: a new hire, or an agent that's never touched the codebase before,
+doesn't have to track down whoever wrote the original code — and doesn't just repeat what was
+already tried and rejected. The same context makes changes safer across the board, turning a
+legacy project back into something tractable instead of a black box only one person ever
+understood.
 
 Because "ask Bob" is not documentation. Keep a Changelog records what changed; Keep the Why
 preserves why it changed. Complements README, AGENTS.md, docs, CONTRIBUTING.md, tests, Keep a
@@ -105,7 +106,7 @@ Produces, inside the project using the skill:
 - `context/` — why the project is the way it is, organized by topic, with its own `README.md`
 - `AGENTS.local.md` — personal preferences and notes, not committed
 
-## Not a Green Field
+## Related Work
 
 Related prior art: Architecture Decision Records, the AGENTS.md standard, git-why, Agent
 Decision Records, Addy Osmani's `documentation-and-adrs` skill. Keep the Why's distinguishing

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,9 @@ plugins:
   - search
   - include-markdown
 
+markdown_extensions:
+  - md_in_html
+
 extra_css:
   - assets/extra.css
 


### PR DESCRIPTION
## Summary

Third round of external-review feedback, all three points Oliver agreed with:

1. **Payoff paragraph trimmed** — it was restating the hook sentence's benefit list almost verbatim (both said "better answers," "faster onboarding," "legacy tractable"). Now only carries the concrete imagery the hook can't fit: the new-hire/agent scenario, "Ask Bob stops being the fallback," the black-box image.
2. **Install section collapsed** — GitHub CLI, manual clone, the agent-path table, and the other-tools list now live under `<details>`, so the recommended one-liner install command stays immediately visible instead of a long CLI-detail wall sitting between "How it works" and the concrete "Example" section.
3. **"Not a green field" → "Related work"** (llms.txt: "Related Work") — the idiom isn't obvious for non-native English readers, and the section doesn't need a defensive-sounding title.

Also required `md_in_html` in `mkdocs.yml` — without it, markdown (bold, links, the path table) inside the new `<details>` block rendered as literal text instead of being parsed. Verified against the built site's HTML output.

## Test plan
- [x] `mkdocs build --strict` passes
- [x] Verified markdown renders correctly inside `<details>` (checked built HTML for the table, bold, and links)
- [x] evals.json unchanged, still valid (31 cases)