### PR TITLE
Promote context/ format to README; fix mkdocs build broken by #116

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![GitHub Release](https://img.shields.io/github/release/oliver-zehentleitner/keep-the-why.svg?label=github)](https://github.com/oliver-zehentleitner/keep-the-why/releases)
-[![License](https://img.shields.io/github/license/oliver-zehentleitner/keep-the-why.svg?color=blue)](LICENSE)
+[![License](https://img.shields.io/github/license/oliver-zehentleitner/keep-the-why.svg?color=blue)](https://github.com/oliver-zehentleitner/keep-the-why/blob/latest/LICENSE)
 [![Security: SkillsLLM](https://skillsllm.com/security-check/badge.svg?owner=oliver-zehentleitner&repo=keep-the-why)](https://skillsllm.com/security-check/IPmNycVdbOyq)
 [![Validate Skill](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/validate-skill.yml/badge.svg)](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/validate-skill.yml)
 [![Link Check](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/link-check.yml/badge.svg)](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/link-check.yml)
@@ -127,9 +127,9 @@ You: This retry wrapper looks over-engineered — a plain retry loop
      would do the same thing. Let's simplify it.
 ```
 
-Working through *why* it could be simplified surfaces a real constraint (the gateway's rate limiter needs that backoff behavior) — the change gets abandoned before it happens. No commit, no diff, no PR ever results, so normally nothing would capture that reasoning at all. Keep the Why records it anyway, so the next person with the same instinct doesn't rediscover it the hard way — see [`examples/abandoned-change.md`](skills/keep-the-why/examples/abandoned-change.md) for the full walkthrough.
+Working through *why* it could be simplified surfaces a real constraint (the gateway's rate limiter needs that backoff behavior) — the change gets abandoned before it happens. No commit, no diff, no PR ever results, so normally nothing would capture that reasoning at all. Keep the Why records it anyway, so the next person with the same instinct doesn't rediscover it the hard way — see [`examples/abandoned-change.md`](https://github.com/oliver-zehentleitner/keep-the-why/blob/latest/skills/keep-the-why/examples/abandoned-change.md) for the full walkthrough.
 
-See [`examples/`](skills/keep-the-why/examples/) for continuous, retrospective, and interview-mode walkthroughs.
+See [`examples/`](https://github.com/oliver-zehentleitner/keep-the-why/tree/latest/skills/keep-the-why/examples) for continuous, retrospective, and interview-mode walkthroughs.
 
 ## The problem
 
@@ -151,15 +151,31 @@ A project's documentation is one coherent group of files, not a single practice:
 | `docs/` | "How do I use or operate this?" | usage docs |
 | `CONTRIBUTING.md` | "How do I contribute to this?" | contribution guide |
 | Tests | "Did I just break something?" | test suite |
-| [Keep a Changelog](https://keepachangelog.com/) | "What changed, release by release?" | [`CHANGELOG.md`](CHANGELOG.md) |
+| [Keep a Changelog](https://keepachangelog.com/) | "What changed, release by release?" | [`CHANGELOG.md`](https://github.com/oliver-zehentleitner/keep-the-why/blob/latest/CHANGELOG.md) |
 | **Keep the Why** (`context/`) | "Why is it built this way?" | `context/` |
 | `AGENTS.local.md` | "What's specific to me, not relevant to anyone else?" | `AGENTS.local.md` (not committed) |
 
-Michael Feathers' classic definition — legacy code is code without tests — covers only the Tests row. Each of the others answers a different question, and none substitutes for another: contribution process belongs in `CONTRIBUTING.md`, not `context/`; rationale belongs in `context/`, not scattered into a README that's supposed to stay a quick pitch. That doesn't mean every project needs all eight files fully built out from day one — use the ones justified by the project's size, lifetime, and number of maintainers, the same way a one-file script doesn't need six `docs/` pages (see `references/repository-structure.md`). What it does mean: once you know which question you're answering, you know exactly which file it goes in — see [`references/repository-structure.md`](skills/keep-the-why/references/repository-structure.md) for the same routing table with more detail. Full methodology behind the `docs/`/`context/` split specifically: [`references/methodology.md`](skills/keep-the-why/references/methodology.md).
+Michael Feathers' classic definition — legacy code is code without tests — covers only the Tests row. Each of the others answers a different question, and none substitutes for another: contribution process belongs in `CONTRIBUTING.md`, not `context/`; rationale belongs in `context/`, not scattered into a README that's supposed to stay a quick pitch. That doesn't mean every project needs all eight files fully built out from day one — use the ones justified by the project's size, lifetime, and number of maintainers, the same way a one-file script doesn't need six `docs/` pages (see `references/repository-structure.md`). What it does mean: once you know which question you're answering, you know exactly which file it goes in — see [`references/repository-structure.md`](https://keepthewhy.com/repository-structure/) for the same routing table with more detail. Full methodology behind the `docs/`/`context/` split specifically: [`references/methodology.md`](https://keepthewhy.com/methodology/).
 
 **What none of them does by itself: stay honest over time.** Tests get skipped under deadline pressure, docs rot, changelogs get forgotten mid-release, and rationale decays — [a 2026 position paper](https://arxiv.org/abs/2601.21116) reported that a retrospective audit of 62 architectural decisions across two internal projects found roughly 23% had stale supporting evidence within two months, most of it caught only reactively, during an incident or a refactor. It's a small, non-replicated sample studying traditional ADRs, not AI-generated decisions specifically — cited here as a directional data point on rationale decay in general, not as proof about AI-assisted work. Keep the Why doesn't solve that alone; it just gives "why" a place to live so it *can* be kept current, the same way a test suite only helps if it actually runs in CI. Keeping all of them honest over time (via CI checks, review habits, whatever fits the project) is a separate, necessary piece this project doesn't ship an opinion on yet.
 
 This isn't a new pattern, either. Docs and changelogs are already commonly kept current almost incidentally today, maintained by a skill or an agent alongside the actual work rather than as separate effort. Keep the Why brings that same low-effort, agent-maintained model to the one layer that couldn't be kept current this way before: the why.
+
+## Format
+
+`context/` entries follow the same shape whether written by hand, by this skill, or by any other tool speaking the convention — a small set of fields, not a fixed template:
+
+| Field | Meaning |
+|---|---|
+| Decision / behavior | What was actually done |
+| Rejected alternative(s) | What else was considered, and why it lost |
+| Reason | Why the chosen path won |
+| **Status** | `active` \| `superseded` \| `open` \| `needs-review` |
+| **Evidence** | `confirmed` \| `inferred` \| `unknown` — how certain the rationale is |
+| Source | Where the rationale came from (interview, issue, commit, postmortem) |
+| Revisit when | A concrete trigger that should prompt re-checking the entry |
+
+Not every field belongs on every entry — Status, Evidence, and the rejected alternative carry the most weight even in a minimal one. Full spec and a worked example: [`references/repository-structure.md`](https://keepthewhy.com/repository-structure/).
 
 ## Related work
 
@@ -187,8 +203,8 @@ See [Why I built this](https://keepthewhy.com/why/) — Oliver Zehentleitner on 
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md).
+See [CONTRIBUTING.md](https://github.com/oliver-zehentleitner/keep-the-why/blob/latest/CONTRIBUTING.md).
 
 ## License
 
-[MIT](LICENSE)
+[MIT](https://github.com/oliver-zehentleitner/keep-the-why/blob/latest/LICENSE)

--- a/docs/security.md
+++ b/docs/security.md
@@ -19,4 +19,4 @@ See [Trust model](trust-model.md) for the full reasoning, the read/write rules, 
 
 ## Reporting a vulnerability in Keep the Why itself
 
-That's a different question from the above — see [`SECURITY.md`](../SECURITY.md) for the disclosure process, or report directly via [GitHub Security Advisories](https://github.com/oliver-zehentleitner/keep-the-why/security/advisories/new).
+That's a different question from the above — see [`SECURITY.md`](https://github.com/oliver-zehentleitner/keep-the-why/blob/latest/SECURITY.md) for the disclosure process, or report directly via [GitHub Security Advisories](https://github.com/oliver-zehentleitner/keep-the-why/security/advisories/new).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
   - Overview: index.md
   - Philosophy: philosophy.md
   - Installation: installation.md
+  - Repository structure: repository-structure.md
   - Security: security.md
   - Badge: badge.md
   - FAQ: faq.md
@@ -54,7 +55,6 @@ nav:
       - Setup: setup.md
       - Migrations: migrations.md
       - Methodology: methodology.md
-      - Repository structure: repository-structure.md
       - Continuous capture: continuous-capture.md
       - Retrospective analysis: retrospective-analysis.md
       - Interview playbook: interview-playbook.md


### PR DESCRIPTION
## Summary
- Add a "Format" section to the README documenting the `context/` entry fields (Status, Evidence, Source, Revisit when, ...) directly — so the format is discoverable without installing the skill, matching the "repo-native convention, not just an agent skill" framing.
- Promote "Repository structure" from the nested Reference nav group to top-level, since it's the format spec, not skill-usage detail.
- **Fixes a live regression from #116**: converting links to relative repo paths fixed GitHub tag-view drift but broke the "Deploy docs" GitHub Action — `docs/index.md` embeds `README.md` via include-markdown, and mkdocs validates `.md` links against its own `docs_dir` tree; links to files outside it (`LICENSE`, `CHANGELOG.md`, `skills/keep-the-why/examples/**`) came back "not found" and failed `mkdocs build --strict`. The workflow has been failing on `main` since #116 merged. The relative paths also produced literal dead hrefs on the published site.

## Fix
Link to the `latest` tag (already the project's own recommended pin — see the Install section) instead of `main` or a bare relative path. Resolves correctly on GitHub and in the built site, without drifting to arbitrary in-development content the way `/blob/main/` did. Files also mirrored as their own docs pages (`repository-structure.md`, `methodology.md`) link to their `keepthewhy.com` URL instead — correct everywhere, not tag-dependent at all.

## Test plan
- [x] `mkdocs build --strict` passes locally with zero warnings
- [x] Verified rendered `href`s in `site/index.html` and `site/security/index.html` all resolve to real targets
- [ ] "Deploy docs" GitHub Action goes green again after merge