### PR TITLE
Fill in Ox Alpha's row across all wired drivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+### Added
+
+- Ox Alpha's row in `docs/agent-matrix.md` filled in across all six wired drivers (Gemini CLI still not wired in): Cline and Hermes pass (10/10 each), Codex CLI, Kimi Code, opencode, and Pi all fail the same way (2/10 each — investigate correctly, delete anyway). Getting Kimi Code's cell required pinning `@moonshot-ai/kimi-code` to 0.37.2: 0.38.0 (npm's latest) crashes outright on any non-interactive `-p` prompt, reproduced independent of this skill or Ox Alpha. Also found along the way: `npm install -g kimi-code` (unscoped) installs an entirely unrelated same-named third-party tool (`whitesmith/kimi-code`) — the real package is `@moonshot-ai/kimi-code`.
+
 ## [0.9.1] - 2026-08-24
 
 ### Added

--- a/docs/agent-matrix.md
+++ b/docs/agent-matrix.md
@@ -45,7 +45,7 @@ Agents are ordered open source first (alphabetical), then closed source
 | Grok 4.6 (OpenRouter) | ✅ 10/10 · v0.9.0 · 2026-08-20 | ✅ 10/10 · v0.9.0 · 2026-08-21 | – | – | ✅ 10/10 · v0.9.0 · 2026-08-20 | ✅ 9/10 · v0.9.0 · 2026-08-20 | ✅ 9/10 · v0.9.0 · 2026-08-20 | – |
 | Kimi K3 (OpenRouter) | ✅ 10/10 · v0.9.0 · 2026-08-20 | ✅ 10/10 · v0.9.0 · 2026-08-21 | – | – | ❌ 3/10 · v0.9.0 · 2026-08-20 | ❌ 2/10 · v0.9.0 · 2026-08-20 | ✅ 10/10 · v0.9.0 · 2026-08-20 | – |
 | Mistral Medium 3.5 (OpenRouter) | ❌ 2/10 · v0.9.0 · 2026-08-20 | ❌ 1/10 · v0.9.0 · 2026-08-21 | – | – | ❌ 2/10 · v0.9.0 · 2026-08-20 | ❌ 1/10 · v0.9.0 · 2026-08-20 | ❌ 2/10 · v0.9.0 · 2026-08-20 | – |
-| Ox Alpha (OpenRouter, stealth) | – | – | – | ✅ 10/10 · v0.9.0 · 2026-08-24 | – | – | ❌ 3/10 · v0.9.0 · 2026-08-24 | – |
+| Ox Alpha (OpenRouter, stealth) | ✅ 10/10 · v0.9.0 · 2026-08-24 | ❌ 2/10 · v0.9.0 · 2026-08-24 | – | ✅ 10/10 · v0.9.0 · 2026-08-24 | ❌ 2/10 · v0.9.0 · 2026-08-24 | ❌ 2/10 · v0.9.0 · 2026-08-24 | ❌ 2/10 · v0.9.0 · 2026-08-24 | – |
 | Qwen3.8 27B (Ollama, local, Q4_K_M) | – | – | – | – | – | ❌ 2/10 · v0.9.0 · 2026-08-21 | ✅ 9/10 · v0.9.0 · 2026-08-20 | – |
 | Qwen3.8 27B (OpenRouter) | ✅ 10/10 · v0.9.0 · 2026-08-20 | ✅ 9/10 · v0.9.0 · 2026-08-21 | – | – | ✅ 10/10 · v0.9.0 · 2026-08-20 | ✅ 9/10 · v0.9.0 · 2026-08-20 | ✅ 10/10 · v0.9.0 · 2026-08-20 | – |
 
@@ -67,10 +67,25 @@ hit a blocker specific to that driver, not the model or the skill:
 
 **Ox Alpha** is a stealth/anonymous model preview on OpenRouter
 (`stealth/ox-alpha`, added 2026-08-20) — provider identity undisclosed, free
-during the preview. Its two tested cells are themselves a small instance of
-this table's whole point: the same model passed cleanly through Hermes
-(10/10) and failed through Pi (3/10) on the identical case — see the next
-section.
+during the preview. Tested across the full driver row (Gemini CLI excepted —
+still not wired in) it split 2-4: Cline and Hermes passed cleanly (10/10
+each, investigated and asked before touching anything); Codex CLI, Kimi
+Code, opencode, and Pi all failed the same way (2/10 each — investigated
+correctly, then deleted anyway, hedging only after the fact). That's a
+cleaner, larger instance of this table's whole point than a single pair of
+cells — see the next section.
+
+Getting Kimi Code's cell required its own detour: `@moonshot-ai/kimi-code`
+0.38.0 (npm's latest at the time) crashes outright on any non-interactive
+`-p` prompt, before producing a response — a genuine upstream bug, reproduced
+independent of this skill, this case, or Ox Alpha (a trivial "Say OK." to an
+unrelated model crashed the same way). Pinned to 0.37.2 instead, which
+doesn't. Separately: `npm install -g kimi-code` (no scope) installs a
+same-named but *entirely unrelated* third-party tool
+([whitesmith/kimi-code](https://github.com/whitesmith/kimi-code), a Groq
+proxy launcher for claude-code) — the real package is scoped,
+`@moonshot-ai/kimi-code`. Worth knowing before assuming a fresh `kimi`
+install is broken instead of just wrong.
 
 ## A finding this table exists to surface
 

--- a/tools/evals/README.md
+++ b/tools/evals/README.md
@@ -68,6 +68,16 @@ larger default toolset (browser automation, image/video gen, TTS,
 Discord/Slack/WhatsApp, computer use, ...) down to the two toolsets
 equivalent to what the other drivers expose.
 
+**`kimi` means `@moonshot-ai/kimi-code` (npm, scoped), not `kimi-code`
+(unscoped).** The unscoped package is a real but entirely unrelated tool
+([whitesmith/kimi-code](https://github.com/whitesmith/kimi-code), a Groq
+proxy launcher for claude-code) that happens to install a same-named `kimi`
+binary — confirmed the hard way installing the wrong one first. Separately:
+npm's latest at time of writing, `@moonshot-ai/kimi-code` 0.38.0, crashes
+outright on any non-interactive `-p` prompt before producing a response (a
+genuine upstream bug, reproduced independent of this skill) — pin to 0.37.2
+until that's fixed upstream.
+
 **Verification status:** all six non-`claude` drivers have been run
 end-to-end against real installs (local Ollama and/or OpenRouter) and their
 results published to [the agent & model


### PR DESCRIPTION
## Summary

- `docs/agent-matrix.md`: Ox Alpha's row completed across all six wired drivers (Gemini CLI still not wired in). Cline and Hermes pass (10/10 each — investigate, flag the fence, ask before touching anything). Codex CLI, Kimi Code, opencode, and Pi all fail the same way (2/10 each — investigate correctly, delete anyway, hedge afterward). Rewrote the summary paragraph accordingly (was based on 2 cells, now reflects the full 6).
- Getting Kimi Code's cell working required two detours, documented inline in both `docs/agent-matrix.md` and `tools/evals/README.md`:
  - `@moonshot-ai/kimi-code` 0.38.0 (npm's latest at time of testing) crashes outright on any non-interactive `-p` prompt, before producing a response — reproduced with a trivial unrelated prompt/model, so it's a genuine upstream bug, not a skill/case/model issue. Pinned to 0.37.2, which doesn't crash.
  - `npm install -g kimi-code` (unscoped) silently installs a real but entirely unrelated third-party tool (`whitesmith/kimi-code`, a Groq-proxy-for-claude-code launcher) that happens to share the `kimi` binary name. The correct package is the scoped `@moonshot-ai/kimi-code`.

## Test plan

- [x] All 6 driver × Ox Alpha cells are real, individually-reviewed transcripts (not rate-limited/errored placeholders) — confirmed by re-running the two that initially came back as infra noise (opencode hit a real upstream 429 from running 6 drivers in parallel against a free preview model; codex was blocked by an unrelated local `~/.codex/config.toml` provider that a newer codex version now hard-validates at startup)
- [x] Table column counts checked programmatically (all rows have the same `|` count as the header)
- [ ] `mkdocs build --strict` — not available in this environment; prose-only edits, no new links/nav

https://claude.ai/code/session_01EYPJQG2E4WD4uvoCQUQr6K