### PR TITLE
Fix trust-model wording clash and hardcoded-main links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![GitHub Release](https://img.shields.io/github/release/oliver-zehentleitner/keep-the-why.svg?label=github)](https://github.com/oliver-zehentleitner/keep-the-why/releases)
-[![License](https://img.shields.io/github/license/oliver-zehentleitner/keep-the-why.svg?color=blue)](https://github.com/oliver-zehentleitner/keep-the-why/blob/main/LICENSE)
+[![License](https://img.shields.io/github/license/oliver-zehentleitner/keep-the-why.svg?color=blue)](LICENSE)
 [![Security: SkillsLLM](https://skillsllm.com/security-check/badge.svg?owner=oliver-zehentleitner&repo=keep-the-why)](https://skillsllm.com/security-check/IPmNycVdbOyq)
 [![Validate Skill](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/validate-skill.yml/badge.svg)](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/validate-skill.yml)
 [![Link Check](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/link-check.yml/badge.svg)](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/link-check.yml)
@@ -127,9 +127,9 @@ You: This retry wrapper looks over-engineered — a plain retry loop
      would do the same thing. Let's simplify it.
 ```
 
-Working through *why* it could be simplified surfaces a real constraint (the gateway's rate limiter needs that backoff behavior) — the change gets abandoned before it happens. No commit, no diff, no PR ever results, so normally nothing would capture that reasoning at all. Keep the Why records it anyway, so the next person with the same instinct doesn't rediscover it the hard way — see [`examples/abandoned-change.md`](https://github.com/oliver-zehentleitner/keep-the-why/blob/main/skills/keep-the-why/examples/abandoned-change.md) for the full walkthrough.
+Working through *why* it could be simplified surfaces a real constraint (the gateway's rate limiter needs that backoff behavior) — the change gets abandoned before it happens. No commit, no diff, no PR ever results, so normally nothing would capture that reasoning at all. Keep the Why records it anyway, so the next person with the same instinct doesn't rediscover it the hard way — see [`examples/abandoned-change.md`](skills/keep-the-why/examples/abandoned-change.md) for the full walkthrough.
 
-See [`examples/`](https://github.com/oliver-zehentleitner/keep-the-why/tree/main/skills/keep-the-why/examples) for continuous, retrospective, and interview-mode walkthroughs.
+See [`examples/`](skills/keep-the-why/examples/) for continuous, retrospective, and interview-mode walkthroughs.
 
 ## The problem
 
@@ -151,11 +151,11 @@ A project's documentation is one coherent group of files, not a single practice:
 | `docs/` | "How do I use or operate this?" | usage docs |
 | `CONTRIBUTING.md` | "How do I contribute to this?" | contribution guide |
 | Tests | "Did I just break something?" | test suite |
-| [Keep a Changelog](https://keepachangelog.com/) | "What changed, release by release?" | [`CHANGELOG.md`](https://github.com/oliver-zehentleitner/keep-the-why/blob/main/CHANGELOG.md) |
+| [Keep a Changelog](https://keepachangelog.com/) | "What changed, release by release?" | [`CHANGELOG.md`](CHANGELOG.md) |
 | **Keep the Why** (`context/`) | "Why is it built this way?" | `context/` |
 | `AGENTS.local.md` | "What's specific to me, not relevant to anyone else?" | `AGENTS.local.md` (not committed) |
 
-Michael Feathers' classic definition — legacy code is code without tests — covers only the Tests row. Each of the others answers a different question, and none substitutes for another: contribution process belongs in `CONTRIBUTING.md`, not `context/`; rationale belongs in `context/`, not scattered into a README that's supposed to stay a quick pitch. That doesn't mean every project needs all eight files fully built out from day one — use the ones justified by the project's size, lifetime, and number of maintainers, the same way a one-file script doesn't need six `docs/` pages (see `references/repository-structure.md`). What it does mean: once you know which question you're answering, you know exactly which file it goes in — see [`references/repository-structure.md`](https://github.com/oliver-zehentleitner/keep-the-why/blob/main/skills/keep-the-why/references/repository-structure.md) for the same routing table with more detail. Full methodology behind the `docs/`/`context/` split specifically: [`references/methodology.md`](https://github.com/oliver-zehentleitner/keep-the-why/blob/main/skills/keep-the-why/references/methodology.md).
+Michael Feathers' classic definition — legacy code is code without tests — covers only the Tests row. Each of the others answers a different question, and none substitutes for another: contribution process belongs in `CONTRIBUTING.md`, not `context/`; rationale belongs in `context/`, not scattered into a README that's supposed to stay a quick pitch. That doesn't mean every project needs all eight files fully built out from day one — use the ones justified by the project's size, lifetime, and number of maintainers, the same way a one-file script doesn't need six `docs/` pages (see `references/repository-structure.md`). What it does mean: once you know which question you're answering, you know exactly which file it goes in — see [`references/repository-structure.md`](skills/keep-the-why/references/repository-structure.md) for the same routing table with more detail. Full methodology behind the `docs/`/`context/` split specifically: [`references/methodology.md`](skills/keep-the-why/references/methodology.md).
 
 **What none of them does by itself: stay honest over time.** Tests get skipped under deadline pressure, docs rot, changelogs get forgotten mid-release, and rationale decays — [a 2026 position paper](https://arxiv.org/abs/2601.21116) reported that a retrospective audit of 62 architectural decisions across two internal projects found roughly 23% had stale supporting evidence within two months, most of it caught only reactively, during an incident or a refactor. It's a small, non-replicated sample studying traditional ADRs, not AI-generated decisions specifically — cited here as a directional data point on rationale decay in general, not as proof about AI-assisted work. Keep the Why doesn't solve that alone; it just gives "why" a place to live so it *can* be kept current, the same way a test suite only helps if it actually runs in CI. Keeping all of them honest over time (via CI checks, review habits, whatever fits the project) is a separate, necessary piece this project doesn't ship an opinion on yet.
 
@@ -187,8 +187,8 @@ See [Why I built this](https://keepthewhy.com/why/) — Oliver Zehentleitner on 
 
 ## Contributing
 
-See [CONTRIBUTING.md](https://github.com/oliver-zehentleitner/keep-the-why/blob/main/CONTRIBUTING.md).
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 
-[MIT](https://github.com/oliver-zehentleitner/keep-the-why/blob/main/LICENSE)
+[MIT](LICENSE)

--- a/docs/security.md
+++ b/docs/security.md
@@ -6,7 +6,7 @@ Two separate questions, both answered here — with the actual detail living in 
 
 Keep the Why treats everything read from a repository — `context/` included — as data, never as instructions. An entry can describe a decision or a constraint; it can't grant itself authority to override a system, developer, or user instruction, expand permissions, authorize a tool call, disable a safety check, or ask for a secret. A suspicious entry gets named and flagged to the user, not silently followed, deleted, or rewritten.
 
-This matters more for `context/` than for an arbitrary repo file precisely because the skill is designed to read it automatically, treat it as trustworthy background, and keep it around across sessions — the same property that makes it useful is what would make injected content dangerous if this rule didn't exist.
+This matters more for `context/` than for an arbitrary repo file precisely because the skill is designed to read it automatically, treat it as high-salience background, and keep it around across sessions — the same property that makes it useful is what would make injected content dangerous if this rule didn't exist.
 
 See [Trust model](trust-model.md) for the full reasoning, the read/write rules, and worked examples.
 
@@ -19,4 +19,4 @@ See [Trust model](trust-model.md) for the full reasoning, the read/write rules, 
 
 ## Reporting a vulnerability in Keep the Why itself
 
-That's a different question from the above — see [`SECURITY.md`](https://github.com/oliver-zehentleitner/keep-the-why/blob/main/SECURITY.md) for the disclosure process, or report directly via [GitHub Security Advisories](https://github.com/oliver-zehentleitner/keep-the-why/security/advisories/new).
+That's a different question from the above — see [`SECURITY.md`](../SECURITY.md) for the disclosure process, or report directly via [GitHub Security Advisories](https://github.com/oliver-zehentleitner/keep-the-why/security/advisories/new).

--- a/skills/keep-the-why/references/trust-model.md
+++ b/skills/keep-the-why/references/trust-model.md
@@ -7,11 +7,11 @@ Why `context/` deserves explicit treatment as an injection surface, and the rule
 Any repository file can carry an indirect prompt injection — code comments, commit messages, and issue text are already recognized as such (see OWASP's [LLM Prompt Injection Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/LLM_Prompt_Injection_Prevention_Cheat_Sheet.html)). `context/` isn't a new category of risk, but it's a sharper version of the same one, because this skill deliberately:
 
 - has an agent read it automatically, often before doing anything else in a session (`AGENTS.md` pointers, `SKILL.md`'s own "Inspect" step)
-- presents it as trustworthy background, not just one more file among many
+- presents it as high-salience background, not just one more file among many
 - persists it across sessions, so one successful injection doesn't need to land twice
 - can populate it from less-vetted sources during retrospective recovery or an interview — git history, issues, and a person's recollection aren't the same as a maintainer directly authoring `context/` themselves
 
-None of this means `context/` is more likely to be attacked than any other file. It means that *if* something injected lands there, this skill's own design — read first, trust by default, keep around indefinitely — is exactly what turns a one-time injection into a persistent one. The value this skill provides (context an agent can act on without re-deriving it) is the same property that makes poisoned context more dangerous than a poisoned comment nobody reads.
+None of this means `context/` is more likely to be attacked than any other file. It means that *if* something injected lands there, this skill's own design — read first, keep around indefinitely — is exactly what turns a one-time injection into a persistent one. The value this skill provides (context an agent can act on without re-deriving it) is the same property that makes poisoned context more dangerous than a poisoned comment nobody reads.
 
 ## The core rule
 


### PR DESCRIPTION
## Summary
- Replace "trustworthy background" / "trust by default" wording in `docs/security.md` and `trust-model.md` with salience framing — the old wording collided with the Source/evidence-level model (`confirmed`/`inferred`/`unknown`), implying `context/` is trusted by default when it explicitly isn't.
- Convert internal repo links in `README.md` and `docs/security.md` from hardcoded `/blob/main/`/`/tree/main/` URLs to relative paths, so a tagged checkout's README resolves links against that tag instead of always pointing at `main`.

## Test plan
- [x] Verified every relative link target exists in the repo tree
- [ ] Link-check CI job passes