### PR TITLE
Cross-link the SkillsLLM security scan from Security and Install

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Full install detail for every method, including tools without a skill runtime at
 | Name | Status | Info |
 |---|---|---|
 | [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why) | Live | Backs the `npx skills add` install method above |
-| [SkillsLLM](https://skillsllm.com/skill/keep-the-why) | Live | Verified, passed SkillsLLM's security scan |
+| [SkillsLLM](https://skillsllm.com/skill/keep-the-why) | Live | Verified, passed [SkillsLLM's security scan](https://skillsllm.com/security-check/IPmNycVdbOyq) |
 | [ASM Registry](https://github.com/luongnv89/asm-registry) | Pending — [PR #5](https://github.com/luongnv89/asm-registry/pull/5) | Manifest pinned to `v0.5.2`; installable via `asm install keep-the-why` once merged |
 | [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills) | Pending — [PR #850](https://github.com/VoltAgent/awesome-agent-skills/pull/850) | Requires "real community usage"; may be declined |
 | [GitHub Copilot plugin marketplace](https://github.com/github/awesome-copilot) | Ready for review — [Issue #2470](https://github.com/github/awesome-copilot/issues/2470) | External plugin submission, pinned to `v0.5.2` |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -35,7 +35,7 @@ Either form prompts for which of its 70+ supported agents (Claude Code, Codex, O
 | Name | Status | Info |
 |---|---|---|
 | [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why) | Live | Backs the `npx skills add` install method above |
-| [SkillsLLM](https://skillsllm.com/skill/keep-the-why) | Live | Verified, passed SkillsLLM's security scan |
+| [SkillsLLM](https://skillsllm.com/skill/keep-the-why) | Live | Verified, passed [SkillsLLM's security scan](https://skillsllm.com/security-check/IPmNycVdbOyq) |
 | [ASM Registry](https://github.com/luongnv89/asm-registry) | Pending — [PR #5](https://github.com/luongnv89/asm-registry/pull/5) | Manifest pinned to `v0.5.2`; installable via `asm install keep-the-why` once merged |
 | [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills) | Pending — [PR #850](https://github.com/VoltAgent/awesome-agent-skills/pull/850) | Requires "real community usage"; may be declined |
 | [GitHub Copilot plugin marketplace](https://github.com/github/awesome-copilot) | Ready for review — [Issue #2470](https://github.com/github/awesome-copilot/issues/2470) | External plugin submission, pinned to `v0.5.2` |
@@ -48,7 +48,7 @@ With [`gh`](https://cli.github.com/) v2.90.0 or later — `gh skill` is [in publ
 gh skill preview oliver-zehentleitner/keep-the-why keep-the-why
 ```
 
-GitHub's own guidance: skills aren't verified by GitHub and may contain prompt injections, hidden instructions, or malicious scripts — inspect before installing. Keep the Why ships instructions only, no executable scripts. Then, pinned to a release:
+GitHub's own guidance: skills aren't verified by GitHub and may contain prompt injections, hidden instructions, or malicious scripts — inspect before installing. Keep the Why ships instructions only, no executable scripts; see [Security](security.md) for what that means in practice, including an independent SkillsLLM scan. Then, pinned to a release:
 
 ```bash
 gh skill install oliver-zehentleitner/keep-the-why keep-the-why@latest

--- a/docs/security.md
+++ b/docs/security.md
@@ -17,6 +17,10 @@ See [Trust model](trust-model.md) for the full reasoning, the read/write rules, 
 - Actions with real side effects still go through whatever the agent running the skill already requires — permission prompts, sandboxing, trust verification. Keep the Why doesn't add a separate permission layer, and doesn't assume those mechanisms are bulletproof either.
 - `context/` is committed alongside the code, reviewed the same way — a change to it is as visible in a diff or a pull request as any other change.
 
+## Independent verification
+
+Beyond this document's own reasoning: [SkillsLLM](https://skillsllm.com/skill/keep-the-why) ran an automated security scan against the skill package and marked it **Verified** — see the [scan report](https://skillsllm.com/security-check/IPmNycVdbOyq) for what it checked. A second opinion, not a substitute for reading `SKILL.md` yourself.
+
 ## Reporting a vulnerability in Keep the Why itself
 
 That's a different question from the above — see [`SECURITY.md`](https://github.com/oliver-zehentleitner/keep-the-why/blob/latest/SECURITY.md) for the disclosure process, or report directly via [GitHub Security Advisories](https://github.com/oliver-zehentleitner/keep-the-why/security/advisories/new).


### PR DESCRIPTION
## Summary
- `docs/security.md`: new "Independent verification" section pointing to the SkillsLLM scan report — the README already carries the badge, but the security page itself said nothing about it.
- `docs/installation.md`: the GitHub-CLI section already warns that skills aren't GitHub-verified — that sentence now points to our own Security page, which links onward to the scan.
- Both "Also listed on" tables (README + `docs/installation.md`): "security scan" is now a direct link to the scan report instead of unlinked text.

## Test plan
- [x] `mkdocs build --strict` passes locally