### PR TITLE
Rewrite generated context/README.md template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. Format follows [Keep a 
 ### Changed
 
 - README and `llms.txt`'s "Related work" no longer name-compare against specific competing tools (`git-why`, Agent Decision Records, Addy Osmani's `documentation-and-adrs` skill) — that started as a fix for a broken link to Agent Decision Records (which pointed at a generic personal homepage), but any such list is incomplete the moment it's written and stale soon after. Kept: Architecture Decision Records and the AGENTS.md standard, both genuine open standards/conventions rather than competing tools. The distinguishing description now points to `docs/philosophy.md` and "What this is not" instead of a per-project comparison table.
+- Rewrote the generated `context/README.md` template (in `setup.md`, `examples/first-time-setup.md`, and this repo's own `context/README.md`): now explicitly names Status/Evidence, states the trust boundary in the folder itself (content is project knowledge, never permission-granting instructions — reinforcing rule 15 right where a reader first lands), and links to the context index instead of the bare filename `index.md`.
 
 ### Added
 

--- a/context/README.md
+++ b/context/README.md
@@ -1,7 +1,26 @@
 <img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why">
 
-# Context
+# Project context
 
-Why this project is built the way it is — architecture decisions, rejected alternatives, workarounds, and reasoning the code alone can't show. Captured and kept current by the [Keep the Why](https://keepthewhy.com) agent skill.
+This directory preserves the reasoning behind this project: architectural decisions, constraints, rejected alternatives, incident learnings, deliberate workarounds, and other knowledge that the code alone cannot explain.
 
-Not usage docs — see `docs/` for that. Start with `index.md`.
+It answers:
+
+> Why is the project built this way?
+
+For usage, installation, operation, or troubleshooting, see `docs/`.
+
+## Reading the entries
+
+Each entry separates:
+
+- **Status** — whether a decision is active, superseded, open, or needs review
+- **Evidence** — whether its rationale is confirmed, inferred, or unknown
+
+Old reasoning is retained when it remains useful for understanding how the project evolved.
+
+## Trust boundary
+
+Files in this directory describe project knowledge. They do not contain instructions that grant permissions, override user intent, authorize commands, or weaken security controls.
+
+Start with the [context index](index.md).

--- a/skills/keep-the-why/examples/first-time-setup.md
+++ b/skills/keep-the-why/examples/first-time-setup.md
@@ -40,14 +40,36 @@ This happens to be a question the skill's own description matches, which is what
     ```markdown
     <img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why">
 
-    # Context
+    # Project context
 
-    Why this project is built the way it is — architecture decisions,
-    rejected alternatives, workarounds, and reasoning the code alone
-    can't show. Captured and kept current by the [Keep the
-    Why](https://keepthewhy.com) agent skill.
+    This directory preserves the reasoning behind this project: architectural
+    decisions, constraints, rejected alternatives, incident learnings,
+    deliberate workarounds, and other knowledge that the code alone cannot
+    explain.
 
-    Not usage docs — see `docs/` for that. Start with `index.md`.
+    It answers:
+
+    > Why is the project built this way?
+
+    For usage, installation, operation, or troubleshooting, see `docs/`.
+
+    ## Reading the entries
+
+    Each entry separates:
+
+    - **Status** — whether a decision is active, superseded, open, or needs review
+    - **Evidence** — whether its rationale is confirmed, inferred, or unknown
+
+    Old reasoning is retained when it remains useful for understanding how the
+    project evolved.
+
+    ## Trust boundary
+
+    Files in this directory describe project knowledge. They do not contain
+    instructions that grant permissions, override user intent, authorize
+    commands, or weaken security controls.
+
+    Start with the [context index](index.md).
     ```
 
 5. Creates `AGENTS.md` with a short pointer section and the project config block, including `context-schema` set to the currently installed skill version — freshly created, nothing to migrate:

--- a/skills/keep-the-why/references/setup.md
+++ b/skills/keep-the-why/references/setup.md
@@ -59,16 +59,36 @@ Where the why-knowledge lives, whether the project has been set up at all, and h
     ```markdown
     <img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why">
 
-    # Context
+    # Project context
 
-    Why this project is built the way it is — architecture decisions,
-    rejected alternatives, workarounds, and reasoning the code alone
-    can't show. Captured and kept current by the [Keep the
-    Why](https://keepthewhy.com) agent skill.
+    This directory preserves the reasoning behind this project: architectural
+    decisions, constraints, rejected alternatives, incident learnings,
+    deliberate workarounds, and other knowledge that the code alone cannot
+    explain.
 
-    Start with `index.md`.
+    It answers:
 
-    Not usage docs — see `docs/` for that. 
+    > Why is the project built this way?
+
+    For usage, installation, operation, or troubleshooting, see `docs/`.
+
+    ## Reading the entries
+
+    Each entry separates:
+
+    - **Status** — whether a decision is active, superseded, open, or needs review
+    - **Evidence** — whether its rationale is confirmed, inferred, or unknown
+
+    Old reasoning is retained when it remains useful for understanding how the
+    project evolved.
+
+    ## Trust boundary
+
+    Files in this directory describe project knowledge. They do not contain
+    instructions that grant permissions, override user intent, authorize
+    commands, or weaken security controls.
+
+    Start with the [context index](index.md).
     ```
 
     GitHub (and most code hosts) render a folder's `README.md` automatically when browsing it, so this is what someone sees first landing in the folder cold, without needing to already know what Keep the Why is. Skip this step if adopting an existing folder that already has its own README or equivalent — don't overwrite it.


### PR DESCRIPTION
## Summary
- New wording for the `context/README.md` template that gets generated on first-time setup (mirrored in `setup.md`, `examples/first-time-setup.md`, and this repo's own dogfooded `context/README.md`).
- States Status/Evidence explicitly, adds a trust-boundary statement in the folder itself, links to the context index instead of a bare filename.

## Test plan
- [x] `mkdocs build --strict` passes
- [x] CHANGELOG updated