### PR TITLE
Sync mkdocs.yml site_description with the current hook sentence

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Keep the Why
-site_description: A repo-native agent skill that captures the reasoning behind a codebase — so your agent gives better answers, onboarding is faster, and legacy projects become tractable again.
+site_description: Keep the Why is a repo-native agent skill that captures the reasoning behind a codebase as a byproduct of working with your agent — so it stops re-suggesting rejected approaches, gives better answers, speeds up onboarding, and makes legacy projects tractable again.
 site_url: https://keepthewhy.com
 repo_url: https://github.com/oliver-zehentleitner/keep-the-why
 repo_name: oliver-zehentleitner/keep-the-why


### PR DESCRIPTION
## Summary
`site_description` still had the pre-rework hero text — missed when README/llms.txt's hook sentence was reworked in #58/#59. This field feeds the docs site's SEO/social-preview meta description tag.

## Test plan
- [x] `mkdocs build --strict` passes
- [x] Verified the new text renders in the built `<meta name="description">` tag