### PR TITLE
Release 0.5.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,6 @@ there before re-litigating or accidentally reverting a decision.
 <!-- keep-the-why:config -->
 - context: `context/`
 - init: complete
-- context-schema: 0.5.0
+- context-schema: 0.5.1
 - capture-confirmation: confirm-always
 <!-- /keep-the-why:config -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-07-27
+
 ### Added
 
 - The generated `context/README.md` template (`setup.md`, `examples/first-time-setup.md`, this repo's own `context/README.md`) now names and links Keep the Why in the body text, not just the logo image — explaining that the folder follows a schema shared across projects, so an agent or person who recognizes it already knows how to work with it.

--- a/llms.txt
+++ b/llms.txt
@@ -30,7 +30,7 @@ get thrown away, not creating separate documentation effort. It isn't magic, tho
 prevents knowledge from decaying on its own. This lowers the friction of the discipline that
 keeps documentation honest; it doesn't replace it.
 
-Version: 0.5.0.
+Version: 0.5.1.
 
 ## Authorship & License
 

--- a/skills/keep-the-why/SKILL.md
+++ b/skills/keep-the-why/SKILL.md
@@ -3,7 +3,7 @@ name: keep-the-why
 description: Preserves or recovers the reasoning behind a codebase - architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain. Use when implementing or reviewing a non-trivial change involving a design decision, workaround, incident fix, operational constraint, rejected alternative, or changed assumption; when documenting an existing or legacy codebase; during onboarding or a maintainer handover; or when interviewing a developer before their knowledge is lost (e.g. before they leave or retire). Identifies what the code cannot explain, asks focused questions instead of generic ones, and maintains concise, topic-based, version-controlled documentation readable by both humans and AI agents.
 license: MIT
 metadata:
-  version: "0.5.0"
+  version: "0.5.1"
   repository: "https://github.com/oliver-zehentleitner/keep-the-why"
 ---
 

--- a/skills/keep-the-why/examples/first-time-setup.md
+++ b/skills/keep-the-why/examples/first-time-setup.md
@@ -85,7 +85,7 @@ This happens to be a question the skill's own description matches, which is what
     <!-- keep-the-why:config -->
     - context: `context/`
     - init: complete
-    - context-schema: 0.5.0
+    - context-schema: 0.5.1
     - capture-confirmation: confirm-when-unsure
     <!-- /keep-the-why:config -->
     ```

--- a/skills/keep-the-why/references/repository-structure.md
+++ b/skills/keep-the-why/references/repository-structure.md
@@ -61,7 +61,7 @@ prior decisions and avoid re-litigating or accidentally reverting them.
 <!-- keep-the-why:config -->
 - context: `context/`
 - init: complete
-- context-schema: 0.5.0
+- context-schema: 0.5.1
 - capture-confirmation: confirm-when-unsure
 <!-- /keep-the-why:config -->
 ```

--- a/skills/keep-the-why/references/setup.md
+++ b/skills/keep-the-why/references/setup.md
@@ -12,7 +12,7 @@ Setup state splits across two files, matching the existing `AGENTS.md`/`AGENTS.l
 <!-- keep-the-why:config -->
 - context: `context/`
 - init: complete
-- context-schema: 0.5.0
+- context-schema: 0.5.1
 - capture-confirmation: confirm-when-unsure
 <!-- /keep-the-why:config -->
 ```


### PR DESCRIPTION
## Summary
- Bump `metadata.version` to 0.5.1, `llms.txt` Version line, CHANGELOG `[Unreleased]` → `[0.5.1]`.
- Advance this repo's own `context-schema` to 0.5.1 (nothing to migrate — no `context/` entry format change).
- Bump illustrative `context-schema` values in `setup.md`, `repository-structure.md`, `examples/first-time-setup.md`.

## Test plan
- [x] `mkdocs build --strict` passes
- [x] evals.json valid (60 cases)