### PR TITLE
Document source-reference in README, llms.txt, and FAQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
-- New project setting `source-reference` (`always` / `never` / `filtered: <criteria>`, default `never`) governs whether the skill actively asks for a related issue, ticket, PR, or post-mortem when recording a `context/` entry — distinct from rule 2's existing (passive) Source field. `filtered` criteria are free text the project defines itself, not a fixed taxonomy. Asking is never the same as requiring one to exist — "no reference" is a complete answer, never invented to fill the field. Project-wide only for now, no personal override, same precedent as `capture-confirmation`. See `context/repo-conventions.md`.
+- New project setting `source-reference` (`always` / `never` / `filtered: <criteria>`, default `never`) governs whether the skill actively asks for a related issue, ticket, PR, or post-mortem when recording a `context/` entry — distinct from rule 2's existing (passive) Source field. `filtered` criteria are free text the project defines itself, not a fixed taxonomy. Asking is never the same as requiring one to exist — "no reference" is a complete answer, never invented to fill the field. Project-wide only for now, no personal override, same precedent as `capture-confirmation`. See `context/repo-conventions.md`. Also documented in `README.md`, `llms.txt`, and `docs/faq.md`.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Keep the Why is a `SKILL.md`-based agent skill — an open, cross-agent format (
 3. **Knowledge-transfer interview** — before a maintainer's knowledge becomes unavailable (leaving, retiring, changing teams), the agent analyzes the codebase first, then either asks targeted questions about exactly what the code couldn't explain, or — for someone whose knowledge is broad and tacit after many years on one system — just listens while they narrate freely and extracts the rationale from that instead.
 4. **Maintenance** — existing rationale docs get kept current: contradictions resolved, superseded entries marked, oversized files split.
 
-First activation in a project runs a short one-time setup instead of guessing at defaults — where the why-knowledge should live, how to start, proactive or explicit-only capture, how much confirmation is needed before something gets written, and whether to periodically check for skill updates or `context/` staleness. See [`docs/setup.md`](docs/setup.md).
+First activation in a project runs a short one-time setup instead of guessing at defaults — where the why-knowledge should live, how to start, proactive or explicit-only capture, how much confirmation is needed before something gets written, whether to actively ask for a related issue or ticket, and whether to periodically check for skill updates or `context/` staleness. See [`docs/setup.md`](docs/setup.md).
 
 Because it's just Markdown in the repo, a `context/` update ships in the same commit or PR as the code change it explains — reviewed the same way, versioned the same way, no separate system to trust or keep in sync.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -21,6 +21,9 @@ No — see "What this is not" in the [Overview](index.md) and in `SKILL.md`. Qua
 **Does the skill always interrupt me to ask before writing anything?**
 Configurable, project-wide, via `capture-confirmation` in `AGENTS.md`: `automatic` (never asks permission, just writes once evidence and proportionality already support it), `confirm-always` (asks before every write), or `confirm-when-unsure` (the default, and what the skill already did before this setting existed — writes directly when things are clear, asks only when genuinely unclear). None of these change whether the skill asks a substantive question about the facts themselves, which stays independent of this setting even in `automatic` mode. See [Setup](setup.md), "The confirmation model."
 
+**Does it link entries to a Jira/GitHub issue or post-mortem?**
+It can, via `source-reference` in `AGENTS.md` (project-wide, default `never`): `always` asks whether a related issue, ticket, PR, or post-mortem exists for every new entry; `filtered: <criteria>` asks only when your own free-text criteria match (e.g. only for incident-related topic files). Either way, asking isn't the same as requiring one — "no reference exists" is a complete answer, never invented to fill the field. This is separate from rule 2's Source field itself, which could already hold a reference, just wasn't actively asked for before this setting existed. See [Setup](setup.md), "The confirmation model."
+
 **What if my project already has a documentation structure I like?**
 Keep the Why is meant to adapt to what exists, not replace a working structure with a fixed template. See [Repository structure](repository-structure.md), "Retrofitting an existing project."
 

--- a/llms.txt
+++ b/llms.txt
@@ -109,15 +109,16 @@ contradicted).
 - Maintenance — keep existing rationale current, resolve contradictions, split oversized files
 
 First activation in a project runs a one-time setup: a project wizard (where `context/` lives,
-starting mode, README badge, and `capture-confirmation`) and a separate personal wizard
-(proactive vs. explicit-only capture, `confirmation-flow`, update-check/consistency-check
-intervals) — see https://keepthewhy.com/setup/. When a later skill update changes the
-`context/` entry format, a `context-schema` version tracked in the project's config is
-compared against the installed skill's `metadata.version` and, if behind, offers a migration —
-see https://keepthewhy.com/migrations/. A developer can personally decline being asked about
-one specific migration without affecting the project or anyone else on it. Updating the skill
-itself (new `metadata.version`, new frontmatter shape, etc.) is independent of this — it only
-asks something of a project when the `context/` entry format actually changes.
+starting mode, README badge, `capture-confirmation`, and `source-reference`) and a separate
+personal wizard (proactive vs. explicit-only capture, `confirmation-flow`,
+update-check/consistency-check intervals) — see https://keepthewhy.com/setup/. When a later
+skill update changes the `context/` entry format, a `context-schema` version tracked in the
+project's config is compared against the installed skill's `metadata.version` and, if behind,
+offers a migration — see https://keepthewhy.com/migrations/. A developer can personally
+decline being asked about one specific migration without affecting the project or anyone else
+on it. Updating the skill itself (new `metadata.version`, new frontmatter shape, etc.) is
+independent of this — it only asks something of a project when the `context/` entry format
+actually changes.
 
 Two more settings decide how writing itself gets confirmed, independent of when the skill
 looks for something worth capturing (`capture-mode`) or whether an entry is warranted at all
@@ -130,6 +131,12 @@ permission question ("should I write this?") is governed by these settings; a su
 clarifying question about the facts themselves is not, and stays independent even in
 `automatic` mode. Applies across all four modes, including maintenance, where `automatic`
 never permits silently overwriting already-confirmed historical information.
+
+A fourth, independent setting, `source-reference` (project-wide) — `always`, `never` (default),
+or `filtered: <criteria>` — decides whether the skill actively asks for a related issue,
+ticket, PR, or post-mortem when recording an entry, separate from Source above, which was
+already able to hold one but was never actively sought. Asking is never the same as requiring
+one to exist: "no reference" is a complete answer, never invented to fill the field.
 
 A genuinely missing field can fall back to a documented default (e.g. `capture-confirmation`
 absent means `confirm-when-unsure`, since that's already the project's real behavior) — but a
@@ -160,6 +167,8 @@ external service (no database, no MCP server).
   it covers only the "why" layer; see "Where this fits" in the README.
 - Don't invent rationale when evidence doesn't support an answer — mark it "unknown" instead of
   guessing.
+- Don't invent an issue, ticket, or post-mortem reference to satisfy `source-reference: always`
+  or a matching `filtered` criterion — "no reference exists" is a complete, valid answer.
 - Don't create a new topic file in `context/` when an existing one on the same subject should be
   updated instead.
 - Don't default to a scripted interview question list for someone with broad, tacit knowledge


### PR DESCRIPTION
## Summary
PR #97 added the `source-reference` setting itself but only touched `SKILL.md`, `references/setup.md`, `context/repo-conventions.md`, this repo's own `AGENTS.md`, and the evals — the user-facing marketing/reference docs were missed.

- `README.md` — setup summary sentence now mentions it
- `llms.txt` — Core Concept (project wizard list + new dedicated paragraph) and Common Mistakes both updated
- `docs/faq.md` — new entry: "Does it link entries to a Jira/GitHub issue or post-mortem?"

## Test plan
- [x] `mkdocs build --strict` passes