### PR TITLE
Add missing AGENTS.local.md pointer to this repo's own AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@ This project uses Keep the Why (itself) to preserve the reasoning behind its own
 
 - Usage docs: see `docs/` (or https://keepthewhy.com)
 - Why things are the way they are: see `context/index.md`
+- If `AGENTS.local.md` exists in this checkout, read that too — personal/local notes, not committed.
 
 Read `context/index.md` before making non-trivial changes — naming, docs
 tooling, and repo structure have already been argued through once; check


### PR DESCRIPTION
## Summary
Caught by actually running the skill's own personal-preferences wizard against this working copy instead of just inspecting the files — no `AGENTS.local.md` existed here yet, and `AGENTS.md` never pointed to it, unlike the skill's own `repository-structure.md` example which shows exactly this line.

Also created `AGENTS.local.md` in this working copy (gitignored, not part of this PR) with defaults: `capture-mode: proactive`, `confirmation-flow: sequential`, `update-check`/`consistency-check` every 14/30 days.

## Test plan
- [x] `mkdocs build --strict` passes