### PR TITLE
Add ASM to "Also listed on"

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Full install detail for every method, including tools without a skill runtime at
 | [SkillsLLM](https://skillsllm.com/skill/keep-the-why) | Live | Verified, passed [SkillsLLM's security scan](https://skillsllm.com/security-check/IPmNycVdbOyq) |
 | [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills#context-engineering) | Live | Listed under "Context Engineering" |
 | [GitHub Copilot plugin marketplace](https://github.com/github/awesome-copilot) | Ready for review — [Issue #2470](https://github.com/github/awesome-copilot/issues/2470) | External plugin submission, pinned to `v0.5.2` |
+| [ASM](https://luongnv.com/asm/) | Pending — [Issue #469](https://github.com/luongnv89/asm/issues/469) | Curated skill index for the `asm` CLI; installable via `asm install keep-the-why` once merged |
 
 ## Example
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -38,6 +38,7 @@ Either form prompts for which of its 70+ supported agents (Claude Code, Codex, O
 | [SkillsLLM](https://skillsllm.com/skill/keep-the-why) | Live | Verified, passed [SkillsLLM's security scan](https://skillsllm.com/security-check/IPmNycVdbOyq) |
 | [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills#context-engineering) | Live | Listed under "Context Engineering" |
 | [GitHub Copilot plugin marketplace](https://github.com/github/awesome-copilot) | Ready for review — [Issue #2470](https://github.com/github/awesome-copilot/issues/2470) | External plugin submission, pinned to `v0.5.2` |
+| [ASM](https://luongnv.com/asm/) | Pending — [Issue #469](https://github.com/luongnv89/asm/issues/469) | Curated skill index for the `asm` CLI; installable via `asm install keep-the-why` once merged |
 
 ## Also recommended: GitHub CLI
 

--- a/llms.txt
+++ b/llms.txt
@@ -91,6 +91,8 @@ needing to be told again.
   https://github.com/VoltAgent/awesome-agent-skills#context-engineering
 - GitHub Copilot plugin marketplace: ready for review, external plugin submission pinned to
   v0.5.2 — https://github.com/github/awesome-copilot/issues/2470
+- ASM: pending, curated skill index for the `asm` CLI, installable via `asm install
+  keep-the-why` once merged — https://github.com/luongnv89/asm/issues/469
 
 ## Core Concept
 


### PR DESCRIPTION
## Summary
- Filed luongnv89/asm#469 requesting keep-the-why be added to the curated skill index (asm-registry itself is dead, so this goes through the main asm repo's index instead)
- Add a "Pending" row to README.md, docs/installation.md, llms.txt

## Test plan
- [x] `mkdocs build` succeeds