### PR TITLE
Add author to SKILL.md metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+### Added
+
+- `SKILL.md` frontmatter's `metadata` block now includes `author: "Oliver Zehentleitner"` — the Agent Skills spec's `metadata` field is an arbitrary key-value map (its own spec example shows `author` as a custom key), not a dedicated top-level field.
+
 ## [0.5.1] - 2026-07-27
 
 ### Added

--- a/skills/keep-the-why/SKILL.md
+++ b/skills/keep-the-why/SKILL.md
@@ -5,6 +5,7 @@ license: MIT
 metadata:
   version: "0.5.1"
   repository: "https://github.com/oliver-zehentleitner/keep-the-why"
+  author: "Oliver Zehentleitner"
 ---
 
 # Keep the Why


### PR DESCRIPTION
## Summary
- Adds `author: "Oliver Zehentleitner"` to `SKILL.md`'s `metadata` block.
- Verified against the Agent Skills spec (agentskills.io/specification): `metadata` is an arbitrary key-value map, and the spec's own example shows `author` as a conventional custom key.

## Test plan
- [x] `skills-ref validate` passes locally
- [x] `mkdocs build --strict` passes