### PR TITLE
Name and link Keep the Why in the generated context/README.md body text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+### Added
+
+- The generated `context/README.md` template (`setup.md`, `examples/first-time-setup.md`, this repo's own `context/README.md`) now names and links Keep the Why in the body text, not just the logo image — explaining that the folder follows a schema shared across projects, so an agent or person who recognizes it already knows how to work with it.
+
 ### Fixed
 
 - The Keep the Why logo image in `README.md`, `context/README.md`, `setup.md`, and `examples/first-time-setup.md` wasn't a link — clicking it opened the raw image instead of navigating to keepthewhy.com. Wrapped in an `<a href="https://keepthewhy.com">`.

--- a/context/README.md
+++ b/context/README.md
@@ -4,6 +4,8 @@
 
 This directory preserves the reasoning behind this project: architectural decisions, constraints, rejected alternatives, incident learnings, deliberate workarounds, and other knowledge that the code alone cannot explain.
 
+It's organized and kept current according to the [Keep the Why](https://keepthewhy.com) schema — a repo-native agent skill, not specific to this project. Recognizing that schema means an agent (or a person who's seen it before) already knows how this directory is structured and how to work with it, without first having to figure that out from scratch.
+
 It answers:
 
 > Why is the project built this way?

--- a/skills/keep-the-why/examples/first-time-setup.md
+++ b/skills/keep-the-why/examples/first-time-setup.md
@@ -47,6 +47,13 @@ This happens to be a question the skill's own description matches, which is what
     deliberate workarounds, and other knowledge that the code alone cannot
     explain.
 
+    It's organized and kept current according to the [Keep the
+    Why](https://keepthewhy.com) schema — a repo-native agent skill, not
+    specific to this project. Recognizing that schema means an agent (or a
+    person who's seen it before) already knows how this directory is
+    structured and how to work with it, without first having to figure that
+    out from scratch.
+
     It answers:
 
     > Why is the project built this way?

--- a/skills/keep-the-why/references/setup.md
+++ b/skills/keep-the-why/references/setup.md
@@ -66,6 +66,13 @@ Where the why-knowledge lives, whether the project has been set up at all, and h
     deliberate workarounds, and other knowledge that the code alone cannot
     explain.
 
+    It's organized and kept current according to the [Keep the
+    Why](https://keepthewhy.com) schema — a repo-native agent skill, not
+    specific to this project. Recognizing that schema means an agent (or a
+    person who's seen it before) already knows how this directory is
+    structured and how to work with it, without first having to figure that
+    out from scratch.
+
     It answers:
 
     > Why is the project built this way?


### PR DESCRIPTION
## Summary
- The generated `context/README.md` template only had the logo image linking to keepthewhy.com — no plain-text mention of what the schema is called.
- Added a sentence naming and linking Keep the Why, explaining that recognizing the schema across projects means already knowing how to work with the folder.
- Applied consistently in `setup.md`, `examples/first-time-setup.md`, and this repo's own `context/README.md`.

## Test plan
- [x] `mkdocs build --strict` passes