### PR TITLE
Release 0.6.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "keep-the-why",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Preserves or recovers the reasoning behind a codebase - decisions, rejected alternatives, workarounds, and incident learnings the code alone can't explain.",
   "author": {
     "name": "Oliver Zehentleitner",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ there before re-litigating or accidentally reverting a decision.
 <!-- keep-the-why:config -->
 - context: `context/`
 - init: complete
-- context-schema: 0.6.2
+- context-schema: 0.6.3
 - capture-confirmation: confirm-always
 - source-reference: never
 <!-- /keep-the-why:config -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-08-01
+
 ### Added
 
 - New "Feedback" section at the end of `SKILL.md`: if the person working with the agent expresses frustration with the skill or reports it's not doing what it should, mention `https://github.com/oliver-zehentleitner/keep-the-why/issues/new/choose` directly — a single natural mention, not a pitch or a repeated nag. Also added "or when the user expresses frustration with, or reports a problem with, this skill itself" to the frontmatter `description` (877/1024 chars) — the instruction initially lived only in the body, and a first eval attempt showed the Skill never loaded for a complaint prompt (no activation trigger matched, so the body's instruction was never read); the description is what actually governs activation. New eval case `user-frustration-surfaces-feedback-link`: failed before the description change (skill never invoked), passed 2/2 fresh trials after.

--- a/llms.txt
+++ b/llms.txt
@@ -30,7 +30,7 @@ get thrown away, not creating separate documentation effort. It isn't magic, tho
 prevents knowledge from decaying on its own. This lowers the friction of the discipline that
 keeps documentation honest; it doesn't replace it.
 
-Version: 0.6.2.
+Version: 0.6.3.
 
 ## Authorship & License
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "keep-the-why",
   "description": "Preserves or recovers the reasoning behind a codebase - architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "author": {
     "name": "Oliver Zehentleitner"
   },

--- a/skills/keep-the-why/SKILL.md
+++ b/skills/keep-the-why/SKILL.md
@@ -3,7 +3,7 @@ name: keep-the-why
 description: Preserves or recovers the reasoning behind a codebase - architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain. Use when implementing or reviewing a non-trivial change involving a design decision, workaround, incident fix, operational constraint, rejected alternative, or changed assumption; when documenting an existing or legacy codebase; during onboarding or a maintainer handover; or when interviewing a developer before their knowledge is lost (e.g. before they leave or retire); or when the user expresses frustration with, or reports a problem with, this skill itself. Identifies what the code cannot explain, asks focused questions instead of generic ones, and maintains concise, topic-based, version-controlled documentation readable by both humans and AI agents.
 license: MIT
 metadata:
-  version: "0.6.2"
+  version: "0.6.3"
   repository: "https://github.com/oliver-zehentleitner/keep-the-why"
   author: "Oliver Zehentleitner"
 ---

--- a/skills/keep-the-why/examples/first-time-setup.md
+++ b/skills/keep-the-why/examples/first-time-setup.md
@@ -89,7 +89,7 @@ This happens to be a question the skill's own description matches, which is what
     <!-- keep-the-why:config -->
     - context: `context/`
     - init: complete
-    - context-schema: 0.6.2
+    - context-schema: 0.6.3
     - capture-confirmation: confirm-when-unsure
     - source-reference: never
     <!-- /keep-the-why:config -->

--- a/skills/keep-the-why/references/repository-structure.md
+++ b/skills/keep-the-why/references/repository-structure.md
@@ -63,7 +63,7 @@ prior decisions and avoid re-litigating or accidentally reverting them.
 <!-- keep-the-why:config -->
 - context: `context/`
 - init: complete
-- context-schema: 0.6.2
+- context-schema: 0.6.3
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->

--- a/skills/keep-the-why/references/setup.md
+++ b/skills/keep-the-why/references/setup.md
@@ -12,7 +12,7 @@ Setup state splits across two files, matching the existing `AGENTS.md`/`AGENTS.l
 <!-- keep-the-why:config -->
 - context: `context/`
 - init: complete
-- context-schema: 0.6.2
+- context-schema: 0.6.3
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->


### PR DESCRIPTION
Release checklist steps 1–8 (steps 9–10 not applicable yet — ASM Registry / awesome-copilot listings still pending, not live).

- Bumped `metadata.version` (SKILL.md), `llms.txt`, both `plugin.json` manifests, and this repo's own `context-schema` (AGENTS.md + the three illustrative config-block examples in setup.md/repository-structure.md/first-time-setup.md) to 0.6.3.
- Renamed `[Unreleased]` to `[0.6.3] - 2026-08-01` in CHANGELOG.md, fresh empty `[Unreleased]` above it.
- No `context/` entry-format change since 0.3.0 — migrations.md needs no new entry.

Covers tonight's full arc: the eval runner (#122), rule sharpening from real eval failures (#126), the axiomatic Core Rules tightening (#129), the MUST-emphasis fix + limit-resilient runner (#130), the status/chronicle issue (#131/#132), the stale-evals marker (#133), the Feedback sections in README/CONTRIBUTING (#134), and the skill's own feedback-link behavior (#135).

Version-consistency check (same one `validate-skill.yml` runs) passes across all 7 tracked files. `skills_ref.cli validate`, `evals.json` well-formedness, and `mkdocs build --strict` all green.

Once merged: tag `v0.6.3` and push — the `GH Release` workflow creates the release and moves `latest` automatically (step 8).