### PR TITLE
Release 0.9.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "keep-the-why",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Preserves or recovers the reasoning behind a codebase - decisions, rejected alternatives, workarounds, and incident learnings the code alone can't explain.",
   "author": {
     "name": "Oliver Zehentleitner",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ there before re-litigating or accidentally reverting a decision.
 <!-- keep-the-why:config -->
 - context: `context/`
 - init: complete
-- context-schema: 0.9.1
+- context-schema: 0.9.2
 - capture-confirmation: confirm-always
 - source-reference: never
 <!-- /keep-the-why:config -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-08-24
+
 ### Added
 
 - Ox Alpha's row in `docs/agent-matrix.md` filled in across all six wired drivers (Gemini CLI still not wired in): Cline and Hermes pass (10/10 each), Codex CLI, Kimi Code, opencode, and Pi all fail the same way (2/10 each — investigate correctly, delete anyway). Getting Kimi Code's cell required pinning `@moonshot-ai/kimi-code` to 0.37.2: 0.38.0 (npm's latest) crashes outright on any non-interactive `-p` prompt, reproduced independent of this skill or Ox Alpha. Also found along the way: `npm install -g kimi-code` (unscoped) installs an entirely unrelated same-named third-party tool (`whitesmith/kimi-code`) — the real package is `@moonshot-ai/kimi-code`.
@@ -367,7 +369,8 @@ Initial release.
 - Logo, wordmark, and favicon.
 - `context/repo-conventions.md`, dogfooding the skill on its own repository from day one.
 
-[Unreleased]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.9.1...HEAD
+[Unreleased]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.9.2...HEAD
+[0.9.2]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.7.0...v0.8.0

--- a/llms.txt
+++ b/llms.txt
@@ -30,7 +30,7 @@ get thrown away, not creating separate documentation effort. It isn't magic, tho
 prevents knowledge from decaying on its own. This lowers the friction of the discipline that
 keeps documentation honest; it doesn't replace it.
 
-Version: 0.9.1.
+Version: 0.9.2.
 
 ## Authorship & License
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "keep-the-why",
   "description": "Preserves or recovers the reasoning behind a codebase - architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "author": {
     "name": "Oliver Zehentleitner"
   },

--- a/skills/keep-the-why/SKILL.md
+++ b/skills/keep-the-why/SKILL.md
@@ -3,7 +3,7 @@ name: keep-the-why
 description: Preserves or recovers the reasoning behind a codebase - architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain. Use when implementing or reviewing a non-trivial change involving a design decision, workaround, incident fix, operational constraint, rejected alternative, or changed assumption; when documenting an existing or legacy codebase; during onboarding or a maintainer handover; or when interviewing a developer before their knowledge is lost (e.g. before they leave or retire); or when the user expresses frustration with, or reports a problem with, this skill itself. Identifies what the code cannot explain, asks focused questions instead of generic ones, and maintains concise, topic-based, version-controlled documentation readable by both humans and AI agents.
 license: MIT
 metadata:
-  version: "0.9.1"
+  version: "0.9.2"
   repository: "https://github.com/oliver-zehentleitner/keep-the-why"
   author: "Oliver Zehentleitner"
 ---

--- a/skills/keep-the-why/examples/first-time-setup.md
+++ b/skills/keep-the-why/examples/first-time-setup.md
@@ -94,7 +94,7 @@ This happens to be a question the skill's own description matches, which is what
     <!-- keep-the-why:config -->
     - context: `context/`
     - init: complete
-    - context-schema: 0.9.1
+    - context-schema: 0.9.2
     - capture-confirmation: confirm-when-unsure
     - source-reference: never
     <!-- /keep-the-why:config -->

--- a/skills/keep-the-why/references/repository-structure.md
+++ b/skills/keep-the-why/references/repository-structure.md
@@ -63,7 +63,7 @@ prior decisions and avoid re-litigating or accidentally reverting them.
 <!-- keep-the-why:config -->
 - context: `context/`
 - init: complete
-- context-schema: 0.9.1
+- context-schema: 0.9.2
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->

--- a/skills/keep-the-why/references/setup.md
+++ b/skills/keep-the-why/references/setup.md
@@ -12,7 +12,7 @@ Setup state splits across two files, matching the existing `AGENTS.md`/`AGENTS.l
 <!-- keep-the-why:config -->
 - context: `context/`
 - init: complete
-- context-schema: 0.9.1
+- context-schema: 0.9.2
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->


### PR DESCRIPTION
Release checklist for 0.9.2 (#183's trust-model.md defanging + the Ox Alpha matrix work already sitting in Unreleased), per `CONTRIBUTING.md`:

1. `metadata.version` in `SKILL.md` → 0.9.2
2. `llms.txt` Version line → 0.9.2
3. `plugin.json` / `.claude-plugin/plugin.json` version → 0.9.2
4. `CHANGELOG.md`: `[Unreleased]` → `[0.9.2] - 2026-08-24`, fresh empty `[Unreleased]` above, compare-link footer updated
5. `migrations.md` — nothing to add, no `context/` entry format change
6. `context-schema` in `AGENTS.md` advanced to 0.9.2 (no migration needed, just kept in sync)
7. Illustrative `context-schema` examples in `setup.md`, `repository-structure.md`, `first-time-setup.md` → 0.9.2

Version consistency check and `mkdocs build --strict` both pass locally.

Once merged: tag `v0.9.2` and push it (triggers `GH Release`), then comment on #178 asking the reporter to test with 0.9.2 — both candidates we could act on (evals.json's packaging, trust-model.md's payload) are now addressed.