### PR TITLE
Set this project's own capture-confirmation to confirm-always

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,5 +14,5 @@ there before re-litigating or accidentally reverting a decision.
 - context: `context/`
 - init: complete
 - context-schema: 0.4.1
-- capture-confirmation: confirm-when-unsure
+- capture-confirmation: confirm-always
 <!-- /keep-the-why:config -->


### PR DESCRIPTION
## Summary
Oliver's actual preference, learned from using the skill directly: be asked before every `context/` write, not just when evidence or proportionality are unclear. Kept project-wide rather than introducing a personal override.

## Test plan
- [x] `mkdocs build --strict` passes