### PR TITLE
Add Pi and Kimi Code to install-paths tables and compat lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,14 @@ Where `<target-directory>` is your agent's skills directory — the folder name 
 | Agent | Project-scoped | Personal |
 |---|---|---|
 | Claude Code | `.claude/skills/keep-the-why` | `~/.claude/skills/keep-the-why` |
+| Cline | `.cline/skills/keep-the-why` | `~/.cline/skills/keep-the-why` |
+| Cursor | `.cursor/skills/keep-the-why` | — (no personal directory) |
 | Gemini CLI | `.gemini/skills/keep-the-why` | `~/.gemini/skills/keep-the-why` |
 | GitHub Copilot | `.github/skills/keep-the-why` | `~/.copilot/skills/keep-the-why` |
-| Cursor | `.cursor/skills/keep-the-why` | — (no personal directory) |
+| Kimi Code | `.kimi/skills/keep-the-why` | `~/.kimi/skills/keep-the-why` |
+| Pi | `.pi/skills/keep-the-why` | `~/.pi/agent/skills/keep-the-why` |
 
-Codex CLI, Antigravity, Amp, OpenCode, Warp, and more read the shared `.agents/skills/keep-the-why` path at project scope (Codex scans it from your current directory up to the repository root) and `~/.agents/skills/keep-the-why` personally — check whether yours does before falling back to a vendor path. Cline uses its own `.cline/skills/keep-the-why` (project) / `~/.cline/skills/keep-the-why` (personal) instead.
+Codex CLI, Antigravity, Amp, OpenCode, Warp, and more read the shared `.agents/skills/keep-the-why` path at project scope (Codex scans it from your current directory up to the repository root) and `~/.agents/skills/keep-the-why` personally — check whether yours does before falling back to a vendor path. Pi and Kimi Code also fall back to this same shared path (project and personal) if their own brand directory above doesn't have it.
 
 Also compatible with Windsurf, Goose, Roo Code, Trae, Factory, JetBrains Junie, and other tools supporting the open Agent Skills format — the directory convention varies, check your tool's own docs.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -79,12 +79,14 @@ The folder name must stay `keep-the-why` (has to match `name` in the frontmatter
 | Agent | Project-scoped | Personal | Last verified |
 |---|---|---|---|
 | Claude Code | `.claude/skills/keep-the-why` | `~/.claude/skills/keep-the-why` | 2026-07-10 |
+| Cline | `.cline/skills/keep-the-why` | `~/.cline/skills/keep-the-why` | 2026-07-10 |
+| Cursor | `.cursor/skills/keep-the-why` | — (no personal directory) | 2026-07-10 |
 | Gemini CLI | `.gemini/skills/keep-the-why` | `~/.gemini/skills/keep-the-why` | 2026-07-10 |
 | GitHub Copilot | `.github/skills/keep-the-why` | `~/.copilot/skills/keep-the-why` | 2026-07-10 |
-| Cursor | `.cursor/skills/keep-the-why` | — (no personal directory) | 2026-07-10 |
-| Cline | `.cline/skills/keep-the-why` | `~/.cline/skills/keep-the-why` | 2026-07-10 |
+| Kimi Code | `.kimi/skills/keep-the-why` | `~/.kimi/skills/keep-the-why` | 2026-08-21 |
+| Pi | `.pi/skills/keep-the-why` | `~/.pi/agent/skills/keep-the-why` | 2026-08-21 |
 
-These paths change as agent tooling evolves — if one doesn't work, check the agent's current docs rather than assuming this table is still accurate. **Codex CLI**, Antigravity, Amp, OpenCode, Warp, and more read the shared `.agents/skills/keep-the-why` path at project scope instead of a vendor-specific one — Codex specifically scans `.agents/skills` from your current working directory up to the repository root (per [OpenAI's Codex skills docs](https://developers.openai.com/codex/skills)) — and `~/.agents/skills/keep-the-why` personally. Also compatible with Windsurf, Goose, Roo Code, Trae, Factory, JetBrains Junie, and other tools supporting the open Agent Skills format — the directory convention varies, check your tool's own docs.
+These paths change as agent tooling evolves — if one doesn't work, check the agent's current docs rather than assuming this table is still accurate. **Codex CLI**, Antigravity, Amp, OpenCode, Warp, and more read the shared `.agents/skills/keep-the-why` path at project scope instead of a vendor-specific one — Codex specifically scans `.agents/skills` from your current working directory up to the repository root (per [OpenAI's Codex skills docs](https://developers.openai.com/codex/skills)) — and `~/.agents/skills/keep-the-why` personally. Pi and Kimi Code also fall back to this same shared path (project and personal) if their own brand directory above doesn't have it. Also compatible with Windsurf, Goose, Roo Code, Trae, Factory, JetBrains Junie, and other tools supporting the open Agent Skills format — the directory convention varies, check your tool's own docs.
 
 Start a new session afterward so the skill is picked up.
 

--- a/llms.txt
+++ b/llms.txt
@@ -68,8 +68,9 @@ rm -rf /tmp/keep-the-why
 ```
 
 Compatible with Claude Code, Codex CLI, Gemini CLI, GitHub Copilot, Cursor, Windsurf,
-Antigravity, Amp, Cline, Goose, Roo Code, OpenCode, Trae, Factory, JetBrains Junie, Warp, and
-other tools supporting the open Agent Skills format. Full paths per agent: see Installation below.
+Antigravity, Amp, Cline, Kimi Code, Pi, Goose, Roo Code, OpenCode, Trae, Factory, JetBrains
+Junie, Warp, and other tools supporting the open Agent Skills format. Full paths per agent: see
+Installation below.
 Also installable as a Claude Code plugin (`.claude-plugin/plugin.json` at the repo root, separate
 from the root `plugin.json` used by GitHub's Copilot CLI plugin marketplace format).
 


### PR DESCRIPTION
## Summary
Pi and Kimi Code were already tested drivers in tools/evals/ but missing entirely from the install documentation. Added:
- `README.md` and `docs/installation.md`: both agents' skill-discovery directories in the install-paths table (verified against each project's own docs — Pi: `.pi/skills/` / `~/.pi/agent/skills/`; Kimi Code: `.kimi/skills/` / `~/.kimi/skills/`), plus a note that both fall back to the shared `.agents/skills/` path like Codex CLI already does.
- `llms.txt`: added both to the general compatibility list.
- Alphabetized the install-paths tables while touching them (were previously in no particular order).

## Test plan
- [x] `mkdocs build --strict` passes