### PR TITLE
Release 0.6.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "keep-the-why",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Preserves or recovers the reasoning behind a codebase - decisions, rejected alternatives, workarounds, and incident learnings the code alone can't explain.",
   "author": {
     "name": "Oliver Zehentleitner",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ there before re-litigating or accidentally reverting a decision.
 <!-- keep-the-why:config -->
 - context: `context/`
 - init: complete
-- context-schema: 0.6.3
+- context-schema: 0.6.4
 - capture-confirmation: confirm-always
 - source-reference: never
 <!-- /keep-the-why:config -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+## [0.6.4] - 2026-08-01
+
 ### Added
 
 - The project init wizard (`references/setup.md`) now asks, as its last setup question, whether to set up something stronger for activation reliability if the current agent's own platform supports it — and if yes, has the *current* agent (not `SKILL.md` itself) check what its own platform actually offers and configure it scoped to the project, rather than hardcoding one vendor's mechanism (e.g. a Claude Code `SessionStart` hook) as universal instruction. Not yet a standardized, tested-across-tools solution — right now this is solved individually, per developer; tracked in the new dedicated issue [#138](https://github.com/oliver-zehentleitner/keep-the-why/issues/138). `context/compatibility.md`'s prior "left entirely to each tool, we do nothing" entry marked superseded by this more active stance; `examples/first-time-setup.md`'s wizard dialogue updated to show the new question; `README.md` and `docs/faq.md` updated with the current state and a link to #138.

--- a/llms.txt
+++ b/llms.txt
@@ -30,7 +30,7 @@ get thrown away, not creating separate documentation effort. It isn't magic, tho
 prevents knowledge from decaying on its own. This lowers the friction of the discipline that
 keeps documentation honest; it doesn't replace it.
 
-Version: 0.6.3.
+Version: 0.6.4.
 
 ## Authorship & License
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "keep-the-why",
   "description": "Preserves or recovers the reasoning behind a codebase - architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "author": {
     "name": "Oliver Zehentleitner"
   },

--- a/skills/keep-the-why/SKILL.md
+++ b/skills/keep-the-why/SKILL.md
@@ -3,7 +3,7 @@ name: keep-the-why
 description: Preserves or recovers the reasoning behind a codebase - architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain. Use when implementing or reviewing a non-trivial change involving a design decision, workaround, incident fix, operational constraint, rejected alternative, or changed assumption; when documenting an existing or legacy codebase; during onboarding or a maintainer handover; or when interviewing a developer before their knowledge is lost (e.g. before they leave or retire); or when the user expresses frustration with, or reports a problem with, this skill itself. Identifies what the code cannot explain, asks focused questions instead of generic ones, and maintains concise, topic-based, version-controlled documentation readable by both humans and AI agents.
 license: MIT
 metadata:
-  version: "0.6.3"
+  version: "0.6.4"
   repository: "https://github.com/oliver-zehentleitner/keep-the-why"
   author: "Oliver Zehentleitner"
 ---

--- a/skills/keep-the-why/examples/first-time-setup.md
+++ b/skills/keep-the-why/examples/first-time-setup.md
@@ -93,7 +93,7 @@ This happens to be a question the skill's own description matches, which is what
     <!-- keep-the-why:config -->
     - context: `context/`
     - init: complete
-    - context-schema: 0.6.3
+    - context-schema: 0.6.4
     - capture-confirmation: confirm-when-unsure
     - source-reference: never
     <!-- /keep-the-why:config -->

--- a/skills/keep-the-why/references/repository-structure.md
+++ b/skills/keep-the-why/references/repository-structure.md
@@ -63,7 +63,7 @@ prior decisions and avoid re-litigating or accidentally reverting them.
 <!-- keep-the-why:config -->
 - context: `context/`
 - init: complete
-- context-schema: 0.6.3
+- context-schema: 0.6.4
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->

--- a/skills/keep-the-why/references/setup.md
+++ b/skills/keep-the-why/references/setup.md
@@ -12,7 +12,7 @@ Setup state splits across two files, matching the existing `AGENTS.md`/`AGENTS.l
 <!-- keep-the-why:config -->
 - context: `context/`
 - init: complete
-- context-schema: 0.6.3
+- context-schema: 0.6.4
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->


### PR DESCRIPTION
Release checklist steps 1–7. Step 8 (tag + push) happens right after you merge this — tells CI to cut the GitHub Release and move `latest`.

- Bumped `metadata.version` (SKILL.md), `llms.txt`, both `plugin.json` manifests, and this repo's own `context-schema` (AGENTS.md + the three illustrative config-block examples) to 0.6.4.
- Renamed `[Unreleased]` to `[0.6.4] - 2026-08-01` in CHANGELOG.md, fresh empty `[Unreleased]` above it.
- Closes the version drift since v0.6.3: #137 (activation-reliability docs) and #139 (wizard's new activation-reliability question) had landed on main without a version bump — README/FAQ/website already described this behavior, but the tagged v0.6.3 release didn't actually have it yet. This release closes that gap.
- No `context/` entry-format change, so `migrations.md` needs no new entry.

Version-consistency check (same one `validate-skill.yml` runs) passes across all 7 tracked files. `skills_ref.cli validate`, `evals.json` well-formedness, and `mkdocs build --strict` all green.