### PR TITLE
ASM listing is live — update Also listed on status

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,10 @@ Full install detail for every method, including tools without a skill runtime at
 
 | Name | Status | Info |
 |---|---|---|
+| [ASM](https://luongnv.com/asm/#/skills/oliver-zehentleitner%2Fkeep-the-why%3A%3Askills%2Fkeep-the-why%3A%3Akeep-the-why) | Live | Curated skill index for the `asm` CLI; installable via `asm install keep-the-why` |
 | [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills#context-engineering) | Live | Listed under "Context Engineering" |
 | [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why) | Live | Backs the `npx skills add` install method above |
 | [SkillsLLM](https://skillsllm.com/skill/keep-the-why) | Live | Verified, passed [SkillsLLM's security scan](https://skillsllm.com/security-check/IPmNycVdbOyq) |
-| [ASM](https://luongnv.com/asm/#/skills/oliver-zehentleitner%2Fkeep-the-why%3A%3Askills%2Fkeep-the-why%3A%3Akeep-the-why) | Live | Curated skill index for the `asm` CLI; installable via `asm install keep-the-why` |
 | [GitHub Copilot plugin marketplace](https://github.com/github/awesome-copilot) | Ready for review — [Issue #2470](https://github.com/github/awesome-copilot/issues/2470) | External plugin submission, pinned to `v0.5.2` |
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Full install detail for every method, including tools without a skill runtime at
 | [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills#context-engineering) | Live | Listed under "Context Engineering" |
 | [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why) | Live | Backs the `npx skills add` install method above |
 | [SkillsLLM](https://skillsllm.com/skill/keep-the-why) | Live | Verified, passed [SkillsLLM's security scan](https://skillsllm.com/security-check/IPmNycVdbOyq) |
-| [ASM](https://luongnv.com/asm/) | Pending — [Issue #469](https://github.com/luongnv89/asm/issues/469) | Curated skill index for the `asm` CLI; installable via `asm install keep-the-why` once merged |
+| [ASM](https://luongnv.com/asm/#/skills/oliver-zehentleitner%2Fkeep-the-why%3A%3Askills%2Fkeep-the-why%3A%3Akeep-the-why) | Live | Curated skill index for the `asm` CLI; installable via `asm install keep-the-why` |
 | [GitHub Copilot plugin marketplace](https://github.com/github/awesome-copilot) | Ready for review — [Issue #2470](https://github.com/github/awesome-copilot/issues/2470) | External plugin submission, pinned to `v0.5.2` |
 
 ## Example

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,7 +37,7 @@ Either form prompts for which of its 70+ supported agents (Claude Code, Codex, O
 | [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills#context-engineering) | Live | Listed under "Context Engineering" |
 | [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why) | Live | Backs the `npx skills add` install method above |
 | [SkillsLLM](https://skillsllm.com/skill/keep-the-why) | Live | Verified, passed [SkillsLLM's security scan](https://skillsllm.com/security-check/IPmNycVdbOyq) |
-| [ASM](https://luongnv.com/asm/) | Pending — [Issue #469](https://github.com/luongnv89/asm/issues/469) | Curated skill index for the `asm` CLI; installable via `asm install keep-the-why` once merged |
+| [ASM](https://luongnv.com/asm/#/skills/oliver-zehentleitner%2Fkeep-the-why%3A%3Askills%2Fkeep-the-why%3A%3Akeep-the-why) | Live | Curated skill index for the `asm` CLI; installable via `asm install keep-the-why` |
 | [GitHub Copilot plugin marketplace](https://github.com/github/awesome-copilot) | Ready for review — [Issue #2470](https://github.com/github/awesome-copilot/issues/2470) | External plugin submission, pinned to `v0.5.2` |
 
 ## Also recommended: GitHub CLI

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -34,10 +34,10 @@ Either form prompts for which of its 70+ supported agents (Claude Code, Codex, O
 
 | Name | Status | Info |
 |---|---|---|
+| [ASM](https://luongnv.com/asm/#/skills/oliver-zehentleitner%2Fkeep-the-why%3A%3Askills%2Fkeep-the-why%3A%3Akeep-the-why) | Live | Curated skill index for the `asm` CLI; installable via `asm install keep-the-why` |
 | [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills#context-engineering) | Live | Listed under "Context Engineering" |
 | [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why) | Live | Backs the `npx skills add` install method above |
 | [SkillsLLM](https://skillsllm.com/skill/keep-the-why) | Live | Verified, passed [SkillsLLM's security scan](https://skillsllm.com/security-check/IPmNycVdbOyq) |
-| [ASM](https://luongnv.com/asm/#/skills/oliver-zehentleitner%2Fkeep-the-why%3A%3Askills%2Fkeep-the-why%3A%3Akeep-the-why) | Live | Curated skill index for the `asm` CLI; installable via `asm install keep-the-why` |
 | [GitHub Copilot plugin marketplace](https://github.com/github/awesome-copilot) | Ready for review — [Issue #2470](https://github.com/github/awesome-copilot/issues/2470) | External plugin submission, pinned to `v0.5.2` |
 
 ## Also recommended: GitHub CLI

--- a/llms.txt
+++ b/llms.txt
@@ -89,8 +89,8 @@ needing to be told again.
 - skills.sh: https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why — live, backs
   the `npx skills add` method above
 - SkillsLLM: live, verified, passed security scan — https://skillsllm.com/skill/keep-the-why
-- ASM: pending, curated skill index for the `asm` CLI, installable via `asm install
-  keep-the-why` once merged — https://github.com/luongnv89/asm/issues/469
+- ASM: live, curated skill index for the `asm` CLI, installable via `asm install
+  keep-the-why` — https://luongnv.com/asm/#/skills/oliver-zehentleitner%2Fkeep-the-why%3A%3Askills%2Fkeep-the-why%3A%3Akeep-the-why
 - GitHub Copilot plugin marketplace: ready for review, external plugin submission pinned to
   v0.5.2 — https://github.com/github/awesome-copilot/issues/2470
 

--- a/llms.txt
+++ b/llms.txt
@@ -84,13 +84,13 @@ needing to be told again.
 
 ## Also Listed On
 
+- ASM: live, curated skill index for the `asm` CLI, installable via `asm install
+  keep-the-why` — https://luongnv.com/asm/#/skills/oliver-zehentleitner%2Fkeep-the-why%3A%3Askills%2Fkeep-the-why%3A%3Akeep-the-why
 - awesome-agent-skills: live, listed under "Context Engineering" —
   https://github.com/VoltAgent/awesome-agent-skills#context-engineering
 - skills.sh: https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why — live, backs
   the `npx skills add` method above
 - SkillsLLM: live, verified, passed security scan — https://skillsllm.com/skill/keep-the-why
-- ASM: live, curated skill index for the `asm` CLI, installable via `asm install
-  keep-the-why` — https://luongnv.com/asm/#/skills/oliver-zehentleitner%2Fkeep-the-why%3A%3Askills%2Fkeep-the-why%3A%3Akeep-the-why
 - GitHub Copilot plugin marketplace: ready for review, external plugin submission pinned to
   v0.5.2 — https://github.com/github/awesome-copilot/issues/2470
 


### PR DESCRIPTION
luongnv89/asm#469 closed, keep-the-why is now in the curated ASM catalog. Updated the ASM row in README.md, docs/installation.md, and llms.txt from Pending to Live with the direct listing link.