### PR TITLE
Fix the awesome-copilot listing entry: ordering and audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,9 @@ Full install detail for every method, including tools without a skill runtime at
 |---|---|---|
 | [ASM](https://luongnv.com/asm/#/skills/oliver-zehentleitner%2Fkeep-the-why%3A%3Askills%2Fkeep-the-why%3A%3Akeep-the-why) | Live | Curated skill index for the `asm` CLI; installable via `asm install keep-the-why` |
 | [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills#context-engineering) | Live | Listed under "Context Engineering" |
+| [GitHub Copilot plugin marketplace](https://awesome-copilot.github.com/plugin/keep-the-why/) | Live | Installable via `copilot plugin install keep-the-why@awesome-copilot` |
 | [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why) | Live | Backs the `npx skills add` install method above |
 | [SkillsLLM](https://skillsllm.com/skill/keep-the-why) | Live | Verified, passed [SkillsLLM's security scan](https://skillsllm.com/security-check/IPmNycVdbOyq) |
-| [GitHub Copilot plugin marketplace](https://awesome-copilot.github.com/plugin/keep-the-why/) | Live | External plugin listing, version kept current via a PR each release (`CONTRIBUTING.md` step 9) |
 
 ## Example
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -36,9 +36,9 @@ Either form prompts for which of its 70+ supported agents (Claude Code, Codex, O
 |---|---|---|
 | [ASM](https://luongnv.com/asm/#/skills/oliver-zehentleitner%2Fkeep-the-why%3A%3Askills%2Fkeep-the-why%3A%3Akeep-the-why) | Live | Curated skill index for the `asm` CLI; installable via `asm install keep-the-why` |
 | [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills#context-engineering) | Live | Listed under "Context Engineering" |
+| [GitHub Copilot plugin marketplace](https://awesome-copilot.github.com/plugin/keep-the-why/) | Live | Installable via `copilot plugin install keep-the-why@awesome-copilot` |
 | [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why) | Live | Backs the `npx skills add` install method above |
 | [SkillsLLM](https://skillsllm.com/skill/keep-the-why) | Live | Verified, passed [SkillsLLM's security scan](https://skillsllm.com/security-check/IPmNycVdbOyq) |
-| [GitHub Copilot plugin marketplace](https://awesome-copilot.github.com/plugin/keep-the-why/) | Live | External plugin listing, version kept current via a PR each release (`CONTRIBUTING.md` step 9) |
 
 ## Also recommended: GitHub CLI
 

--- a/llms.txt
+++ b/llms.txt
@@ -98,11 +98,11 @@ needing to be told again.
   keep-the-why` — https://luongnv.com/asm/#/skills/oliver-zehentleitner%2Fkeep-the-why%3A%3Askills%2Fkeep-the-why%3A%3Akeep-the-why
 - awesome-agent-skills: live, listed under "Context Engineering" —
   https://github.com/VoltAgent/awesome-agent-skills#context-engineering
+- GitHub Copilot plugin marketplace: live, installable via `copilot plugin install
+  keep-the-why@awesome-copilot` — https://awesome-copilot.github.com/plugin/keep-the-why/
 - skills.sh: https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why — live, backs
   the `npx skills add` method above
 - SkillsLLM: live, verified, passed security scan — https://skillsllm.com/skill/keep-the-why
-- GitHub Copilot plugin marketplace: live, external plugin listing, version kept current via a
-  PR each release — https://awesome-copilot.github.com/plugin/keep-the-why/
 
 ## Core Concept
 


### PR DESCRIPTION
Follow-up to #186 (already merged) — two things wrong with the new GitHub Copilot plugin marketplace row that only showed up after merge:

1. **A-Z ordering was broken** — it sat after SkillsLLM instead of alphabetically between awesome-agent-skills and skills.sh.
2. **Wrong audience** — the Info column said "version kept current via a PR each release (`CONTRIBUTING.md` step 9)", which is maintainer-process detail, not something a reader evaluating or installing the skill needs. Every other row in the table gives reader-facing value (how to install, what it's backed by, what's verified) — rewrote to match: the install command, same style as the ASM and skills.sh rows.

`mkdocs build --strict` passes.