### PR TITLE
Release 0.9.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "keep-the-why",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Preserves or recovers the reasoning behind a codebase - decisions, rejected alternatives, workarounds, and incident learnings the code alone can't explain.",
   "author": {
     "name": "Oliver Zehentleitner",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ there before re-litigating or accidentally reverting a decision.
 <!-- keep-the-why:config -->
 - context: `context/`
 - init: complete
-- context-schema: 0.8.0
+- context-schema: 0.9.0
 - capture-confirmation: confirm-always
 - source-reference: never
 <!-- /keep-the-why:config -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-08-20
+
+### Added
+
+- 2 new eval cases: `type-field-multiple-values-when-warranted` (an incident+workaround bundled fact — verifies the agent writes two separate `**Type:**` lines instead of picking one) and `open-question-gets-status-open-not-unknown` (a genuinely unexplainable code oddity found during a retrospective pass — verifies `Status: open`, not the invalid `Status: unknown`, paired with `Evidence: unknown`). Both smoke-tested locally, 2/2 pass.
+
 ### Fixed
 
 - `references/repository-structure.md` never explained or demonstrated `Status: open` on its own — only `needs-review` got a worked mention (via **Revisit when**). Two independently-written projects reached for `Status: unknown` on genuinely open questions instead, since `unknown` reads as the more natural English word — but that's an Evidence level, not a Status one. Added a dedicated **Status** paragraph with a worked `open` example and an explicit "not the same as `Evidence: unknown`" note, in both `references/repository-structure.md` and `SKILL.md` rule 7.
@@ -328,7 +334,8 @@ Initial release.
 - Logo, wordmark, and favicon.
 - `context/repo-conventions.md`, dogfooding the skill on its own repository from day one.
 
-[Unreleased]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.6.4...v0.7.0
 [0.6.1]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.6.0...v0.6.1

--- a/llms.txt
+++ b/llms.txt
@@ -30,7 +30,7 @@ get thrown away, not creating separate documentation effort. It isn't magic, tho
 prevents knowledge from decaying on its own. This lowers the friction of the discipline that
 keeps documentation honest; it doesn't replace it.
 
-Version: 0.8.0.
+Version: 0.9.0.
 
 ## Authorship & License
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "keep-the-why",
   "description": "Preserves or recovers the reasoning behind a codebase - architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "author": {
     "name": "Oliver Zehentleitner"
   },

--- a/skills/keep-the-why/SKILL.md
+++ b/skills/keep-the-why/SKILL.md
@@ -3,7 +3,7 @@ name: keep-the-why
 description: Preserves or recovers the reasoning behind a codebase - architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain. Use when implementing or reviewing a non-trivial change involving a design decision, workaround, incident fix, operational constraint, rejected alternative, or changed assumption; when documenting an existing or legacy codebase; during onboarding or a maintainer handover; or when interviewing a developer before their knowledge is lost (e.g. before they leave or retire); or when the user expresses frustration with, or reports a problem with, this skill itself. Identifies what the code cannot explain, asks focused questions instead of generic ones, and maintains concise, topic-based, version-controlled documentation readable by both humans and AI agents.
 license: MIT
 metadata:
-  version: "0.8.0"
+  version: "0.9.0"
   repository: "https://github.com/oliver-zehentleitner/keep-the-why"
   author: "Oliver Zehentleitner"
 ---

--- a/skills/keep-the-why/examples/first-time-setup.md
+++ b/skills/keep-the-why/examples/first-time-setup.md
@@ -94,7 +94,7 @@ This happens to be a question the skill's own description matches, which is what
     <!-- keep-the-why:config -->
     - context: `context/`
     - init: complete
-    - context-schema: 0.8.0
+    - context-schema: 0.9.0
     - capture-confirmation: confirm-when-unsure
     - source-reference: never
     <!-- /keep-the-why:config -->

--- a/skills/keep-the-why/references/repository-structure.md
+++ b/skills/keep-the-why/references/repository-structure.md
@@ -63,7 +63,7 @@ prior decisions and avoid re-litigating or accidentally reverting them.
 <!-- keep-the-why:config -->
 - context: `context/`
 - init: complete
-- context-schema: 0.8.0
+- context-schema: 0.9.0
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->

--- a/skills/keep-the-why/references/setup.md
+++ b/skills/keep-the-why/references/setup.md
@@ -12,7 +12,7 @@ Setup state splits across two files, matching the existing `AGENTS.md`/`AGENTS.l
 <!-- keep-the-why:config -->
 - context: `context/`
 - init: complete
-- context-schema: 0.8.0
+- context-schema: 0.9.0
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->


### PR DESCRIPTION
## Summary
- Minor version bump: `Type` accepting multiple values (#156) is a `context-schema`-relevant change to the `context/` entry format, same tier as 0.7.0/0.8.0's Type-field additions — not just a skill-behavior change, hence minor rather than patch.
- Full release checklist from `CONTRIBUTING.md`: `metadata.version`/`llms.txt`/both `plugin.json` copies bumped to 0.9.0, `CHANGELOG.md` `[Unreleased]` renamed to `[0.9.0] - 2026-08-20` with a fresh empty `[Unreleased]` above and compare links updated, `migrations.md` already had its `## 0.9.0` section from #156 (verified complete against the full CHANGELOG history — every release that changed entry format has a migration entry, none of the others needed one), this repo's own `context-schema` (`AGENTS.md`) advanced to 0.9.0, and illustrative `context-schema` examples in `setup.md`/`repository-structure.md`/`first-time-setup.md` bumped to match (`evals.json`'s deliberately historical 0.2.0 scenario left untouched, per the checklist's own exemption).
- Also included: the `Status: open` documentation fix (#157) and the two new eval cases with fixtures (#158), both merged since 0.8.0.
- Nothing to backfill in this repo's own existing `context/` entries — the 0.9.0 migration's entry-level step is a next-touched rule, not a dedicated pass.
- Step 9 (awesome-copilot listing PR) skipped — still "Ready for review" (Issue #2470), not actually listed there yet.

## Test plan
- [x] `python3 -m skills_ref.cli validate skills/keep-the-why` passes
- [x] `python3 -c "import json; print(len(json.load(open('skills/keep-the-why/evals/evals.json'))))"` → 70, valid JSON
- [x] Version consistency grep across all files clean (no stray `0.8.0` outside `CHANGELOG.md` history and `migrations.md`'s historical heading)
- [ ] After merge: tag `v0.9.0` and push — `GH Release` workflow creates the release and moves `latest`