### PR TITLE
Document asm as an install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ gh skill install oliver-zehentleitner/keep-the-why keep-the-why@latest
 
 Prompts for which agent and scope (project or personal) to install for. This installs just the skill package (`skills/keep-the-why/`), not the whole repo — no docs/, mkdocs config, or CI files end up in your project.
 
+**Also installable via [asm](https://luongnv.com/asm/)** (agent-skill-manager):
+
+```bash
+asm install github:oliver-zehentleitner/keep-the-why#latest:skills/keep-the-why --tool <tool>
+```
+
+Replace `<tool>` with your agent (`claude`, `codex`, `opencode`, `cline`, `gemini`, and more — run `asm install --help` for the full list).
+
 **Also installable as a Claude Code plugin** — `.claude-plugin/plugin.json` at the repo root (separate from the root `plugin.json`, which serves GitHub's Copilot CLI plugin marketplace format).
 
 **Fallback — manual clone**, if neither of the above is available. The skill lives under `skills/keep-the-why/` in this repo, not at the root, so clone to a scratch location and copy just that folder rather than cloning straight into your agent's skills directory (cloning the whole repo there would nest an embedded git repository inside yours, and pull in unrelated project files):

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -62,6 +62,16 @@ gh skill install oliver-zehentleitner/keep-the-why keep-the-why
 
 Either form prompts for which agent and scope (project or personal) to install for, and installs only the skill package (`skills/keep-the-why/` in this repo) — not the whole repository. Run `gh skill install --help` for non-interactive flags.
 
+## Also installable: asm
+
+With [`asm`](https://luongnv.com/asm/) (agent-skill-manager), pinned to a release, from the skill's subdirectory in this repo:
+
+```bash
+asm install github:oliver-zehentleitner/keep-the-why#latest:skills/keep-the-why --tool <tool>
+```
+
+Replace `<tool>` with your agent (`claude`, `codex`, `opencode`, `cline`, `gemini`, and more — run `asm install --help` for the full list). Replace `#latest` with an exact [tag](https://github.com/oliver-zehentleitner/keep-the-why/releases) to pin to a specific version instead of always the newest, or drop it to track `main` directly.
+
 ## Fallback: manual clone
 
 If neither CLI is available. The skill lives under `skills/keep-the-why/`, not at the repo root — clone to a scratch location and copy just that folder, rather than cloning the whole repo straight into your agent's skills directory (which would nest an embedded git repository inside yours and pull in docs/, mkdocs config, and CI files you don't need). Pinned to a release:

--- a/llms.txt
+++ b/llms.txt
@@ -57,6 +57,15 @@ Also recommended, with GitHub CLI v2.90.0+:
 gh skill install oliver-zehentleitner/keep-the-why keep-the-why@latest
 ```
 
+Also installable with asm (agent-skill-manager, https://luongnv.com/asm/):
+
+```bash
+asm install github:oliver-zehentleitner/keep-the-why#latest:skills/keep-the-why --tool <tool>
+```
+
+Replace <tool> with your agent (claude, codex, opencode, cline, gemini, and more — run
+`asm install --help` for the full list).
+
 Fallback (manual clone) — the skill lives under `skills/keep-the-why/` in this repo, not at the
 root, so clone to a scratch location and copy just that folder rather than cloning the whole repo
 into your agent's skills directory:


### PR DESCRIPTION
## Summary
asm was already live in the "Also listed on" table but not described as an actual install method with a copy-pasteable command, unlike skills CLI, GitHub CLI, and manual clone.

Verified live before writing this (asm v2.14.0):
```
asm install github:oliver-zehentleitner/keep-the-why#latest:skills/keep-the-why --tool claude
```
Correctly parses the `#tag:subdirectory` source, clones the right ref, finds the skill, detects v0.9.0. Ran through step 7/8 (install preview) — stopped short of the final write on purpose (needs `--yes` non-interactively; this was a verification run, not a real install).

Added to README.md's "Other install methods" details block, docs/installation.md as its own `## Also installable: asm` section, and llms.txt's Quick Start.

## Test plan
- [x] `mkdocs build --strict` passes
- [x] Command verified live against a real asm install (see above)