### PR TITLE
fix: exclude mcpmarket.com from Link Check

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -5,3 +5,9 @@
 # architecture.md) resolve only after the runner overlays the shared _base
 # fixture at runtime, so checking them as repo files produces false positives.
 exclude_path = ["tools/evals/fixtures"]
+
+# mcpmarket.com rate-limits lychee's request bursts with 429s (seen repeatedly
+# on the "Also listed on" link across README.md/llms.txt/docs/installation.md,
+# unrelated to the link's actual validity) - skip it rather than have Link
+# Check flake red on every push that touches any of those files.
+exclude = ["^https://mcpmarket\\.com/"]


### PR DESCRIPTION
## Summary
- Link Check has flaked red on `PR #201`/`#202` with `[429] https://mcpmarket.com/tools/skills/keep-the-why ... Rejected status code: 429 Too Many Requests` — not a broken link, mcpmarket.com just rate-limits lychee's request bursts.
- Added an `exclude` regex for `mcpmarket.com` to `lychee.toml` so Link Check stops flaking on any push that touches `README.md`/`llms.txt`/`docs/installation.md`.

## Test plan
- [ ] Link Check passes clean on this PR (no more 429 on the mcpmarket.com line)
- [ ] Oliver reviews and merges