### PR TITLE
Add "Also listed on" marketplace table to README and installation docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+### Added
+
+- "Also listed on" table in `README.md` and `docs/installation.md`, tracking marketplace listing status (skills.sh, GitHub Copilot plugin marketplace, awesome-agent-skills, SkillsLLM) — only lists what's actually confirmed live or has an open, trackable submission, not aspirational entries.
+
 ## [0.5.2] - 2026-07-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
-- "Also listed on" table in `README.md` and `docs/installation.md`, tracking marketplace listing status (skills.sh, GitHub Copilot plugin marketplace, awesome-agent-skills, SkillsLLM) — only lists what's actually confirmed live or has an open, trackable submission, not aspirational entries.
+- "Also listed on" table in `README.md` and `docs/installation.md`, plus an equivalent "Also Listed On" section in `llms.txt`, tracking marketplace listing status (skills.sh, GitHub Copilot plugin marketplace, awesome-agent-skills, SkillsLLM) — only lists what's actually confirmed live or has an open, trackable submission, not aspirational entries.
 
 ## [0.5.2] - 2026-07-28
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,15 @@ Also compatible with Windsurf, Goose, Roo Code, Trae, Factory, JetBrains Junie, 
 
 Full install detail for every method, including tools without a skill runtime at all: [`docs/installation.md`](docs/installation.md) or [https://keepthewhy.com/installation/](https://keepthewhy.com/installation/).
 
+### Also listed on
+
+| Name | Status | Info |
+|---|---|---|
+| [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why) | Live | Backs the `npx skills add` install method above |
+| [GitHub Copilot plugin marketplace](https://github.com/github/awesome-copilot) | Ready for review — [Issue #2470](https://github.com/github/awesome-copilot/issues/2470) | External plugin submission, pinned to `v0.5.2` |
+| [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills) | Pending — [PR #850](https://github.com/VoltAgent/awesome-agent-skills/pull/850) | Requires "real community usage"; may be declined |
+| [SkillsLLM](https://skillsllm.com/) | Not eligible yet | Requires 100+ GitHub stars to submit |
+
 ## Example
 
 ```text

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -30,6 +30,15 @@ npx skills add oliver-zehentleitner/keep-the-why
 
 Either form prompts for which of its 70+ supported agents (Claude Code, Codex, OpenCode, and more) and scope (project or personal) to install for, then installs via symlink or copy, your choice. Also listed on [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why).
 
+## Also listed on
+
+| Name | Status | Info |
+|---|---|---|
+| [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why) | Live | Backs the `npx skills add` install method above |
+| [GitHub Copilot plugin marketplace](https://github.com/github/awesome-copilot) | Ready for review — [Issue #2470](https://github.com/github/awesome-copilot/issues/2470) | External plugin submission, pinned to `v0.5.2` |
+| [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills) | Pending — [PR #850](https://github.com/VoltAgent/awesome-agent-skills/pull/850) | Requires "real community usage"; may be declined |
+| [SkillsLLM](https://skillsllm.com/) | Not eligible yet | Requires 100+ GitHub stars to submit |
+
 ## Also recommended: GitHub CLI
 
 With [`gh`](https://cli.github.com/) v2.90.0 or later — `gh skill` is [in public preview](https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/customize-cloud-agent/add-skills) and subject to change:

--- a/llms.txt
+++ b/llms.txt
@@ -80,6 +80,16 @@ and most AGENTS.md-aware tools already read that file at the start of every sess
 own, independent of this skill. Every later session picks the project back up without
 needing to be told again.
 
+## Also Listed On
+
+- skills.sh: https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why — live, backs
+  the `npx skills add` method above
+- GitHub Copilot plugin marketplace: ready for review, external plugin submission pinned to
+  v0.5.2 — https://github.com/github/awesome-copilot/issues/2470
+- awesome-agent-skills: pending review — requires "real community usage", may be declined —
+  https://github.com/VoltAgent/awesome-agent-skills/pull/850
+- SkillsLLM: not eligible yet, requires 100+ GitHub stars — https://skillsllm.com/
+
 ## Core Concept
 
 Four modes. Every entry is classified on two separate axes: **Evidence** (confirmed / inferred /


### PR DESCRIPTION
## Summary
- Adds an "Also listed on" table (Name | Status | Info) to both `README.md` and `docs/installation.md`
- Only lists entries that are confirmed live (skills.sh) or have an open, trackable submission (linking to the issue/PR) — nothing aspirational
- Update as each submission's status changes: awesome-copilot (currently ready-for-review), awesome-agent-skills (currently pending), SkillsLLM (blocked on 100+ stars)