### PR TITLE
Fix driver error masking: a lone preamble JSON line suppressed real errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 - Ox Alpha's row in `docs/agent-matrix.md` filled in across all six wired drivers (Gemini CLI still not wired in): Cline and Hermes pass (10/10 each), Codex CLI, Kimi Code, opencode, and Pi all fail the same way (2/10 each — investigate correctly, delete anyway). Getting Kimi Code's cell required pinning `@moonshot-ai/kimi-code` to 0.37.2: 0.38.0 (npm's latest) crashes outright on any non-interactive `-p` prompt, reproduced independent of this skill or Ox Alpha. Also found along the way: `npm install -g kimi-code` (unscoped) installs an entirely unrelated same-named third-party tool (`whitesmith/kimi-code`) — the real package is `@moonshot-ai/kimi-code`.
 
+### Fixed
+
+- All six `run_agent_*()` drivers (`claude`, `pi`, `opencode`, `kimi`, `cline`, `codex`) only recorded a driver-level error when the CLI exited non-zero *and* produced zero parseable JSON stdout lines — but several of these CLIs print one harmless preamble line (a version or session-start event) before crashing or failing outright, which was enough to suppress the error entirely. The case then proceeded to the judge with a near-empty transcript and got scored as a normal model/skill failure instead of being flagged as unresolved. Caught twice in one afternoon testing Ox Alpha: Pi's missing-API-key exit and Kimi Code's internal crash (see above) were both about to be recorded as genuine 0/10 fails. Now any non-zero exit is always an error, regardless of `events`; falls back to stdout when stderr is empty. Verified against the Pi repro: now correctly reports `error` (with the real "No API key found" message) instead of a silent `fail`.
+
 ## [0.9.1] - 2026-08-24
 
 ### Added

--- a/tools/evals/run.py
+++ b/tools/evals/run.py
@@ -337,8 +337,8 @@ def run_agent_claude(prompt, cwd, model, timeout, disallowed_tools=None):
         except json.JSONDecodeError:
             pass
     error = None
-    if proc.returncode != 0 and not events:
-        error = f"claude exited {proc.returncode}: {proc.stderr[:2000]}"
+    if proc.returncode != 0:
+        error = f"claude exited {proc.returncode}: {(proc.stderr or proc.stdout)[:2000]}"
     return {"events": events, "error": error}
 
 
@@ -368,8 +368,8 @@ def run_agent_pi(prompt, cwd, model, timeout, disallowed_tools=None):
         except json.JSONDecodeError:
             pass
     error = None
-    if proc.returncode != 0 and not events:
-        error = f"pi exited {proc.returncode}: {proc.stderr[:2000]}"
+    if proc.returncode != 0:
+        error = f"pi exited {proc.returncode}: {(proc.stderr or proc.stdout)[:2000]}"
     return {"events": events, "error": error}
 
 
@@ -408,8 +408,8 @@ def run_agent_opencode(prompt, cwd, model, timeout, disallowed_tools=None):
         except json.JSONDecodeError:
             pass
     error = None
-    if proc.returncode != 0 and not events:
-        error = f"opencode exited {proc.returncode}: {proc.stderr[:2000]}"
+    if proc.returncode != 0:
+        error = f"opencode exited {proc.returncode}: {(proc.stderr or proc.stdout)[:2000]}"
     return {"events": events, "error": error}
 
 
@@ -438,8 +438,8 @@ def run_agent_kimi(prompt, cwd, model, timeout, disallowed_tools=None):
         except json.JSONDecodeError:
             pass
     error = None
-    if proc.returncode != 0 and not events:
-        error = f"kimi exited {proc.returncode}: {proc.stderr[:2000]}"
+    if proc.returncode != 0:
+        error = f"kimi exited {proc.returncode}: {(proc.stderr or proc.stdout)[:2000]}"
     return {"events": events, "error": error}
 
 
@@ -497,8 +497,8 @@ def run_agent_cline(prompt, cwd, model, timeout, disallowed_tools=None):
         except json.JSONDecodeError:
             pass
     error = None
-    if proc.returncode != 0 and not events:
-        error = f"cline exited {proc.returncode}: {proc.stderr[:2000]}"
+    if proc.returncode != 0:
+        error = f"cline exited {proc.returncode}: {(proc.stderr or proc.stdout)[:2000]}"
     return {"events": events, "error": error}
 
 
@@ -548,8 +548,8 @@ def run_agent_codex(prompt, cwd, model, timeout, disallowed_tools=None):
         except json.JSONDecodeError:
             pass
     error = None
-    if proc.returncode != 0 and not events:
-        error = f"codex exited {proc.returncode}: {proc.stderr[:2000]}"
+    if proc.returncode != 0:
+        error = f"codex exited {proc.returncode}: {(proc.stderr or proc.stdout)[:2000]}"
     return {"events": events, "error": error}
 
 


### PR DESCRIPTION
## Summary

- All six `run_agent_*()` drivers (`claude`, `pi`, `opencode`, `kimi`, `cline`, `codex`) only recorded a driver-level error when the CLI exited non-zero **and** produced zero parseable JSON stdout lines. Several of these CLIs print one harmless preamble line (a version/session-start event) before crashing or failing outright — enough to make `events` non-empty and suppress the error entirely. The case then proceeded to the judge with a near-empty transcript and got scored as a genuine model/skill failure instead of being flagged unresolved.
- Caught twice in one afternoon testing Ox Alpha (see #182): Pi's missing-API-key exit and Kimi Code's internal 0.38.0 crash were both about to be recorded as real 0/10 fails, not driver errors.
- Fix: any non-zero exit is now always an error, regardless of `events`; falls back to stdout when stderr is empty.

## Test plan

- [x] `python3 -c "import ast; ast.parse(...)"` — syntax OK
- [x] Reproduced the Pi failure mode (`OPENROUTER_API_KEY` unset, `--driver pi --model openrouter/stealth/ox-alpha --cases chestertons-fence-guard`) — before the fix this silently scored `fail`/0; after the fix it correctly reports `verdict: error` with the real "No API key found for openrouter" message
- [ ] `mkdocs build --strict` — not available in this environment; this PR doesn't touch docs

https://claude.ai/code/session_01EYPJQG2E4WD4uvoCQUQr6K