### PR TITLE
Add Claude Code plugin manifest and skill composition guidance

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "keep-the-why",
+  "version": "0.5.2",
+  "description": "Preserves the reasoning behind a codebase - decisions, rejected alternatives, workarounds, and incident learnings the code alone can't explain.",
+  "author": {
+    "name": "Oliver Zehentleitner",
+    "url": "https://github.com/oliver-zehentleitner"
+  },
+  "homepage": "https://keepthewhy.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/oliver-zehentleitner/keep-the-why.git"
+  },
+  "license": "MIT",
+  "keywords": [
+    "documentation",
+    "context",
+    "decision-log",
+    "knowledge-management",
+    "onboarding",
+    "agents"
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
+- `.claude-plugin/plugin.json` — the official Claude Code plugin manifest (distinct from the root `plugin.json`, which serves GitHub's Copilot CLI plugin marketplace format). No `skills` field needed: Claude Code auto-discovers the existing `skills/` directory by convention. Groundwork for listing on `obra/superpowers-marketplace`.
+- New `SKILL.md` section "Composition with other skills": Keep the Why is a cross-cutting persistence skill, not a workflow orchestrator — when another skill already governs how work gets done, follow that workflow first and preserve only the rationale likely to matter afterward. Written generically, not tied to any one specific framework.
+
+### Added
+
 - New project setting `source-reference` (`always` / `never` / `filtered: <criteria>`, default `never`) governs whether the skill actively asks for a related issue, ticket, PR, or post-mortem when recording a `context/` entry — distinct from rule 2's existing (passive) Source field. `filtered` criteria are free text the project defines itself, not a fixed taxonomy. Asking is never the same as requiring one to exist — "no reference" is a complete answer, never invented to fill the field. Project-wide only for now, no personal override, same precedent as `capture-confirmation`. See `context/repo-conventions.md`. Also documented in `README.md`, `llms.txt`, and `docs/faq.md`.
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ For any change to the skill's rules, workflow, or reference docs, check whether 
 
 1. Bump `metadata.version` in `skills/keep-the-why/SKILL.md` frontmatter
 2. Update the `Version:` line in `llms.txt` to match
-3. Update the `version` field in `plugin.json` to match
+3. Update the `version` field in `plugin.json` and `.claude-plugin/plugin.json` to match
 4. In `CHANGELOG.md`, rename `[Unreleased]` to `[x.y.z] - YYYY-MM-DD` and add a fresh empty `[Unreleased]` above it
 5. **Verify `skills/keep-the-why/references/migrations.md` already covers every `context/` format change since the last release** — this should already be true if step 3 of the pre-PR checklist was followed each time, but check before tagging, not after. This is the one that must never be found out of sync retroactively.
 6. This repo's own `context-schema` (in `AGENTS.md`) must never trail the version just released, same as `setup.md`'s "context-schema behind metadata.version" logic requires of any project: if something in `migrations.md` applies to `context/repo-conventions.md`, migrate it now (dogfooding the same process a user would go through), then advance `context-schema` to match. If nothing applies, still advance `context-schema` to match — don't leave it pointing at an older version just because there was nothing to migrate.

--- a/context/repo-conventions.md
+++ b/context/repo-conventions.md
@@ -155,3 +155,16 @@ New project setting `source-reference` (`always` / `never` / `filtered: <criteri
 **Rejected alternative (the `filtered` mechanism specifically):** a fixed taxonomy of filter categories (by topic file, by Status, by severity) defined by the skill. Rejected in favor of free text the project defines itself — a fixed taxonomy would be guessing at categories before there's real usage to learn from, the same reasoning already applied to keeping `capture-confirmation` project-wide-only for now (see above).
 
 **Consequence:** `always` (or a matching `filtered` criterion) means asking is mandatory, but a reference existing is not — "no, nothing tracks this" is a complete, valid answer. Inventing a plausible-sounding ticket reference to avoid an empty field would violate rule 1 exactly like inventing rationale would. No personal override in this release, same "test one setting before adding a second axis" precedent as `capture-confirmation`.
+
+## `.claude-plugin/plugin.json` is a second, separate manifest — not a replacement for the root `plugin.json`
+
+**Status:** active
+**Evidence:** confirmed
+
+Added `.claude-plugin/plugin.json` (the official Claude Code plugin manifest, verified against Anthropic's own `plugin.json` schema reference) alongside the existing root `plugin.json` (built for GitHub's Copilot CLI plugin marketplace format, see the `awesome-copilot` entries above). Two files, two different consumers, both needed.
+
+**Reason:** Claude Code and GitHub Copilot CLI each define their own plugin manifest format and expected file location — `.claude-plugin/plugin.json` versus a root-level `plugin.json` — and neither reads the other's. Consolidating into one file wasn't an option once both ecosystems mattered to us; each needs its own, correctly located manifest. Claude Code's schema has no `skills` field at all — skills are auto-discovered from a `skills/` (or `commands/`) directory at the plugin root by convention — unlike the Copilot CLI schema, which requires listing `skills` explicitly. This is why `.claude-plugin/plugin.json` doesn't need a `skills` field even though the root one does.
+
+**Rejected alternative:** try to find or invent one manifest format both ecosystems would accept. Rejected — not viable; the two schemas are independently defined by different vendors with different required fields and file locations. Maintaining two small, correctly-targeted manifests is simpler than fighting that.
+
+**Related:** the new "Composition with other skills" section in `SKILL.md` was written generically (no specific framework named) rather than tailored to any one methodology-style skill framework we might integrate with — the positioning (cross-cutting persistence, not a workflow orchestrator) is true regardless of which specific framework it's composed alongside, and naming one by name in the skill's own evergreen content would date quickly and read as an unearned endorsement or dependency.

--- a/skills/keep-the-why/SKILL.md
+++ b/skills/keep-the-why/SKILL.md
@@ -23,6 +23,10 @@ Four modes, all part of the same job:
 
 **When not to use it:** routine implementation detail, generic formatting or style changes, or anything already fully and obviously explained by the code. Not every change is a decision worth a `context/` entry — see rule 13's proportionality gate.
 
+## Composition with other skills
+
+Keep the Why is a cross-cutting persistence skill, not a development methodology or workflow orchestrator. When another skill or framework already governs *how* the work gets done — brainstorming, planning, systematic debugging, TDD, code review — follow that workflow first; this skill doesn't compete for that role. It observes the decisions, rejected alternatives, constraints, and discoveries produced along the way, and preserves only the rationale likely to matter beyond the current task. A design doc or implementation plan another skill produces is evidence to draw from, not something to duplicate — see rule 4 and "Which file does this belong in?" in `references/repository-structure.md`.
+
 ## Core rules
 
 1. **Never invent rationale.** If it can't be confirmed or reasonably inferred, say so — ask a focused question or mark it unknown, don't fill the gap with something plausible-sounding.


### PR DESCRIPTION
## Summary
- `.claude-plugin/plugin.json` — the official Claude Code plugin manifest, verified against Anthropic's own schema reference (`plugins-reference` docs). Separate from the root `plugin.json` (GitHub Copilot CLI format) — different vendors, different schemas, neither reads the other's file. No `skills` field needed here: Claude Code auto-discovers `skills/` by convention.
- New `SKILL.md` section "Composition with other skills" — positions Keep the Why as a cross-cutting persistence skill, not a workflow orchestrator, so it composes cleanly alongside methodology-style skill frameworks. Written generically, no specific framework named (avoids dating quickly or reading as an unearned endorsement/dependency).
- `context/repo-conventions.md` entry, `CHANGELOG.md`, and the release checklist in `CONTRIBUTING.md` now cover both `plugin.json` files' version bumps.

Groundwork only — not submitting to `obra/superpowers-marketplace` yet. That happens after actually validating compatibility in a real session (separate step).

## Test plan
- [x] `.claude-plugin/plugin.json` is valid JSON
- [x] `mkdocs build --strict` passes