### PR TITLE
Correct SkillsLLM listing status to Live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to this project are documented here. Format follows [Keep a 
 - New `SKILL.md` section "Composition with other skills": Keep the Why is a cross-cutting persistence skill, not a workflow orchestrator — when another skill already governs how work gets done, follow that workflow first and preserve only the rationale likely to matter afterward. Written generically, not tied to any one specific framework.
 - Submitted a manifest to the [ASM Registry](https://github.com/luongnv89/asm-registry) ([PR #5](https://github.com/luongnv89/asm-registry/pull/5)), pinned to `v0.5.2` — listed in the "Also listed on" tables in `README.md`, `docs/installation.md`, and `llms.txt`. Updating the pinned commit on future releases is now step 10 of the release checklist in `CONTRIBUTING.md`.
 
+### Changed
+
+- [SkillsLLM](https://skillsllm.com/skill/keep-the-why) listing status corrected from "Not eligible yet" to "Live" in the "Also listed on" tables — the prior "requires 100+ GitHub stars" note was wrong; SkillsLLM listed the skill unprompted at 11 stars, verified with a clean security scan.
+
 ### Added
 
 - New project setting `source-reference` (`always` / `never` / `filtered: <criteria>`, default `never`) governs whether the skill actively asks for a related issue, ticket, PR, or post-mortem when recording a `context/` entry — distinct from rule 2's existing (passive) Source field. `filtered` criteria are free text the project defines itself, not a fixed taxonomy. Asking is never the same as requiring one to exist — "no reference" is a complete answer, never invented to fill the field. Project-wide only for now, no personal override, same precedent as `capture-confirmation`. See `context/repo-conventions.md`. Also documented in `README.md`, `llms.txt`, and `docs/faq.md`.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Full install detail for every method, including tools without a skill runtime at
 | [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why) | Live | Backs the `npx skills add` install method above |
 | [GitHub Copilot plugin marketplace](https://github.com/github/awesome-copilot) | Ready for review — [Issue #2470](https://github.com/github/awesome-copilot/issues/2470) | External plugin submission, pinned to `v0.5.2` |
 | [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills) | Pending — [PR #850](https://github.com/VoltAgent/awesome-agent-skills/pull/850) | Requires "real community usage"; may be declined |
-| [SkillsLLM](https://skillsllm.com/) | Not eligible yet | Requires 100+ GitHub stars to submit |
+| [SkillsLLM](https://skillsllm.com/skill/keep-the-why) | Live | Verified, passed SkillsLLM's security scan |
 | [ASM Registry](https://github.com/luongnv89/asm-registry) | Pending — [PR #5](https://github.com/luongnv89/asm-registry/pull/5) | Manifest pinned to `v0.5.2`; installable via `asm install keep-the-why` once merged |
 
 ## Example

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,7 +37,7 @@ Either form prompts for which of its 70+ supported agents (Claude Code, Codex, O
 | [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why) | Live | Backs the `npx skills add` install method above |
 | [GitHub Copilot plugin marketplace](https://github.com/github/awesome-copilot) | Ready for review — [Issue #2470](https://github.com/github/awesome-copilot/issues/2470) | External plugin submission, pinned to `v0.5.2` |
 | [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills) | Pending — [PR #850](https://github.com/VoltAgent/awesome-agent-skills/pull/850) | Requires "real community usage"; may be declined |
-| [SkillsLLM](https://skillsllm.com/) | Not eligible yet | Requires 100+ GitHub stars to submit |
+| [SkillsLLM](https://skillsllm.com/skill/keep-the-why) | Live | Verified, passed SkillsLLM's security scan |
 | [ASM Registry](https://github.com/luongnv89/asm-registry) | Pending — [PR #5](https://github.com/luongnv89/asm-registry/pull/5) | Manifest pinned to `v0.5.2`; installable via `asm install keep-the-why` once merged |
 
 ## Also recommended: GitHub CLI

--- a/llms.txt
+++ b/llms.txt
@@ -88,7 +88,7 @@ needing to be told again.
   v0.5.2 — https://github.com/github/awesome-copilot/issues/2470
 - awesome-agent-skills: pending review — requires "real community usage", may be declined —
   https://github.com/VoltAgent/awesome-agent-skills/pull/850
-- SkillsLLM: not eligible yet, requires 100+ GitHub stars — https://skillsllm.com/
+- SkillsLLM: live, verified, passed security scan — https://skillsllm.com/skill/keep-the-why
 - ASM Registry: pending — manifest pinned to v0.5.2, installable via `asm install keep-the-why`
   once merged — https://github.com/luongnv89/asm-registry/pull/5
 


### PR DESCRIPTION
Checked https://skillsllm.com/skill/keep-the-why — we're already listed: Verified status, clean security scan (npm/pip audit, prompt-injection checks), 11 GitHub stars, added 7/28/2026.

The "Also listed on" tables said "Not eligible yet — Requires 100+ GitHub stars to submit", which turned out to be wrong — SkillsLLM listed the skill without us submitting anything, and without meeting that star count. Corrects `README.md`, `docs/installation.md`, and `llms.txt` to "Live" with the direct listing link, plus a `CHANGELOG.md` entry.