### PR TITLE
Fix .claude-plugin/plugin.json: repository must be a string

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -7,10 +7,7 @@
     "url": "https://github.com/oliver-zehentleitner"
   },
   "homepage": "https://keepthewhy.com",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/oliver-zehentleitner/keep-the-why.git"
-  },
+  "repository": "https://github.com/oliver-zehentleitner/keep-the-why.git",
   "license": "MIT",
   "keywords": [
     "documentation",


### PR DESCRIPTION
`claude plugin validate .` (installed CLI 2.1.220) rejects the object form (`{type, url}`) with "expected string, received object" — the schema-reference doc I built PR #99 from apparently described a format the real validator doesn't accept. Fixed to a plain string, revalidated: passes.