### PR TITLE
Full consistency audit: fix two stragglers the positioning sweep missed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+### Fixed
+
+- Full project-wide consistency audit after the positioning sweep. Found and fixed two stragglers the sweep missed: `mkdocs.yml`'s `site_description` (feeds keepthewhy.com's meta description and social preview cards via `overrides/main.html`) still had the old "is a repo-native agent skill" wording; `CONTRIBUTING.md` still referred to a "prior-art comparison in the README" — stale since the README's "Related work" section deliberately dropped name-by-name comparisons. Everything else checked clean: version numbers (`SKILL.md`, `llms.txt`, both `plugin.json` files, `context-schema`) match at 0.6.0 everywhere; "Also listed on" tables are identical across `README.md`, `docs/installation.md`, and `llms.txt`, and all four tracked external submissions were re-verified live; `mkdocs build --strict`, Link Check, and Validate Skill all pass on `main`.
+
 ### Changed
 
 - Repositioned Keep the Why as "a repo-native convention and agent skill," not just "an agent skill" — the previous framing throughout (README hero, `llms.txt`'s blockquote, README's "How it works", `docs/philosophy.md`'s closing summary, `docs/installation.md`'s opener, and the generated `context/README.md` template embedded in `setup.md`, `examples/first-time-setup.md`, and this repo's own `context/README.md`) defined it as the skill itself, undermining the point that the skill is one half of an open convention, not the whole thing. Standardized on "repo-native" over "repository-native" (the existing majority spelling) while at it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ The installable skill package lives under `skills/keep-the-why/` (SKILL.md, refe
 - Sharper wording in `skills/keep-the-why/SKILL.md` itself, especially anything that makes the Evidence (confirmed / inferred / unknown) or Status (active / superseded / open / needs-review) classification more reliable in practice.
 - Additional eval cases in `skills/keep-the-why/evals/evals.json` — particularly failure modes you've hit (hallucinated rationale, generic interview questions, index bloat) that aren't covered yet.
 - **Cross-agent test results.** The evals exist, but nobody's run the full set against Claude Code, Codex CLI, and Gemini CLI yet and published the results — that's a real gap, not something this project claims to have done. If you run the evals against an agent, open an issue or PR with what you found (pass/fail per case, agent, and version) — that's exactly the kind of verified claim worth adding to the README once there's actual data behind it.
-- Corrections to the prior-art comparison in the README — if something is inaccurate or missing, say so.
+- Corrections to the README's "Related work" section — if something is inaccurate or missing, say so.
 
 ## What to avoid
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Keep the Why
-site_description: Keep the Why is a repo-native agent skill that captures the reasoning behind a codebase as a byproduct of working with your agent — so it stops re-suggesting rejected approaches, gives better answers, speeds up onboarding, and makes legacy projects tractable again.
+site_description: Keep the Why is a repo-native convention and agent skill that preserves the reasoning behind a codebase as a byproduct of working with your agent — so it stops re-suggesting rejected approaches, gives better answers, speeds up onboarding, and makes legacy projects tractable again.
 site_url: https://keepthewhy.com
 repo_url: https://github.com/oliver-zehentleitner/keep-the-why
 repo_name: oliver-zehentleitner/keep-the-why


### PR DESCRIPTION
## Summary
Full project-wide audit as requested. Checked: version numbers, "Also listed on" tables across all three files (with live status re-verification), positioning terminology, CONTRIBUTING.md checklist accuracy against actual repo structure, mkdocs nav completeness, all include-wrapper pages, badge snippet, CI status.

Found two stragglers from the positioning sweep:
- `mkdocs.yml`'s `site_description` — feeds keepthewhy.com's `<meta name="description">` and OG/Twitter cards via `overrides/main.html`, still said "is a repo-native agent skill"
- `CONTRIBUTING.md` — referenced a "prior-art comparison in the README" that no longer exists (README's "Related work" deliberately dropped name-by-name comparisons)

Everything else came back clean - see CHANGELOG entry for the full list of what was checked.

## Test plan
- [x] `mkdocs build --strict` passes
- [x] Link Check and Validate Skill both green on current `main`
- [x] Re-verified live status of all four tracked external submissions (awesome-copilot #2470, ASM Registry PR #5, awesome-agent-skills PR #850, superpowers #2051) - all still open, tables accurate