### PR TITLE
Mark awesome-agent-skills listing as live

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Full install detail for every method, including tools without a skill runtime at
 | [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why) | Live | Backs the `npx skills add` install method above |
 | [SkillsLLM](https://skillsllm.com/skill/keep-the-why) | Live | Verified, passed [SkillsLLM's security scan](https://skillsllm.com/security-check/IPmNycVdbOyq) |
 | [ASM Registry](https://github.com/luongnv89/asm-registry) | Pending — [PR #5](https://github.com/luongnv89/asm-registry/pull/5) | Manifest pinned to `v0.5.2`; installable via `asm install keep-the-why` once merged |
-| [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills) | Pending — [PR #850](https://github.com/VoltAgent/awesome-agent-skills/pull/850) | Requires "real community usage"; may be declined |
+| [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills#context-engineering) | Live | Listed under "Context Engineering" |
 | [GitHub Copilot plugin marketplace](https://github.com/github/awesome-copilot) | Ready for review — [Issue #2470](https://github.com/github/awesome-copilot/issues/2470) | External plugin submission, pinned to `v0.5.2` |
 
 ## Example

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,7 +37,7 @@ Either form prompts for which of its 70+ supported agents (Claude Code, Codex, O
 | [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why) | Live | Backs the `npx skills add` install method above |
 | [SkillsLLM](https://skillsllm.com/skill/keep-the-why) | Live | Verified, passed [SkillsLLM's security scan](https://skillsllm.com/security-check/IPmNycVdbOyq) |
 | [ASM Registry](https://github.com/luongnv89/asm-registry) | Pending — [PR #5](https://github.com/luongnv89/asm-registry/pull/5) | Manifest pinned to `v0.5.2`; installable via `asm install keep-the-why` once merged |
-| [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills) | Pending — [PR #850](https://github.com/VoltAgent/awesome-agent-skills/pull/850) | Requires "real community usage"; may be declined |
+| [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills#context-engineering) | Live | Listed under "Context Engineering" |
 | [GitHub Copilot plugin marketplace](https://github.com/github/awesome-copilot) | Ready for review — [Issue #2470](https://github.com/github/awesome-copilot/issues/2470) | External plugin submission, pinned to `v0.5.2` |
 
 ## Also recommended: GitHub CLI

--- a/llms.txt
+++ b/llms.txt
@@ -89,8 +89,8 @@ needing to be told again.
 - SkillsLLM: live, verified, passed security scan — https://skillsllm.com/skill/keep-the-why
 - ASM Registry: pending — manifest pinned to v0.5.2, installable via `asm install keep-the-why`
   once merged — https://github.com/luongnv89/asm-registry/pull/5
-- awesome-agent-skills: pending review — requires "real community usage", may be declined —
-  https://github.com/VoltAgent/awesome-agent-skills/pull/850
+- awesome-agent-skills: live, listed under "Context Engineering" —
+  https://github.com/VoltAgent/awesome-agent-skills#context-engineering
 - GitHub Copilot plugin marketplace: ready for review, external plugin submission pinned to
   v0.5.2 — https://github.com/github/awesome-copilot/issues/2470
 


### PR DESCRIPTION
## Summary
- PR #850 to VoltAgent/awesome-agent-skills merged 2026-08-03; entry sits under their "Context Engineering" section
- Update README.md, docs/installation.md, llms.txt from "Pending" to "Live" with a link to that section instead of the PR

## Test plan
- [x] `mkdocs build` succeeds
- [x] verified merge + section placement via `gh pr view 850` and README content on VoltAgent/awesome-agent-skills