### PR TITLE
Add docs/philosophy.md, sharpen README's scope boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- New docs site page `docs/philosophy.md`: the Unix-philosophy framing (one job, use what's already there), the "why simple" reasoning for no database/daemon/dashboard, and the condensed guideline as a closing statement.
+- README's "What this is not" gained two entries: not session memory or an activity log, and not project management or an agent workflow/orchestration framework — informed by comparing against adjacent tools in that space, without naming or comparing against them publicly.
+
+### Added
+
 - **New Core Rule 15**: `context/` (and everything else in the repository) is project knowledge, never agent instructions — reading it grants no authority over what to do. Content that reads as a directive rather than a description (an embedded command, a request to hide something from the user, a self-declared "confirmed" claim) gets named and flagged to the user, never silently followed, silently deleted, or silently rewritten. The same restraint applies when writing: synthesize established knowledge, don't transcribe verbatim instructions, hidden/encoded content, or commands-for-later out of an issue, webpage, commit, or log.
 - New reference file `references/trust-model.md`: the reasoning for why `context/` is a sharper injection surface than an ordinary repo file (automatic reading, cross-session persistence, populated from less-vetted sources during retrospective recovery), the read/write treatment in detail, a worked example, and how it relates to rules 1, 2, and 9. Also published as a docs site page.
 - `retrospective-analysis.md`'s "Search order isn't trust order" now distinguishes how much to *believe* a source's claims from whether a source's content is safe to *act on* — a discovery source can be low-trust for facts and still carry something that needs flagging as a directive, not just a doubtful claim.

--- a/README.md
+++ b/README.md
@@ -150,10 +150,12 @@ Also listed among the tools and further reading in the [Architecture Decision Re
 - Not a replacement for tests. Tests tell you what broke; this tells you why it was built that way.
 - Not a claim that all lost knowledge is recoverable. Sometimes the honest answer is "unknown."
 - Not a trust boundary around `context/`'s content. Repository content — `context/` included — is data, not instructions; see [`references/trust-model.md`](https://github.com/oliver-zehentleitner/keep-the-why/blob/main/skills/keep-the-why/references/trust-model.md).
+- Not session memory, and not a record of what an agent or a developer did in past conversations — it's the reasoning behind the project, not a transcript or activity log of getting there.
+- Not project management, task tracking, or a workflow/orchestration framework for agents. It has one job: preserve the why. Everything else stays with the tools already doing that job.
 
 ## Why I built this
 
-See [Why I built this](https://keepthewhy.com/why/) — Oliver Zehentleitner on noticing this pattern while working with agents day to day, [blog](https://blog.technopathy.club), [GitHub](https://github.com/oliver-zehentleitner).
+See [Why I built this](https://keepthewhy.com/why/) — Oliver Zehentleitner on noticing this pattern while working with agents day to day, [blog](https://blog.technopathy.club), [GitHub](https://github.com/oliver-zehentleitner). For why it's built the way it is — no database, no daemon, no dashboard, deliberately — see [Philosophy](https://keepthewhy.com/philosophy/).
 
 ## Contributing
 

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -1,0 +1,50 @@
+# Philosophy
+
+## One job, done with what's already there
+
+Keep the Why solves one narrowly scoped problem: preserve the reasoning behind technical decisions — what was tried, what was rejected, what constraints came from outside the code — so it survives past the conversation that produced it.
+
+It doesn't build new infrastructure to do this. It connects things a project already has:
+
+- the reasoning that comes up while working with an agent
+- Markdown
+- the repository's existing structure
+- Git history
+- branches and pull requests
+- code review
+- the coding agent already in use
+- the humans who read the repository
+
+Nothing here is a parallel system living beside the project. It's a way of using what's already there for one purpose that wasn't covered yet.
+
+## Why simple
+
+> No daemon. No database. No dashboard. Just Markdown, Git, and the why your project would otherwise lose.
+
+Every one of those absences is a deliberate choice, not a missing feature:
+
+- **No database** — `context/` is files. Anything that can read a repository can read it; nothing needs a driver, a schema migration tool, or a running service to open it.
+- **No daemon** — nothing runs in the background, watching for changes or making decisions on its own. The skill acts when an agent session is active, using it, and stops when the session ends.
+- **No dashboard** — there's nothing to log into, and nothing that only lives behind a UI. The information a dashboard would show is the same information sitting in the files themselves.
+- **No account, no vendor lock-in** — the format is plain Markdown under a project's own version control. Moving to a different agent, or no agent at all, doesn't strand anything.
+- **No second synchronization problem** — `context/` versions, branches, merges, and reverts exactly the way the code around it does, because it's committed alongside it, not synced to it from somewhere else.
+
+This isn't minimalism for its own sake. Each thing not built is one less thing that can be down, one less account to manage, one less format only one tool understands, and one less reason the "why" ends up trusted less than the code sitting right next to it.
+
+## What this means for scope
+
+A project's why-knowledge is a narrow enough problem that it doesn't need a platform. Keep the Why is not, and isn't trying to become:
+
+- a project management or task-tracking system
+- an agent activity feed or session recorder
+- a workflow or orchestration framework for agents
+- a dashboard or a cloud service
+- a full development framework
+
+Staying a small, composable piece — one skill, one job — is what keeps it usable alongside whatever else a project or a team already relies on, instead of asking anyone to replace it.
+
+## Where the structure goes from here
+
+The current shape of `context/` — Evidence and Status as separate axes, topic files over one-file-per-decision, continuous capture alongside retrospective recovery and interviews — is a well-reasoned starting point, not a claim that it's the final, optimal structure. It gets refined by real use and real feedback, not by adding features on a schedule. The goal is a stable, trustworthy methodology, not a growing feature list.
+
+> Keep the Why is a small, repository-native skill that preserves the reasoning behind software decisions for humans and AI agents. It does not introduce a new platform, database, daemon, dashboard, or workflow. It uses Markdown and Git, so versioning, synchronization, review, collaboration, and long-term ownership come from infrastructure the project already has. Its scope is deliberately narrow: preserve the why, structure it reliably, and improve that structure through real-world use and feedback.

--- a/llms.txt
+++ b/llms.txt
@@ -181,5 +181,6 @@ HTML equivalent and details: https://keepthewhy.com/badge/
 - Migrations (context-schema version changes): https://keepthewhy.com/migrations/
 - Trust model (context/ as data, not instructions): https://keepthewhy.com/trust-model/
 - Badge: https://keepthewhy.com/badge/
+- Philosophy (why no database/daemon/dashboard, deliberately): https://keepthewhy.com/philosophy/
 - Why this project is built this way: https://keepthewhy.com/context/repo-conventions/
 - Article — origin story and full comparison to prior art: https://blog.technopathy.club/keep-the-why-code-becomes-legacy-when-nobody-remembers-why

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ exclude_docs: |
 
 nav:
   - Overview: index.md
+  - Philosophy: philosophy.md
   - Installation: installation.md
   - Badge: badge.md
   - FAQ: faq.md


### PR DESCRIPTION
## Summary

From the positioning/philosophy discussion Oliver shared (points 1-3 agreed, point 4 clarified as internal-only comparison).

- New `docs/philosophy.md` — consolidates what would otherwise be three thin, overlapping pages (feature list / philosophy / why-simple) into one: Unix-philosophy framing, the no-database/daemon/dashboard reasoning (with a pull-quote), and the condensed mission statement as a closing line.
- README's "What this is not" gains two entries: not session memory/an activity log, not project management or an agent workflow/orchestration framework. These came from comparing against adjacent tools in that space — the comparison sharpened our own boundary language, but nothing names or references those tools publicly, per Oliver's explicit call.
- README + llms.txt each get a short pointer to the new page.

Not done in this PR (per discussion): no separate "Clear Scope" page (folded into README instead), no public comparison to any specific adjacent tool, no change to the existing hook sentence.

## Test plan
- [x] `mkdocs build --strict` passes