### PR TITLE
Fix rendering bugs in examples/first-time-setup.md on the docs site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+### Fixed
+
+- `examples/first-time-setup.md` rendered badly on the docs site — fenced code blocks nested inside numbered list items collapsed into unhighlighted inline code, and the sequential wizard dialogue (consecutive `>` lines with no blank line between turns) collapsed into one run-on paragraph inside the blockquote. Neither broke `mkdocs build --strict`, since both are rendering-fidelity issues, not broken links. Added `pymdownx.superfences` to `mkdocs.yml` (plain `fenced_code` doesn't handle fences nested inside list items) and inserted blank `>` lines between each dialogue turn. Verified against the actual built HTML, not just a successful build.
+
 ### Added
 
 - README, `docs/installation.md`, and `llms.txt` now tell installers to explicitly prompt their agent ("initialize Keep the Why in this project") after installing, rather than only saying "start a new session." A Skill activates on a matching conversation, not automatically on session start — without the explicit nudge, the one-time setup wizard would only run whenever something happened to trigger it organically.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ plugins:
 
 markdown_extensions:
   - md_in_html
+  - pymdownx.superfences
 
 extra_css:
   - assets/extra.css

--- a/skills/keep-the-why/examples/first-time-setup.md
+++ b/skills/keep-the-why/examples/first-time-setup.md
@@ -12,12 +12,19 @@ The skill has just been installed in a project. There's no `AGENTS.md`, no `cont
 2. Runs the project init wizard, one question at a time. This developer has no stored `confirmation-flow` yet (nothing to read it from — it's itself one of the questions the personal wizard hasn't asked yet), so the wizard defaults to `sequential`, not a bundled block:
 
     > **Agent:** This project isn't set up with Keep the Why yet. Quick setup, one question at a time — say "defaults" any time to take the rest as-is. First: where should the why-knowledge live? [`context/`]
+    >
     > **User:** defaults.
+    >
     > **Agent:** Got it, `context/`. Next: how do you want to start — capture from now on only, work through existing history now, sit down for an interview, or some combination? [fresh]
+    >
     > **User:** defaults.
+    >
     > **Agent:** Add the Keep the Why badge to README.md? [yes]
+    >
     > **User:** yes.
+    >
     > **Agent:** Last one: how much confirmation before something gets written to `context/` — automatic, always ask, or only when unclear? [only when unclear]
+    >
     > **User:** defaults.
 
 3. Adds the badge to `README.md`, as the last badge after the existing ones:
@@ -55,12 +62,19 @@ The skill has just been installed in a project. There's no `AGENTS.md`, no `cont
 6. Runs the personal preferences wizard, separately, also one question at a time for the same reason:
 
     > **Agent:** And a couple of preferences just for you (not committed). Capture proactively during conversation, or only when asked? [proactive]
+    >
     > **User:** explicit-only.
+    >
     > **Agent:** When there's more than one thing to confirm at once — including questions like these — one at a time, or as a list you can review together? [one at a time]
+    >
     > **User:** defaults.
+    >
     > **Agent:** Check for skill updates? [yes, every 14 days]
+    >
     > **User:** defaults.
+    >
     > **Agent:** Check `context/` for staleness? [yes, every 30 days]
+    >
     > **User:** defaults on the rest.
 
 7. `AGENTS.local.md` doesn't exist yet. Checks `.gitignore` first — it already has an `AGENTS.local.md` entry (from an earlier project convention), so nothing to add there. Creates `AGENTS.local.md`, referenced from `AGENTS.md`, with the personal config block:


### PR DESCRIPTION
## Summary

Checked what you flagged as looking stale on https://keepthewhy.com/examples/first-time-setup/ — the content itself is actually current (sequential wizard, capture-confirmation, confirmation-flow, context-schema: 0.4.2 all present). The problem is two rendering bugs, neither of which `mkdocs build --strict` catches since both are fidelity issues, not broken links:

1. **Fenced code blocks nested inside numbered list items** (the badge snippet, `context/README.md` content, both config block examples) rendered as unhighlighted inline code instead of a proper code block. Plain markdown's `fenced_code` doesn't reliably handle fences nested inside list items — added `pymdownx.superfences` to `mkdocs.yml`, which does. Verified with a minimal local reproduction before/after.
2. **The sequential wizard dialogue collapsed into one run-on paragraph.** Consecutive `>` lines with no blank line between them are one blockquote paragraph in CommonMark — technically correct behavior, just not what the source intended when I rewrote it for sequential presentation (#71). Added a blank `>` line between each Agent/User turn.

Verified against the actual built HTML output this time (`grep`'d the rendered `site/` directory), not just a successful strict build — that only checks links and nav, not whether markdown rendered the way it was meant to. Spot-checked a few other pages with fences/tables inside lists or `<details>` blocks for regressions; none found.

## Test plan
- [x] `mkdocs build --strict` passes
- [x] `skills-ref validate skills/keep-the-why` passes
- [x] Manually confirmed both fixes in the rendered HTML