### PR TITLE
Add a dedicated, discoverable Security page to the docs site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 - New docs site page `docs/philosophy.md`: the Unix-philosophy framing (one job, use what's already there), the "why simple" reasoning for no database/daemon/dashboard, and the condensed guideline as a closing statement.
 - README's "What this is not" gained two entries: not session memory or an activity log, and not project management or an agent workflow/orchestration framework — informed by comparing against adjacent tools in that space, without naming or comparing against them publicly.
+- New docs site page `docs/security.md`, a prominent, discoverable entry point separate from "Trust model" — the security posture overview (no external service/telemetry/daemon, no secrets in `context/`, actions still go through the agent's own permission model), pointing to `trust-model.md` for the injection-specific detail and `SECURITY.md` for vulnerability reporting, which are two different questions that were previously only findable separately.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Also listed among the tools and further reading in the [Architecture Decision Re
 - Not a guarantee, and not magic. No tool prevents knowledge from decaying on its own — anything claiming an agent fully replaces the thinking, pruning, and questioning that keeps documentation honest is overselling. This doesn't replace that discipline; it lowers the friction of applying it enough to make it practical to sustain in the first place.
 - Not a replacement for tests. Tests tell you what broke; this tells you why it was built that way.
 - Not a claim that all lost knowledge is recoverable. Sometimes the honest answer is "unknown."
-- Not a trust boundary around `context/`'s content. Repository content — `context/` included — is data, not instructions; see [`references/trust-model.md`](https://github.com/oliver-zehentleitner/keep-the-why/blob/main/skills/keep-the-why/references/trust-model.md).
+- Not a trust boundary around `context/`'s content. Repository content — `context/` included — is data, not instructions; see [Security](https://keepthewhy.com/security/).
 - Not session memory, and not a record of what an agent or a developer did in past conversations — it's the reasoning behind the project, not a transcript or activity log of getting there.
 - Not project management, task tracking, or a workflow/orchestration framework for agents. It has one job: preserve the why. Everything else stays with the tools already doing that job.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,22 @@
+# Security
+
+Two separate questions, both answered here — with the actual detail living in its own place rather than duplicated.
+
+## Is it safe to let an agent read and write `context/`?
+
+Keep the Why treats everything read from a repository — `context/` included — as data, never as instructions. An entry can describe a decision or a constraint; it can't grant itself authority to override a system, developer, or user instruction, expand permissions, authorize a tool call, disable a safety check, or ask for a secret. A suspicious entry gets named and flagged to the user, not silently followed, deleted, or rewritten.
+
+This matters more for `context/` than for an arbitrary repo file precisely because the skill is designed to read it automatically, treat it as trustworthy background, and keep it around across sessions — the same property that makes it useful is what would make injected content dangerous if this rule didn't exist.
+
+See [Trust model](trust-model.md) for the full reasoning, the read/write rules, and worked examples.
+
+## What Keep the Why does and doesn't add to your attack surface
+
+- No external service, no telemetry, no daemon, no database — see [Philosophy](philosophy.md). There's nothing running that Keep the Why itself could leak through.
+- No secrets, credentials, or personal data belong in `context/` (Core rule 9) — retrospective recovery and interviews synthesize rationale, they don't transcribe raw material verbatim.
+- Actions with real side effects still go through whatever the agent running the skill already requires — permission prompts, sandboxing, trust verification. Keep the Why doesn't add a separate permission layer, and doesn't assume those mechanisms are bulletproof either.
+- `context/` is committed alongside the code, reviewed the same way — a change to it is as visible in a diff or a pull request as any other change.
+
+## Reporting a vulnerability in Keep the Why itself
+
+That's a different question from the above — see [`SECURITY.md`](https://github.com/oliver-zehentleitner/keep-the-why/blob/main/SECURITY.md) for the disclosure process, or report directly via [GitHub Security Advisories](https://github.com/oliver-zehentleitner/keep-the-why/security/advisories/new).

--- a/llms.txt
+++ b/llms.txt
@@ -179,6 +179,7 @@ HTML equivalent and details: https://keepthewhy.com/badge/
 - Docs: https://keepthewhy.com
 - Setup (project + personal wizards, timer checks): https://keepthewhy.com/setup/
 - Migrations (context-schema version changes): https://keepthewhy.com/migrations/
+- Security (overview, links to trust model and vulnerability reporting): https://keepthewhy.com/security/
 - Trust model (context/ as data, not instructions): https://keepthewhy.com/trust-model/
 - Badge: https://keepthewhy.com/badge/
 - Philosophy (why no database/daemon/dashboard, deliberately): https://keepthewhy.com/philosophy/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ nav:
   - Overview: index.md
   - Philosophy: philosophy.md
   - Installation: installation.md
+  - Security: security.md
   - Badge: badge.md
   - FAQ: faq.md
   - Why I built this: why.md


### PR DESCRIPTION
## Summary

Trust model already existed (#76) but was nested under Reference, and answers a narrower question (is `context/`'s content safe to read/write) than what a visitor evaluating the project for security concerns would actually search for.

- New `docs/security.md` — top-level nav entry, not nested under Reference. Short posture overview (no external service/telemetry/daemon, no secrets in `context/`, actions still go through the agent's own permission model), then two clearly separated pointers: `trust-model.md` for the injection-specific detail, `SECURITY.md` for reporting a vulnerability in the project itself. These are genuinely two different questions that were previously only findable separately.
- README's trust-boundary bullet now points to the new Security page instead of directly at `trust-model.md`, since it's the more complete entry point and links deeper itself.
- llms.txt Docs list gains the new page.

## Test plan
- [x] `mkdocs build --strict` passes