### PR TITLE
release: 0.10.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "keep-the-why",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "Preserves or recovers the reasoning behind a codebase - decisions, rejected alternatives, workarounds, and incident learnings the code alone can't explain.",
   "author": {
     "name": "Oliver Zehentleitner",

--- a/.github/workflows/validate-skill.yml
+++ b/.github/workflows/validate-skill.yml
@@ -39,7 +39,7 @@ jobs:
           check plugin.json '(?<="version": ")[0-9]+\.[0-9]+\.[0-9]+'
           check .claude-plugin/plugin.json '(?<="version": ")[0-9]+\.[0-9]+\.[0-9]+'
           check llms.txt '(?<=^Version: )[0-9]+\.[0-9]+\.[0-9]+'
-          check AGENTS.md '(?<=context-schema: )[0-9]+\.[0-9]+\.[0-9]+'
+          check .keep-the-why '(?<=context-schema: )[0-9]+\.[0-9]+\.[0-9]+'
           check skills/keep-the-why/references/setup.md '(?<=context-schema: )[0-9]+\.[0-9]+\.[0-9]+'
           check skills/keep-the-why/references/repository-structure.md '(?<=context-schema: )[0-9]+\.[0-9]+\.[0-9]+'
           check skills/keep-the-why/examples/first-time-setup.md '(?<=context-schema: )[0-9]+\.[0-9]+\.[0-9]+'

--- a/.keep-the-why
+++ b/.keep-the-why
@@ -1,0 +1,12 @@
+This is machine-readable project state for the Keep the Why skill
+(https://keepthewhy.com). See context/index.md, or this project's own
+README, for what Keep the Why actually is.
+
+<!-- keep-the-why:config -->
+- id: oliver-zehentleitner---keep-the-why
+- context: `context/`
+- init: complete
+- context-schema: 0.10.0
+- capture-confirmation: confirm-always
+- source-reference: never
+<!-- /keep-the-why:config -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,13 +10,8 @@ Read `context/index.md` before making non-trivial changes — naming, docs
 tooling, and repo structure have already been argued through once; check
 there before re-litigating or accidentally reverting a decision.
 
-<!-- keep-the-why:config -->
-- context: `context/`
-- init: complete
-- context-schema: 0.9.2
-- capture-confirmation: confirm-always
-- source-reference: never
-<!-- /keep-the-why:config -->
+Keep the Why's config for this project migrated to .keep-the-why on
+2026-09-01 — requires skill version 0.10.0 or later to read it.
 
 ## Working conventions (no why needed, just follow these)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-09-01
+
 ### Added
 
 - A judge anti-hallucination rule in `tools/evals/run.py`'s `JUDGE_PROMPT`: every concrete factual claim in the judge's `reasoning` must be traceable to something literally present in the transcript/diff it was given, or stated as inference rather than fact — a direct response to the one confirmed judge hallucination already on record (the fabricated `SessionStart`-hook detail, see `docs/evals.md`).
@@ -24,6 +26,7 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Fixed
 
+- `.github/workflows/validate-skill.yml`'s "Check version consistency across the repo" step still greped `AGENTS.md` for `context-schema` — stale since the config move above relocated that field to `.keep-the-why`. Caught while migrating this repo's own `context/` for the 0.10.0 release (checklist step 6): the check would otherwise report a mismatch against every project's own migrated config, this repo's included. Now checks `.keep-the-why` instead.
 - `update-check-cannot-run-surfaced-once` and `update-check-repeat-failure-no-reask` fixtures simulated "no web access this session" by denying `WebFetch`/`WebSearch` only — Bash could still reach the network directly, so the agent used `curl` and got a real, successful GitHub API response instead of the intended failure. Found while re-testing both under the new `SessionStart` hook above (`update-check-repeat-failure-no-reask` had been passing already, but by coincidence — a genuine successful check is also valid output for its expected behavior, so the bug was silent). Fixed by also denying `Bash(curl *)`/`Bash(wget *)` in both `case.json` files; both now correctly simulate the failure and pass for the right reason.
 
 ## [0.9.2] - 2026-08-24

--- a/context/AGENTS.md
+++ b/context/AGENTS.md
@@ -1,0 +1,1 @@
+Before creating or editing anything in this directory, invoke the keep-the-why skill. Don't write to the schema by hand.

--- a/context/CLAUDE.md
+++ b/context/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/llms.txt
+++ b/llms.txt
@@ -30,7 +30,7 @@ get thrown away, not creating separate documentation effort. It isn't magic, tho
 prevents knowledge from decaying on its own. This lowers the friction of the discipline that
 keeps documentation honest; it doesn't replace it.
 
-Version: 0.9.2.
+Version: 0.10.0.
 
 ## Authorship & License
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "keep-the-why",
   "description": "Preserves or recovers the reasoning behind a codebase - architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "author": {
     "name": "Oliver Zehentleitner"
   },

--- a/skills/keep-the-why/SKILL.md
+++ b/skills/keep-the-why/SKILL.md
@@ -3,7 +3,7 @@ name: keep-the-why
 description: Preserves or recovers the reasoning behind a codebase - architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain. Use when implementing or reviewing a non-trivial change involving a design decision, workaround, incident fix, operational constraint, rejected alternative, or changed assumption; when documenting an existing or legacy codebase; during onboarding or a maintainer handover; or when interviewing a developer before their knowledge is lost (e.g. before they leave or retire); or when the user expresses frustration with, or reports a problem with, this skill itself. Identifies what the code cannot explain, asks focused questions instead of generic ones, and maintains concise, topic-based, version-controlled documentation readable by both humans and AI agents.
 license: MIT
 metadata:
-  version: "0.9.2"
+  version: "0.10.0"
   repository: "https://github.com/oliver-zehentleitner/keep-the-why"
   author: "Oliver Zehentleitner"
 ---

--- a/skills/keep-the-why/examples/first-time-setup.md
+++ b/skills/keep-the-why/examples/first-time-setup.md
@@ -109,7 +109,7 @@ This names the skill and its purpose directly — not a task that happens to mat
     - id: acme---widget-service
     - context: `context/`
     - init: complete
-    - context-schema: 0.9.2
+    - context-schema: 0.10.0
     - capture-confirmation: confirm-when-unsure
     - source-reference: never
     <!-- /keep-the-why:config -->

--- a/skills/keep-the-why/references/migrations.md
+++ b/skills/keep-the-why/references/migrations.md
@@ -4,7 +4,7 @@ What changed in each version that an existing project may need to know about or 
 
 Entries below assume 0.2.0 as the starting point — nothing before it tracked a `context-schema` at all, and 0.2.0 itself introduced no `context/` entry format change.
 
-## Unreleased — Project/personal config moves into dedicated `.keep-the-why` files
+## 0.10.0 — Project/personal config moves into dedicated `.keep-the-why` files
 
 **What changed:** the project config block (`<!-- keep-the-why:config -->`) moves out of the entry-point file (`AGENTS.md`, or whatever a project already uses) into a dedicated `.keep-the-why` file at the project root. The personal config block (`<!-- keep-the-why:local -->`) moves out of `AGENTS.local.md` into a dedicated, non-project file at `~/.keep-the-why/<id>.md`, keyed by a new `id` field the project file now carries. See "Why dedicated files, not entry-point blocks" in `context/config-format.md` for the reasoning, and `references/setup.md` for the full format and detection logic. Three optional additions ship alongside the relocation, none of which existing projects are required to adopt: a `personal-defaults` block a project can offer new developers (plus a machine-wide `~/.keep-the-why/config` policy governing whether that's asked about or auto-applied), `pinned-version`/`pinned-path` fields for pinning to a vendored skill copy, and `context/AGENTS.md` + `context/CLAUDE.md` guard files. Not a `context/` entry-format change — existing entries are untouched — but it needs real action from an existing project, not a silent backfill.
 
@@ -52,7 +52,7 @@ Keep the Why's config for this project migrated to .keep-the-why on
 2026-08-31 — requires skill version 0.10.0 or later to read it.
 ```
 
-## Unreleased — `context/index.md` entries sorted alphabetically
+## 0.10.0 — `context/index.md` entries sorted alphabetically
 
 **What changed:** new entries in `context/index.md` are inserted in alphabetical order by filename instead of appended at the end — see `context/entry-format.md` and [#194](https://github.com/oliver-zehentleitner/keep-the-why/issues/194). Not a `context/` entry-format change, but it does need action in an existing project: the merge-conflict reduction this convention exists for only works once the whole list is actually sorted.
 

--- a/skills/keep-the-why/references/repository-structure.md
+++ b/skills/keep-the-why/references/repository-structure.md
@@ -77,7 +77,7 @@ README, for what Keep the Why actually is.
 - id: acme---widget-service
 - context: `context/`
 - init: complete
-- context-schema: 0.9.2
+- context-schema: 0.10.0
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->

--- a/skills/keep-the-why/references/setup.md
+++ b/skills/keep-the-why/references/setup.md
@@ -17,7 +17,7 @@ README, for what Keep the Why actually is.
 - id: oliver-zehentleitner---keep-the-why
 - context: `context/`
 - init: complete
-- context-schema: 0.9.2
+- context-schema: 0.10.0
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->


### PR DESCRIPTION
## Summary
- Version bump 0.9.2 → 0.10.0: `SKILL.md` metadata.version, `plugin.json`/`.claude-plugin/plugin.json`, `llms.txt`, illustrative context-schema examples in `setup.md`/`repository-structure.md`/`first-time-setup.md`
- `CHANGELOG.md`: `[Unreleased]` rolled into `[0.10.0] - 2026-09-01`, fresh empty `[Unreleased]` above
- `migrations.md`: the two `Unreleased` sections (config move to `.keep-the-why`, `context/index.md` alphabetical sort) renamed to `0.10.0`
- Dogfoods this repo's own migration (release checklist step 6): `.keep-the-why` created (context-schema 0.10.0), config block removed from `AGENTS.md`, `context/AGENTS.md`+`context/CLAUDE.md` guard files added, personal block moved out of `AGENTS.local.md`
- Fixes `validate-skill.yml`'s version-consistency check, which still greped `AGENTS.md` for `context-schema` — stale since that field moved to `.keep-the-why`; would have false-failed against this repo's own migrated config

## Consistency check performed before this PR
- Version-consistency check (the one `validate-skill.yml` runs) — clean at 0.9.2 baseline, clean at 0.10.0 after bump
- `skills-ref` validate on `skills/keep-the-why` — valid
- `evals.json` well-formed, 73 cases, matches every hardcoded count reference
- `mkdocs build --strict` — clean (only the known upstream MkDocs-2.0 vendor warning)
- `migrations.md` already covered everything since 0.9.2 (two Unreleased entries, now renamed)
- No open PRs, CI green on `main`; a transient 429 from mcpmarket.com in the link checker, not a real broken link

## Test plan
- [ ] Oliver reviews and merges
- [ ] Tag `v0.10.0` and push (triggers `GH Release`) — on separate explicit go-ahead, not part of this PR