### PR TITLE
Keep README and llms.txt eval mentions generic; numbers live in docs/evals.md only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 - `CONTRIBUTING.md`: the cross-agent bullet now points at the runner and names non-Claude agents as the remaining gap; pre-PR checklist item 4 asks for a matching fixture alongside a new or changed eval case.
 - `evals/README.md`: replaced the "no automated runner, no scoring" status with a pointer to `tools/evals/` (linked to `main` on purpose — the runner is development tooling, not part of any release artifact).
+- `README.md` and `llms.txt` now describe the eval suite generically and point at https://keepthewhy.com/evals/ for numbers — concrete run results live in exactly one place (`docs/evals.md`) instead of going stale in three.
 - Rewrote 36 eval prompts from third-person scenario narration ("A developer says they don't want…", "capture-confirmation is set to automatic. During the conversation…") into direct user requests and utterances. Against a real materialized project, the narrated form reliably made the agent answer "I don't see an actual task in your message" instead of exercising the behavior under test; expected behaviors are untouched. Three of these also stopped hardcoding an installed-skill version that contradicts the actually installed one, and two stopped referring to files ("this file") that no fresh session has open.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ First activation in a project runs a short one-time setup instead of guessing at
 
 Because it's just Markdown in the repo, a `context/` update ships in the same commit or PR as the code change it explains — reviewed the same way, versioned the same way, no separate system to trust or keep in sync.
 
-The skill's behavior is exercised by 67 eval cases, executed for real (fixture project, fresh agent session, LLM-judged): **59/67 passed** with Claude Code and Claude Sonnet 5 as of skill 0.6.2 — including an honest analysis of the 8 failures, most of which quantify the documented skill-activation limitation rather than the capture logic itself. See [Evals](https://keepthewhy.com/evals/) for results, caveats, and how to reproduce or run it against other agents.
+The skill's behavior is exercised by 67 eval cases, executed for real — a fixture project per case, a fresh agent session, LLM-judged verdicts, tested with Claude Code. Current results including an honest failure analysis, the stated caveats, and how to reproduce or run the suite against other agents: [Evals](https://keepthewhy.com/evals/).
 
 Where the captured knowledge actually lives, and how it relates to everything else a project already has, is one coherent picture — see "Where this fits" below.
 

--- a/llms.txt
+++ b/llms.txt
@@ -166,11 +166,10 @@ Produces, inside the project using the skill:
 ## Testing / Evals
 
 67 eval cases ship with the skill, executed for real by a local runner in the repo
-(fixture project per case, fresh non-interactive agent session, LLM-judged verdicts).
-Latest run: 59/67 passed (2026-07-31, skill 0.6.2, Claude Code with Claude Sonnet 5,
-agent and judge). Most failures quantify the documented skill-activation limitation
-(low-signal prompts don't load the skill) rather than the capture logic. Full results,
-caveats, and reproduction: https://keepthewhy.com/evals/
+(fixture project per case, fresh non-interactive agent session, LLM-judged verdicts),
+tested with Claude Code and Claude Sonnet. Current numbers live in one place only, so
+they can't drift: https://keepthewhy.com/evals/ — including the failure analysis,
+stated caveats, and reproduction instructions.
 
 ## Related Work
 


### PR DESCRIPTION
Concrete run results in three places would drift on every new run. `docs/evals.md` is now the single page carrying current numbers; `README.md` and `llms.txt` describe the suite (67 cases, fixture projects, real agent sessions, LLM-judged, tested with Claude Code) and point there.

`mkdocs build --strict` green.