### PR TITLE
Wrap logo image in a link to keepthewhy.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+### Fixed
+
+- The Keep the Why logo image in `README.md`, `context/README.md`, `setup.md`, and `examples/first-time-setup.md` wasn't a link — clicking it opened the raw image instead of navigating to keepthewhy.com. Wrapped in an `<a href="https://keepthewhy.com">`.
+
 ## [0.5.0] - 2026-07-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Telegram](https://img.shields.io/badge/community-telegram-41ab8c)](https://t.me/unicorndevs)
 [![Keep the Why](https://keepthewhy.com/assets/badge.svg)](https://keepthewhy.com)
 
-<img src="docs/assets/logo.png" alt="Keep the Why — because &quot;ask Bob&quot; is not documentation.">
+<a href="https://keepthewhy.com"><img src="docs/assets/logo.png" alt="Keep the Why — because &quot;ask Bob&quot; is not documentation."></a>
 
 # Keep the Why
 

--- a/context/README.md
+++ b/context/README.md
@@ -1,4 +1,4 @@
-<img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why">
+<a href="https://keepthewhy.com"><img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why"></a>
 
 # Project context
 

--- a/skills/keep-the-why/examples/first-time-setup.md
+++ b/skills/keep-the-why/examples/first-time-setup.md
@@ -38,7 +38,7 @@ This happens to be a question the skill's own description matches, which is what
 4. `context/` doesn't exist yet, so creates it with a short `README.md` inside (GitHub renders this automatically when someone browses the folder):
 
     ```markdown
-    <img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why">
+    <a href="https://keepthewhy.com"><img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why"></a>
 
     # Project context
 

--- a/skills/keep-the-why/references/setup.md
+++ b/skills/keep-the-why/references/setup.md
@@ -57,7 +57,7 @@ Where the why-knowledge lives, whether the project has been set up at all, and h
 3. If the why-knowledge folder is being created fresh (not an existing folder being adopted), add a short `README.md` inside it:
 
     ```markdown
-    <img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why">
+    <a href="https://keepthewhy.com"><img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why"></a>
 
     # Project context
 


### PR DESCRIPTION
## Summary
- Clicking the Keep the Why logo in `README.md`, `context/README.md`, `setup.md`, and `examples/first-time-setup.md` opened the raw image file instead of navigating anywhere.
- Wrapped each in `<a href="https://keepthewhy.com">`.

## Test plan
- [x] `mkdocs build --strict` passes