### PR TITLE
Three small doc fixes: precise detection wording, dogfood own config, sync repo-conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,4 +13,5 @@ there before re-litigating or accidentally reverting a decision.
 - context: `context/`
 - init: complete
 - context-schema: 0.3.1
+- capture-confirmation: confirm-when-unsure
 <!-- /keep-the-why:config -->

--- a/context/repo-conventions.md
+++ b/context/repo-conventions.md
@@ -60,7 +60,7 @@ Setup state is written into `<!-- keep-the-why:config -->` / `<!-- keep-the-why:
 **Status:** active
 **Evidence:** confirmed
 
-Where `context/` lives and whether the project has been initialized are in the committed `AGENTS.md` config block. Capture-mode preference, and the update-check/consistency-check intervals and their last-run timestamps, are in the personal, uncommitted `AGENTS.local.md` block instead. A project can be `init: complete` while a specific developer still gets asked their own preferences, if they don't have an `AGENTS.local.md` yet.
+Where `context/` lives, whether the project has been initialized, and how much confirmation is needed before writing (`capture-confirmation`) are in the committed `AGENTS.md` config block. Capture-mode preference, `confirmation-flow` (how multiple pending confirmations get presented), and the update-check/consistency-check intervals and their last-run timestamps, are in the personal, uncommitted `AGENTS.local.md` block instead. A project can be `init: complete` while a specific developer still gets asked their own preferences, if they don't have an `AGENTS.local.md` yet.
 
 **Reason:** the first version bundled everything into one committed block. Oliver pointed out that capture-mode and check-interval preferences are individual workflow choices, not project facts — one developer wanting weekly update checks and another wanting none are both fine, and forcing one answer onto everyone (or making it a merge-conflict-prone shared timestamp several sessions race to update) doesn't fit the existing `AGENTS.md`/`AGENTS.local.md` boundary this project already draws for exactly this kind of distinction.
 

--- a/skills/keep-the-why/references/setup.md
+++ b/skills/keep-the-why/references/setup.md
@@ -44,7 +44,7 @@ Where the why-knowledge lives, whether the project has been set up at all, and h
 - **Project block present, `init: complete`** → project is set up. Don't re-run this part regardless of who's asking — it's a project property, not a per-developer one. Once committed, every other developer or session inherits it silently.
 - **Project block present, `init: declined`** → set up was explicitly declined for this project. Don't re-ask.
 - **Personal block missing** (independent of the project block's state) → run the personal preferences wizard (below). This is why a project already marked `init: complete` can still prompt a *new* developer once — the project is set up, but this particular person hasn't stated their own preferences yet.
-- **Personal block present** → use it, no re-asking.
+- **Personal block present** → use all valid stored values as-is, no re-asking for them. This isn't unconditional, though: ask once for any required field that's still missing (e.g. `confirmation-flow` added to the skill after this block was created — see "Missing fields vs. invalid fields" below), and clarify any invalid, contradictory, or ambiguous value per rule 14 rather than silently using it. "No re-asking" applies to settings that are actually present and valid, not to the whole block regardless of its contents.
 
 ## Project init wizard (once per project)
 


### PR DESCRIPTION
## Summary

Last three points from review, all confirmed against the actual current state before fixing:

1. `setup.md`'s "Personal block present → use it, no re-asking" read as a blanket statement that formally contradicted the missing-field/invalid-value handling documented further down. Precised.
2. This repo's own `AGENTS.md` was missing `capture-confirmation` — functionally fine (missing field gets the default), but `repository-structure.md`'s example now claims a real config block always has it. Dogfooded.
3. `context/repo-conventions.md`'s project/personal config-split entry predated `confirmation-flow` and `capture-confirmation` — updated to list both correctly.

## Test plan
- [x] `mkdocs build --strict` passes
- [x] `skills-ref validate skills/keep-the-why` passes