### PR TITLE
Explain the overrides/ theme directory with a README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented here. Format follows [Keep a 
 - Local eval runner in `tools/evals/`: materializes a per-case fixture project (shared `_base` plus per-case overlays, optional extra git commits and tool restrictions via `case.json`), runs a real non-interactive Claude Code session against it with the skill installed, captures transcript plus working-tree changes, and grades both with an LLM judge into per-case JSON results and a summary. Deliberately outside `skills/keep-the-why/`, which stays instructions-only. Results directory is gitignored; findings get communicated in the docs instead.
 
 - `docs/evals.md` — new docs page publishing the first full eval run (59/67 with Claude Code + Claude Sonnet 5 on skill 0.6.2) with an analysis of the 8 failures (5 quantify the documented skill-activation limitation, 3 are judgment misses with the skill active), stated caveats (single run, same-vendor judge, one agent), and reproduction instructions. Linked from `README.md`, `llms.txt`, and the mkdocs nav.
+- `overrides/README.md` — explains what the theme-override directory is for (mkdocs-material `custom_dir`, currently the Open Graph/Twitter-card meta tags in `main.html`) and why it sits at the repo root instead of inside `docs/`.
 
 ### Changed
 

--- a/overrides/README.md
+++ b/overrides/README.md
@@ -1,0 +1,21 @@
+# overrides/
+
+Theme-override directory for the docs site, wired up via `theme.custom_dir:
+overrides` in `mkdocs.yml`. Files here replace or extend the mkdocs-material
+theme's built-in templates — they affect how keepthewhy.com renders, not the
+documentation content itself (that lives in `docs/`).
+
+Currently one file:
+
+- `main.html` — extends the theme's `base.html` and injects the Open Graph
+  and Twitter-card `<meta>` tags into every page's `<head>`. This is what
+  makes a shared keepthewhy.com link show the logo card, title, and
+  description on X, LinkedIn, Slack, and similar platforms.
+
+The folder sits at the repo root on purpose: it's the documented
+mkdocs-material convention (an `overrides` folder next to `mkdocs.yml`), and
+placing it inside `docs/` would make mkdocs treat the raw template as site
+content and publish it verbatim into the built site.
+
+This README is inert — the theme engine only resolves known template names
+(`main.html`, `base.html`, `partials/…`), so a Markdown file here is ignored.


### PR DESCRIPTION
`overrides/` had no explanation of what it is or why it exists. The new README covers: it's mkdocs-material's theme-override directory (`theme.custom_dir` in `mkdocs.yml`), currently holding only `main.html` with the Open Graph/Twitter-card meta tags that render keepthewhy.com's link previews; it sits at the repo root because that's the documented mkdocs-material convention, and placing it inside `docs/` would publish the raw Jinja template verbatim into the built site (verified with a test build). A Markdown file inside `custom_dir` is inert — the theme engine only resolves known template names.

`mkdocs build --strict` green.