### PR TITLE
Add MCP Market to the Also-Listed-On tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Full install detail for every method, including tools without a skill runtime at
 | [ASM](https://luongnv.com/asm/#/skills/oliver-zehentleitner%2Fkeep-the-why%3A%3Askills%2Fkeep-the-why%3A%3Akeep-the-why) | Live | Curated skill index for the `asm` CLI; installable via `asm install keep-the-why` |
 | [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills#context-engineering) | Live | Listed under "Context Engineering" |
 | [GitHub Copilot plugin marketplace](https://awesome-copilot.github.com/plugin/keep-the-why/) | Live | Installable via `copilot plugin install keep-the-why@awesome-copilot` |
+| [MCP Market](https://mcpmarket.com/tools/skills/keep-the-why) | Live | Skill marketplace listing |
 | [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why) | Live | Backs the `npx skills add` install method above |
 | [SkillsLLM](https://skillsllm.com/skill/keep-the-why) | Live | Verified, passed [SkillsLLM's security scan](https://skillsllm.com/security-check/IPmNycVdbOyq) |
 

--- a/README.md
+++ b/README.md
@@ -114,14 +114,14 @@ Full install detail for every method, including tools without a skill runtime at
 
 ### Also listed on
 
-| Name | Status | Info |
-|---|---|---|
-| [ASM](https://luongnv.com/asm/#/skills/oliver-zehentleitner%2Fkeep-the-why%3A%3Askills%2Fkeep-the-why%3A%3Akeep-the-why) | Live | Curated skill index for the `asm` CLI; installable via `asm install keep-the-why` |
-| [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills#context-engineering) | Live | Listed under "Context Engineering" |
-| [GitHub Copilot plugin marketplace](https://awesome-copilot.github.com/plugin/keep-the-why/) | Live | Installable via `copilot plugin install keep-the-why@awesome-copilot` |
-| [MCP Market](https://mcpmarket.com/tools/skills/keep-the-why) | Live | Skill marketplace listing |
-| [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why) | Live | Backs the `npx skills add` install method above |
-| [SkillsLLM](https://skillsllm.com/skill/keep-the-why) | Live | Verified, passed [SkillsLLM's security scan](https://skillsllm.com/security-check/IPmNycVdbOyq) |
+| Name | Info |
+|---|---|
+| [ASM](https://luongnv.com/asm/#/skills/oliver-zehentleitner%2Fkeep-the-why%3A%3Askills%2Fkeep-the-why%3A%3Akeep-the-why) | Curated skill index for the `asm` CLI; installable via `asm install keep-the-why` |
+| [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills#context-engineering) | Listed under "Context Engineering" |
+| [GitHub Copilot plugin marketplace](https://awesome-copilot.github.com/plugin/keep-the-why/) | Installable via `copilot plugin install keep-the-why@awesome-copilot` |
+| [MCP Market](https://mcpmarket.com/tools/skills/keep-the-why) | Skill marketplace listing |
+| [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why) | Backs the `npx skills add` install method above |
+| [SkillsLLM](https://skillsllm.com/skill/keep-the-why) | Verified, passed [SkillsLLM's security scan](https://skillsllm.com/security-check/IPmNycVdbOyq) |
 
 ## Example
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,6 +37,7 @@ Either form prompts for which of its 70+ supported agents (Claude Code, Codex, O
 | [ASM](https://luongnv.com/asm/#/skills/oliver-zehentleitner%2Fkeep-the-why%3A%3Askills%2Fkeep-the-why%3A%3Akeep-the-why) | Live | Curated skill index for the `asm` CLI; installable via `asm install keep-the-why` |
 | [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills#context-engineering) | Live | Listed under "Context Engineering" |
 | [GitHub Copilot plugin marketplace](https://awesome-copilot.github.com/plugin/keep-the-why/) | Live | Installable via `copilot plugin install keep-the-why@awesome-copilot` |
+| [MCP Market](https://mcpmarket.com/tools/skills/keep-the-why) | Live | Skill marketplace listing |
 | [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why) | Live | Backs the `npx skills add` install method above |
 | [SkillsLLM](https://skillsllm.com/skill/keep-the-why) | Live | Verified, passed [SkillsLLM's security scan](https://skillsllm.com/security-check/IPmNycVdbOyq) |
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -32,14 +32,14 @@ Either form prompts for which of its 70+ supported agents (Claude Code, Codex, O
 
 ## Also listed on
 
-| Name | Status | Info |
-|---|---|---|
-| [ASM](https://luongnv.com/asm/#/skills/oliver-zehentleitner%2Fkeep-the-why%3A%3Askills%2Fkeep-the-why%3A%3Akeep-the-why) | Live | Curated skill index for the `asm` CLI; installable via `asm install keep-the-why` |
-| [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills#context-engineering) | Live | Listed under "Context Engineering" |
-| [GitHub Copilot plugin marketplace](https://awesome-copilot.github.com/plugin/keep-the-why/) | Live | Installable via `copilot plugin install keep-the-why@awesome-copilot` |
-| [MCP Market](https://mcpmarket.com/tools/skills/keep-the-why) | Live | Skill marketplace listing |
-| [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why) | Live | Backs the `npx skills add` install method above |
-| [SkillsLLM](https://skillsllm.com/skill/keep-the-why) | Live | Verified, passed [SkillsLLM's security scan](https://skillsllm.com/security-check/IPmNycVdbOyq) |
+| Name | Info |
+|---|---|
+| [ASM](https://luongnv.com/asm/#/skills/oliver-zehentleitner%2Fkeep-the-why%3A%3Askills%2Fkeep-the-why%3A%3Akeep-the-why) | Curated skill index for the `asm` CLI; installable via `asm install keep-the-why` |
+| [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills#context-engineering) | Listed under "Context Engineering" |
+| [GitHub Copilot plugin marketplace](https://awesome-copilot.github.com/plugin/keep-the-why/) | Installable via `copilot plugin install keep-the-why@awesome-copilot` |
+| [MCP Market](https://mcpmarket.com/tools/skills/keep-the-why) | Skill marketplace listing |
+| [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why) | Backs the `npx skills add` install method above |
+| [SkillsLLM](https://skillsllm.com/skill/keep-the-why) | Verified, passed [SkillsLLM's security scan](https://skillsllm.com/security-check/IPmNycVdbOyq) |
 
 ## Also recommended: GitHub CLI
 

--- a/llms.txt
+++ b/llms.txt
@@ -94,16 +94,16 @@ needing to be told again.
 
 ## Also Listed On
 
-- ASM: live, curated skill index for the `asm` CLI, installable via `asm install
+- ASM: curated skill index for the `asm` CLI, installable via `asm install
   keep-the-why` — https://luongnv.com/asm/#/skills/oliver-zehentleitner%2Fkeep-the-why%3A%3Askills%2Fkeep-the-why%3A%3Akeep-the-why
-- awesome-agent-skills: live, listed under "Context Engineering" —
+- awesome-agent-skills: listed under "Context Engineering" —
   https://github.com/VoltAgent/awesome-agent-skills#context-engineering
-- GitHub Copilot plugin marketplace: live, installable via `copilot plugin install
+- GitHub Copilot plugin marketplace: installable via `copilot plugin install
   keep-the-why@awesome-copilot` — https://awesome-copilot.github.com/plugin/keep-the-why/
-- MCP Market: live, skill marketplace listing — https://mcpmarket.com/tools/skills/keep-the-why
-- skills.sh: https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why — live, backs
+- MCP Market: skill marketplace listing — https://mcpmarket.com/tools/skills/keep-the-why
+- skills.sh: https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why — backs
   the `npx skills add` method above
-- SkillsLLM: live, verified, passed security scan — https://skillsllm.com/skill/keep-the-why
+- SkillsLLM: verified, passed security scan — https://skillsllm.com/skill/keep-the-why
 
 ## Core Concept
 

--- a/llms.txt
+++ b/llms.txt
@@ -100,6 +100,7 @@ needing to be told again.
   https://github.com/VoltAgent/awesome-agent-skills#context-engineering
 - GitHub Copilot plugin marketplace: live, installable via `copilot plugin install
   keep-the-why@awesome-copilot` — https://awesome-copilot.github.com/plugin/keep-the-why/
+- MCP Market: live, skill marketplace listing — https://mcpmarket.com/tools/skills/keep-the-why
 - skills.sh: https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why — live, backs
   the `npx skills add` method above
 - SkillsLLM: live, verified, passed security scan — https://skillsllm.com/skill/keep-the-why


### PR DESCRIPTION
New listing: https://mcpmarket.com/tools/skills/keep-the-why

Note: couldn't independently verify the page content — it's behind a Vercel bot-checkpoint that blocks automated fetches (WebFetch and curl both got a JS challenge page, not the real listing). Added a minimal, conservative entry ("Live" / "Skill marketplace listing") matching the existing table format rather than guessing at specifics like an install command or verification status. Let me know if the actual listing page says something more specific that should be reflected here.
