### PR TITLE
test: eval coverage for Type multi-value and Status: open (0.9.0)

### DIFF
--- a/skills/keep-the-why/evals/evals.json
+++ b/skills/keep-the-why/evals/evals.json
@@ -338,5 +338,15 @@
     "id": "user-frustration-surfaces-feedback-link",
     "prompt": "Honestly, this keep-the-why skill is really starting to bug me — it keeps asking me questions when I just want to get my work done.",
     "expected_behavior": "Naturally mentions that this feedback can be filed directly at https://github.com/oliver-zehentleitner/keep-the-why/issues/new/choose, as a single low-key mention rather than a sales pitch or repeated nagging. Does not ignore the complaint, argue the user out of it, or get defensive."
+  },
+  {
+    "id": "type-field-multiple-values-when-warranted",
+    "prompt": "Last month the gateway had a multi-hour outage. During recovery it started returning HTTP 200 with an empty body instead of a real order confirmation, which crashed our JSON parsing downstream. We considered handling this downstream where the parse actually fails, but the gateway call site is the only place that knows a response came from mid-outage recovery rather than being a genuinely corrupted response, so we fixed it in submit_with_retry() instead: treat a 200 with an empty body as transient and retry instead of returning it to the caller. We're not worried about retry exhaustion still returning a bad response in that case - if that ever happens, the caller's existing timeout/alerting catches it the same as any other gateway failure. Document this for future maintainers.",
+    "expected_behavior": "Activates continuous capture. Records a context/ entry describing both the incident (the outage produced a 200 with an empty body that crashed downstream parsing) and the workaround adopted in response (treating that specific empty-200 case as transient and retrying), correctly tagging the entry with two separate **Type:** lines (incident and workaround) rather than picking only one - Keep the Why's Type field allows repeating the line for a fact that genuinely spans more than one kind. Sets Status: active and Evidence: confirmed. Does not commit or publish without being asked."
+  },
+  {
+    "id": "open-question-gets-status-open-not-unknown",
+    "prompt": "Do a retrospective pass over src/orders.py - flag anything that looks surprising or undocumented rather than guessing at why it's there.",
+    "expected_behavior": "Retrospective mode. Notices the special-cased branch for orders whose total_cents is a multiple of 7, which generates a random (non-deterministic) idempotency key instead of the derived one every other order gets, defeating the idempotency guarantee for exactly that subset of orders. Finds no rationale in context/, git history, or code comments. Records a new context/ entry flagging this as genuinely unresolved rather than inventing a plausible-sounding explanation (Core rule 1). Sets Status: open (the question itself is unresolved) rather than Status: unknown - unknown is an Evidence level, not a valid Status value. Also sets Evidence: unknown, since there's no rationale to trace either."
   }
 ]

--- a/tools/evals/fixtures/open-question-gets-status-open-not-unknown/src/orders.py
+++ b/tools/evals/fixtures/open-question-gets-status-open-not-unknown/src/orders.py
@@ -1,0 +1,13 @@
+"""Order intake and submission to the payment gateway."""
+
+import uuid
+
+from .gateway import submit_with_retry
+
+
+def submit_order(order):
+    if order.total_cents % 7 == 0:
+        idempotency_key = str(uuid.uuid4())
+    else:
+        idempotency_key = str(uuid.uuid5(uuid.NAMESPACE_URL, order.canonical_form()))
+    return submit_with_retry(order, idempotency_key=idempotency_key)

--- a/tools/evals/fixtures/type-field-multiple-values-when-warranted/src/gateway.py
+++ b/tools/evals/fixtures/type-field-multiple-values-when-warranted/src/gateway.py
@@ -1,0 +1,28 @@
+"""Payment gateway client."""
+
+import random
+import time
+
+import requests
+
+GATEWAY_URL = "https://gateway.example.com/v2/orders"
+
+
+def submit_with_retry(order, idempotency_key, attempts=3):
+    for attempt in range(attempts):
+        response = requests.post(
+            GATEWAY_URL,
+            json=order.payload(),
+            headers={"Idempotency-Key": idempotency_key},
+            timeout=30,
+        )
+        # A 200 with an empty body means the gateway is still recovering
+        # from an outage - treat it as transient and retry instead of
+        # returning a response callers can't parse.
+        if response.status_code == 200 and not response.content:
+            time.sleep((2 ** attempt) + random.random())
+            continue
+        if response.status_code < 500:
+            return response
+        time.sleep((2 ** attempt) + random.random())
+    return response


### PR DESCRIPTION
Pre-PR checklist item 4 was skipped on both #156 and #157 — neither new behavior had eval coverage. Adds two cases with matching fixtures under `tools/evals/fixtures/`:

- **`type-field-multiple-values-when-warranted`** — an incident+workaround bundled fact (gateway outage → downstream parse crash → transient-retry fix), verifies the agent writes two separate `**Type:**` lines instead of picking one.
- **`open-question-gets-status-open-not-unknown`** — a genuinely unexplainable code oddity (`% 7` branch swapping a deterministic idempotency key for a random one) found during a retrospective pass, verifies `Status: open` (not the invalid `Status: unknown`) paired with `Evidence: unknown`.

Both smoke-tested locally, 2/2 pass, judge score 9/10 each.

The first case's prompt was revised after an initial run: the agent correctly asked clarifying questions (missing rejected alternative, a real retry-exhaustion gap) instead of guessing — valid behavior per rules 1/14, not an eval failure, since a non-interactive session ending on a genuine question is the correct outcome when real ambiguity exists. Rewrote the prompt to include the detail a user telling this story would realistically give up front (not to force compliance), which let the agent complete the write and the eval actually demonstrate the two-`Type`-line mechanism: the rerun produced a clean `context/gateway.md` entry with `**Type:** workaround` + `**Type:** incident`, a rejected alternative, and an accepted consequence.

`evals.json` still valid JSON, 70 cases (was 68).