### PR TITLE
Release 0.4.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,6 @@ there before re-litigating or accidentally reverting a decision.
 <!-- keep-the-why:config -->
 - context: `context/`
 - init: complete
-- context-schema: 0.4.1
+- context-schema: 0.4.2
 - capture-confirmation: confirm-always
 <!-- /keep-the-why:config -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,19 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-07-25
+
 ### Changed
 
 - **`confirmation-flow`'s scope broadened**: it now governs how *both wizards' own questions* get presented, not just multiple pending `context/` entry confirmations. `sequential` (default, and the only behavior a developer with no stored preference yet gets) asks one question, waits for the answer, then asks the next. `batch` bundles them into one message, the way both wizards used to work unconditionally before this setting existed — now a legitimate choice once a developer's preference is actually known, not the default. Caught in practice: bundling every wizard question together contradicted a developer's own already-stated `confirmation-flow: sequential` preference.
 - `examples/first-time-setup.md` rewritten to actually demonstrate sequential, turn-by-turn wizard presentation instead of the old bundled-question block.
 - 2 new eval cases: a first-ever activation defaults to sequential wizard presentation; a developer with an established `confirmation-flow: batch` preference gets bundled questions even in a brand-new project, since the preference travels with the developer, not the project.
+
+### Fixed
+
+- This repo's own `AGENTS.md` never pointed to `AGENTS.local.md`, unlike the skill's own `repository-structure.md` example — caught by actually running the personal-preferences wizard against this working copy instead of just inspecting the files.
+- `mkdocs.yml`'s `site_description` still had the pre-rework hero text from before README/llms.txt's hook sentence was reworked in `0.4.0`'s cycle — fed the docs site's SEO/social-preview meta description with stale copy.
+- Release checklist gained a step for `examples/first-time-setup.md`'s illustrative `context-schema` value, which otherwise goes stale on every release that doesn't touch the `context/` format — same situation this repo's own `AGENTS.md` would be in without the existing `context-schema` catch-up step.
 
 ## [0.4.1] - 2026-07-24
 
@@ -120,7 +128,8 @@ Initial release.
 - Logo, wordmark, and favicon.
 - `context/repo-conventions.md`, dogfooding the skill on its own repository from day one.
 
-[Unreleased]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.4.2...HEAD
+[0.4.2]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.3.0...v0.3.1

--- a/llms.txt
+++ b/llms.txt
@@ -30,7 +30,7 @@ get thrown away, not creating separate documentation effort. It isn't magic, tho
 prevents knowledge from decaying on its own. This lowers the friction of the discipline that
 keeps documentation honest; it doesn't replace it.
 
-Version: 0.4.1.
+Version: 0.4.2.
 
 ## Authorship & License
 

--- a/skills/keep-the-why/SKILL.md
+++ b/skills/keep-the-why/SKILL.md
@@ -3,7 +3,7 @@ name: keep-the-why
 description: Preserves or recovers the reasoning behind a codebase - architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain. Use when implementing or reviewing a non-trivial change involving a design decision, workaround, incident fix, operational constraint, rejected alternative, or changed assumption; when documenting an existing or legacy codebase; during onboarding or a maintainer handover; or when interviewing a developer before their knowledge is lost (e.g. before they leave or retire). Identifies what the code cannot explain, asks focused questions instead of generic ones, and maintains concise, topic-based, version-controlled documentation readable by both humans and AI agents.
 license: MIT
 metadata:
-  version: "0.4.1"
+  version: "0.4.2"
   repository: "https://github.com/oliver-zehentleitner/keep-the-why"
 ---
 

--- a/skills/keep-the-why/examples/first-time-setup.md
+++ b/skills/keep-the-why/examples/first-time-setup.md
@@ -47,7 +47,7 @@ The skill has just been installed in a project. There's no `AGENTS.md`, no `cont
     <!-- keep-the-why:config -->
     - context: `context/`
     - init: complete
-    - context-schema: 0.4.1
+    - context-schema: 0.4.2
     - capture-confirmation: confirm-when-unsure
     <!-- /keep-the-why:config -->
     ```


### PR DESCRIPTION
## Summary
- Version bump: SKILL.md and llms.txt 0.4.1 to 0.4.2
- CHANGELOG.md: Unreleased renamed to 0.4.2 (confirmation-flow wizard-scope fix plus small housekeeping since 0.4.1), fresh empty Unreleased above
- This repo's own context-schema advanced 0.4.1 to 0.4.2
- Applied the release checklist's new step 6: bumped examples/first-time-setup.md's illustrative context-schema value too

Once merged: tag v0.4.2 and push the tag to trigger the GH Release workflow.

## Test plan
- mkdocs build --strict passes
- skills-ref validate passes
- evals.json valid (54 cases)