### PR TITLE
README: AGENTS.md row also names plain agent instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+### Changed
+
+- README's "Where this fits" table: `AGENTS.md`'s row now also names plain rules the agent should just follow (no rationale attached), matching the "Working conventions" section added to this repo's own `AGENTS.md`.
+
 ### Added
 
 - Added a "Working conventions" section to `AGENTS.md`, separate from the keep-the-why config block, for plain rules that need no rationale (currently: CHANGELOG heading/ordering).

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ A project's documentation is one coherent group of files, not a single practice:
 | File | Answers | Artifact |
 |---|---|---|
 | README | "What is this, and should I care?" | `README.md` |
-| `AGENTS.md` | "Where do I look, if I'm an agent working in this repo?" | `AGENTS.md` |
+| `AGENTS.md` | "Where do I look, if I'm an agent working in this repo?" — plus any rule the agent should just follow, no rationale attached | `AGENTS.md` |
 | `docs/` | "How do I use or operate this?" | usage docs |
 | `CONTRIBUTING.md` | "How do I contribute to this?" | contribution guide |
 | Tests | "Did I just break something?" | test suite |


### PR DESCRIPTION
Matches the "Working conventions" section already added to this repo's own AGENTS.md (rules the agent should just follow, no rationale attached) - README's routing table didn't mention that use case at all.