### PR TITLE
docs: turn Also listed on table into a plain link list

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,14 +114,12 @@ Full install detail for every method, including tools without a skill runtime at
 
 ### Also listed on
 
-| Name | Info |
-|---|---|
-| [ASM](https://luongnv.com/asm/#/skills/oliver-zehentleitner%2Fkeep-the-why%3A%3Askills%2Fkeep-the-why%3A%3Akeep-the-why) | Curated skill index for the `asm` CLI; installable via `asm install keep-the-why` |
-| [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills#context-engineering) | Listed under "Context Engineering" |
-| [GitHub Copilot plugin marketplace](https://awesome-copilot.github.com/plugin/keep-the-why/) | Installable via `copilot plugin install keep-the-why@awesome-copilot` |
-| [MCP Market](https://mcpmarket.com/tools/skills/keep-the-why) | Skill marketplace listing |
-| [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why) | Backs the `npx skills add` install method above |
-| [SkillsLLM](https://skillsllm.com/skill/keep-the-why) | Verified, passed [SkillsLLM's security scan](https://skillsllm.com/security-check/IPmNycVdbOyq) |
+- [ASM](https://luongnv.com/asm/#/skills/oliver-zehentleitner%2Fkeep-the-why%3A%3Askills%2Fkeep-the-why%3A%3Akeep-the-why)
+- [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills#context-engineering)
+- [GitHub Copilot plugin marketplace](https://awesome-copilot.github.com/plugin/keep-the-why/)
+- [MCP Market](https://mcpmarket.com/tools/skills/keep-the-why)
+- [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why)
+- [SkillsLLM](https://skillsllm.com/skill/keep-the-why)
 
 ## Example
 


### PR DESCRIPTION
## Summary
- "Also listed on" in the README was a two-column table with an Info column
- Converted to a plain bullet list of linked names, Info column dropped entirely