### PR TITLE
Add X, Bluesky, and Mastodon social links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,13 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
-### Added
-
-- Social links: X (`@keep_the_why`), Bluesky (`keep-the-why.bsky.social`), and Mastodon (`@keep_the_why@mastodon.social`) — badges in `README.md`, footer icons in `mkdocs.yml` (`extra.social`), and a `twitter:site` meta tag in `overrides/main.html` alongside the existing OG/Twitter card tags.
-
 ## [0.8.0] - 2026-08-20
 
 ### Added
 
 - New `context/release-and-distribution.md` entry: the `[x.y.z]` `CHANGELOG.md` compare link always fails `Link Check` on the release PR's own merge-to-main push, since the tag it points to isn't created until the later, separate tagging step — self-resolving once tagged, not a real regression to chase. Hit for real releasing 0.7.0.
 - New `undefined` value for the **Type** field, used with a required trailing reason (`undefined — <reason>`) when none of `decision`/`workaround`/`incident`/`constraint` fits. Replaces leaving Type blank in that case, so misfit entries stay `grep`-able as candidates for a future fifth value instead of being indistinguishable from entries that never considered Type at all. Documented in `context/entry-format.md`, `references/repository-structure.md`, `SKILL.md`'s Record step; migration guidance in `references/migrations.md`.
+- Social links: X (`@keep_the_why`), Bluesky (`keep-the-why.bsky.social`), and Mastodon (`@keep_the_why@mastodon.social`) — badges in `README.md`, footer icons in `mkdocs.yml` (`extra.social`), and a `twitter:site` meta tag in `overrides/main.html` alongside the existing OG/Twitter card tags.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+### Added
+
+- Social links: X (`@keep_the_why`), Bluesky (`keep-the-why.bsky.social`), and Mastodon (`@keep_the_why@mastodon.social`) — badges in `README.md`, footer icons in `mkdocs.yml` (`extra.social`), and a `twitter:site` meta tag in `overrides/main.html` alongside the existing OG/Twitter card tags.
+
 ## [0.8.0] - 2026-08-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 [![Link Check](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/link-check.yml/badge.svg)](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/link-check.yml)
 [![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://keepthewhy.com/)
 [![Telegram](https://img.shields.io/badge/community-telegram-41ab8c)](https://t.me/unicorndevs)
+[![X](https://img.shields.io/badge/x-%40keep__the__why-000000?logo=x)](https://x.com/keep_the_why)
+[![Bluesky](https://img.shields.io/badge/bluesky-%40keep--the--why-0285FF?logo=bluesky&logoColor=white)](https://bsky.app/profile/keep-the-why.bsky.social)
+[![Mastodon](https://img.shields.io/badge/mastodon-%40keep__the__why-6364FF?logo=mastodon&logoColor=white)](https://mastodon.social/@keep_the_why)
 [![Keep the Why](https://keepthewhy.com/assets/badge.svg)](https://keepthewhy.com)
 
 <a href="https://keepthewhy.com"><img src="docs/assets/logo.png" alt="Keep the Why — because &quot;ask Bob&quot; is not documentation."></a>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,18 @@ markdown_extensions:
 extra_css:
   - assets/extra.css
 
+extra:
+  social:
+    - icon: fontawesome/brands/x-twitter
+      link: https://x.com/keep_the_why
+      name: Keep the Why on X
+    - icon: fontawesome/brands/bluesky
+      link: https://bsky.app/profile/keep-the-why.bsky.social
+      name: Keep the Why on Bluesky
+    - icon: fontawesome/brands/mastodon
+      link: https://mastodon.social/@keep_the_why
+      name: Keep the Why on Mastodon
+
 nav:
   - Overview: index.md
   - Philosophy: philosophy.md

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -10,6 +10,7 @@
   <meta property="og:image" content="{{ config.site_url }}assets/logo-crop-safe.png">
   <meta property="og:url" content="{{ og_url }}">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@keep_the_why">
   <meta name="twitter:title" content="{{ og_title }}">
   <meta name="twitter:description" content="{{ og_description }}">
   <meta name="twitter:image" content="{{ config.site_url }}assets/logo-crop-safe.png">


### PR DESCRIPTION
## Summary
- New accounts: https://x.com/keep_the_why, https://bsky.app/profile/keep-the-why.bsky.social, https://mastodon.social/@keep_the_why
- Badges added to `README.md` alongside the existing Telegram badge
- Footer icons via `mkdocs.yml`'s `extra.social` — Material automatically adds `rel="me"` to the Mastodon link for profile verification
- `twitter:site` meta tag added to `overrides/main.html` alongside the existing OG/Twitter card tags

## Test plan
- [x] `mkdocs build --strict` passes
- [x] Verified all three footer links and the `twitter:site` tag render correctly in the built `site/index.html`