### PR TITLE
Simplify README tagline and matrix page cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Keep a Changelog records what changed. Keep the Why preserves why it changed.
 
 Documentation is normally extra work that happens after the code is done — reload the reasoning from memory, write it down again, file it somewhere else: a wiki, an ADR, a PR description nobody reopens. That's exactly why it so often doesn't happen. When an agent is already how you work — deciding, weighing trade-offs, explaining itself in the same conversation that produces the change — the reasoning shows up for free, as a byproduct of that conversation, not separate effort. Keep the Why's actual job is narrower than it sounds: don't let that reasoning get thrown away.
 
-**Tested with:** Claude Code · Pi · opencode · Kimi Code — plus Codex CLI, Cline, and Gemini CLI on the roadmap. See the [agent & model matrix](https://keepthewhy.com/agent-matrix/) for what's actually been run against what, and how.
+**Tested with:** Claude Code, Pi, and more — see the [agent & model matrix](https://keepthewhy.com/agent-matrix/) for what's actually been run against what, and how.
 
 Website: [https://keepthewhy.com](https://keepthewhy.com/) · [llms.txt](https://keepthewhy.com/llms.txt) for AI agents/assistants looking up this project
 

--- a/docs/agent-matrix.md
+++ b/docs/agent-matrix.md
@@ -34,25 +34,14 @@ where LLM-judged) · skill version · date tested.
 | Model\* | Claude Code | Pi | opencode | Kimi Code | Codex CLI | Cline | Gemini CLI |
 |---|---|---|---|---|---|---|---|
 | Claude Sonnet 5 (native) | ✅ 9/10 · v0.9.0 · 2026-08-20 | – | – | – | – | – | – |
-| Qwen3.8 27B (Ollama, local, Q4_K_M) | – | ✅ pass¹ · v0.9.0 · 2026-08-20 | – | – | – | – | – |
-| Qwen3.8 27B (OpenRouter) | – | ✅ 10/10 · v0.9.0 · 2026-08-20 | ✅ 9/10² · v0.9.0 · 2026-08-20 | ✅ 10/10² · v0.9.0 · 2026-08-20 | – | – | – |
+| Qwen3.8 27B (Ollama, local, Q4_K_M) | – | ✅ pass · v0.9.0 · 2026-08-20 | – | – | – | – | – |
+| Qwen3.8 27B (OpenRouter) | – | ✅ 10/10 · v0.9.0 · 2026-08-20 | ✅ 9/10 · v0.9.0 · 2026-08-20 | ✅ 10/10 · v0.9.0 · 2026-08-20 | – | – | – |
 | Kimi K3 (OpenRouter) | – | – | – | – | – | – | – |
 | DeepSeek (OpenRouter) | – | – | – | – | – | – | – |
 | GPT (OpenAI) | – | – | – | – | – | – | – |
 | Gemini | – | – | – | – | – | – | – |
 | Mistral (OpenRouter) | – | – | – | – | – | – | – |
 | Grok (OpenRouter) | – | – | – | – | – | – | – |
-
-¹ ~1h49m on an 8GB-VRAM card running mostly on CPU. Observed directly, not
-run through the automated judge.
-² See "A finding this table exists to surface" below — an earlier, informal
-run of this exact cell removed the code under test before asking instead of
-after.
-
-Codex CLI and Cline both have clean, first-party custom-provider support
-(OpenRouter reachable without a proxy) and are next in line to fill in.
-Gemini CLI has no clean first-party path to a non-Gemini model — only via a
-community wrapper or a LiteLLM proxy — so it's lower priority.
 
 ## A finding this table exists to surface
 


### PR DESCRIPTION
## Summary
- README "Tested with" line no longer hardcodes specific agent names (would need editing every time a new one gets added) — just "Claude Code, Pi, and more" + the matrix link.
- `docs/agent-matrix.md`: removed the two per-cell footnotes and the Codex CLI/Cline/Gemini CLI roadmap paragraph under the table, keeping the table as the focal point. The Chesterton's Fence finding stays in its own full section below, unchanged.

## Test plan
- [x] `mkdocs build --strict` passes