### PR TITLE
Release 0.6.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "keep-the-why",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Preserves or recovers the reasoning behind a codebase - decisions, rejected alternatives, workarounds, and incident learnings the code alone can't explain.",
   "author": {
     "name": "Oliver Zehentleitner",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ there before re-litigating or accidentally reverting a decision.
 <!-- keep-the-why:config -->
 - context: `context/`
 - init: complete
-- context-schema: 0.6.1
+- context-schema: 0.6.2
 - capture-confirmation: confirm-always
 - source-reference: never
 <!-- /keep-the-why:config -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,27 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-07-31
+
+### Added
+
+- "Format" section in README documenting `context/` entry fields (Status, Evidence, Source, Revisit when, ...) directly — discoverable without installing the skill, matching the "repo-native convention, not just an agent skill" framing.
+- "Independent verification" section in `docs/security.md`, linking to the SkillsLLM security scan report.
+
 ### Changed
 
+- `docs/installation.md`'s GitHub-CLI warning about unverified skills now points to `docs/security.md`, which links onward to the SkillsLLM scan; both "Also listed on" tables link "security scan" directly to the scan report.
+- Promoted "Repository structure" from the nested Reference nav group to top-level in `mkdocs.yml`'s nav, since it documents the `context/` format, not skill-usage detail.
+- Replaced "trustworthy background" / "trust by default" wording in `docs/security.md` and `references/trust-model.md` with salience framing — the previous wording collided with the Source/evidence-level model (`confirmed`/`inferred`/`unknown`), implying `context/` is trusted by default when it explicitly isn't.
 - Split `context/repo-conventions.md` (187 lines, five unrelated topics in one file) into `context/release-and-distribution.md`, `context/config-format.md`, `context/positioning.md`, and `context/compatibility.md` — rule 5 (organize by topic) and rule 8 (split large files) applied to this repo's own `context/`, not just advice given to others. All cross-references (`CONTRIBUTING.md`, `references/setup.md`, `docs/faq.md`, `mkdocs.yml` nav, `docs/context/*.md`) updated to match.
 
 ### Removed
 
 - The "Launch-readiness pass" entry in `context/repo-conventions.md` (SKILL.md trimmed, negative evals added, README reordered ahead of the initial launch). On review, none of the four bundled changes had a real rejected alternative — all four were corrections made in response to external review feedback, which rule 6 already excludes from `context/` regardless of significance. The "what happened" is already covered by the `[0.1.0]` entry below.
+
+### Fixed
+
+- Internal links in `README.md` and `docs/security.md` hardcoded to `/blob/main/` (so a tagged checkout's README could show newer, unreleased `main` content instead of that tag's own) — changed to `/blob/latest/` (the project's own recommended pin) or, for pages also mirrored on the docs site (`repository-structure.md`, `methodology.md`), to their `keepthewhy.com` URL. An intermediate fix using bare relative paths broke the "Deploy docs" GitHub Action (`mkdocs build --strict` validates `.md` links against its own `docs_dir`, and these point outside it) — caught and corrected before release.
 
 ## [0.6.1] - 2026-07-30
 
@@ -227,7 +241,13 @@ Initial release.
 - Logo, wordmark, and favicon.
 - `context/repo-conventions.md`, dogfooding the skill on its own repository from day one.
 
-[Unreleased]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.4.2...HEAD
+[Unreleased]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.6.2...HEAD
+[0.6.2]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.6.1...v0.6.2
+[0.6.1]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.5.2...v0.6.0
+[0.5.2]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.5.1...v0.5.2
+[0.5.1]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.4.2...v0.5.0
 [0.4.2]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.3.1...v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,8 +241,7 @@ Initial release.
 - Logo, wordmark, and favicon.
 - `context/repo-conventions.md`, dogfooding the skill on its own repository from day one.
 
-[Unreleased]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.6.2...HEAD
-[0.6.2]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.6.1...v0.6.2
+[Unreleased]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.6.1...HEAD
 [0.6.1]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.5.2...v0.6.0
 [0.5.2]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.5.1...v0.5.2

--- a/llms.txt
+++ b/llms.txt
@@ -30,7 +30,7 @@ get thrown away, not creating separate documentation effort. It isn't magic, tho
 prevents knowledge from decaying on its own. This lowers the friction of the discipline that
 keeps documentation honest; it doesn't replace it.
 
-Version: 0.6.1.
+Version: 0.6.2.
 
 ## Authorship & License
 

--- a/llms.txt
+++ b/llms.txt
@@ -227,5 +227,5 @@ HTML equivalent and details: https://keepthewhy.com/badge/
 - Trust model (context/ as data, not instructions): https://keepthewhy.com/trust-model/
 - Badge: https://keepthewhy.com/badge/
 - Philosophy (why no database/daemon/dashboard, deliberately): https://keepthewhy.com/philosophy/
-- Why this project is built this way: https://keepthewhy.com/context/repo-conventions/
+- Why this project is built this way (release/distribution, config format, positioning, compatibility): https://keepthewhy.com/context/release-and-distribution/, https://keepthewhy.com/context/config-format/, https://keepthewhy.com/context/positioning/, https://keepthewhy.com/context/compatibility/
 - Article — origin story and full comparison to prior art: https://blog.technopathy.club/keep-the-why-code-becomes-legacy-when-nobody-remembers-why

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "keep-the-why",
   "description": "Preserves or recovers the reasoning behind a codebase - architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": {
     "name": "Oliver Zehentleitner"
   },

--- a/skills/keep-the-why/SKILL.md
+++ b/skills/keep-the-why/SKILL.md
@@ -3,7 +3,7 @@ name: keep-the-why
 description: Preserves or recovers the reasoning behind a codebase - architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain. Use when implementing or reviewing a non-trivial change involving a design decision, workaround, incident fix, operational constraint, rejected alternative, or changed assumption; when documenting an existing or legacy codebase; during onboarding or a maintainer handover; or when interviewing a developer before their knowledge is lost (e.g. before they leave or retire). Identifies what the code cannot explain, asks focused questions instead of generic ones, and maintains concise, topic-based, version-controlled documentation readable by both humans and AI agents.
 license: MIT
 metadata:
-  version: "0.6.1"
+  version: "0.6.2"
   repository: "https://github.com/oliver-zehentleitner/keep-the-why"
   author: "Oliver Zehentleitner"
 ---

--- a/skills/keep-the-why/examples/first-time-setup.md
+++ b/skills/keep-the-why/examples/first-time-setup.md
@@ -85,7 +85,7 @@ This happens to be a question the skill's own description matches, which is what
     <!-- keep-the-why:config -->
     - context: `context/`
     - init: complete
-    - context-schema: 0.6.1
+    - context-schema: 0.6.2
     - capture-confirmation: confirm-when-unsure
     <!-- /keep-the-why:config -->
     ```

--- a/skills/keep-the-why/references/repository-structure.md
+++ b/skills/keep-the-why/references/repository-structure.md
@@ -63,7 +63,7 @@ prior decisions and avoid re-litigating or accidentally reverting them.
 <!-- keep-the-why:config -->
 - context: `context/`
 - init: complete
-- context-schema: 0.6.1
+- context-schema: 0.6.2
 - capture-confirmation: confirm-when-unsure
 <!-- /keep-the-why:config -->
 ```

--- a/skills/keep-the-why/references/setup.md
+++ b/skills/keep-the-why/references/setup.md
@@ -12,7 +12,7 @@ Setup state splits across two files, matching the existing `AGENTS.md`/`AGENTS.l
 <!-- keep-the-why:config -->
 - context: `context/`
 - init: complete
-- context-schema: 0.6.1
+- context-schema: 0.6.2
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->


### PR DESCRIPTION
## Summary
Version bump per the release checklist in `CONTRIBUTING.md`:
- `metadata.version` / `version` fields: `SKILL.md`, `plugin.json`, `.claude-plugin/plugin.json`, `llms.txt` → 0.6.2
- `context-schema` advanced to 0.6.2 (`AGENTS.md` + illustrative examples in `references/setup.md`, `references/repository-structure.md`, `examples/first-time-setup.md`) — no entry-format change this release, advanced per this repo's own convention anyway.
- `CHANGELOG.md`: folded `[Unreleased]` into `[0.6.2] - 2026-07-31`. Backfilled Added/Changed/Fixed entries for #116–#118, which merged without a CHANGELOG line. Also backfilled the compare-links list at the bottom (stale since 0.4.2, missing 0.5.0–0.6.1).

No `context/` entry format change, so nothing needed in `migrations.md`.

## Test plan
- [x] Version-consistency check (same script as `validate-skill.yml`) passes across all files
- [x] `evals.json` still valid JSON
- [x] `mkdocs build --strict` passes locally