### PR TITLE
Add context/entry-format.md to docs nav

### DIFF
--- a/docs/context/entry-format.md
+++ b/docs/context/entry-format.md
@@ -1,0 +1,1 @@
+{% include-markdown "../../context/entry-format.md" %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,5 +66,6 @@ nav:
   - "Why this project is built this way":
       - Release and distribution: context/release-and-distribution.md
       - Skill configuration format: context/config-format.md
+      - Entry and layout format: context/entry-format.md
       - Positioning: context/positioning.md
       - Compatibility: context/compatibility.md


### PR DESCRIPTION
## Summary
- #147 added `context/entry-format.md` but missed wiring it into the published docs — every other `context/*.md` file has a `mkdocs.yml` nav entry and a `docs/context/*.md` include-markdown wrapper; this one had neither.

## Test plan
- [x] `mkdocs build` succeeds with no warnings
- [x] rendered page contains the actual content (verified via built `site/context/entry-format/index.html`)