### PR TITLE
docs(skill): shorten description, add edge cases + example section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+### Changed
+
+- `SKILL.md` frontmatter `description` shortened from 118 to 27 words and reworded to start with a recognized action verb ("Extract and preserve...", was "Preserves or recovers..."), with an explicit negative-trigger clause pointing to `CHANGELOG.md`/Keep a Changelog for "what changed" — the removed detail (the four modes, the frustration/problem-report trigger) was already duplicated in the body's `## When to use this skill` and `## Feedback` sections, so nothing was lost. Prompted by an `asm eval` (agent-skill-manager) run scoring this skill 71/100 (C), citing the 877-char description as both over that tool's ~250-char runtime-truncation budget and unrecognized as imperative.
+- `SKILL.md` gained a `## Edge cases` section (the prior inline "When not to use it" sentence, restructured as a bullet list with one addition: corrections per rule 6 are explicitly out of scope) and an `## Example` section showing the expected `context/` topic-file output of workflow step 5, reusing the existing example already in `references/repository-structure.md` rather than inventing new content.
+- Net effect of the above, re-scored with the same `asm eval`: 71/100 (C) → 90/100 (A); `skill-best-practice` sub-score 86/100 → 100/100 pass. The two remaining lower-scoring categories (context efficiency, more imperative voice throughout) would require splitting `## Core rules` across files or flattening its intentionally precise wording — left alone as genuine trade-offs, not pursued here.
+
 ## [0.10.0] - 2026-09-01
 
 ### Added

--- a/skills/keep-the-why/SKILL.md
+++ b/skills/keep-the-why/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: keep-the-why
-description: Preserves or recovers the reasoning behind a codebase - architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain. Use when implementing or reviewing a non-trivial change involving a design decision, workaround, incident fix, operational constraint, rejected alternative, or changed assumption; when documenting an existing or legacy codebase; during onboarding or a maintainer handover; or when interviewing a developer before their knowledge is lost (e.g. before they leave or retire); or when the user expresses frustration with, or reports a problem with, this skill itself. Identifies what the code cannot explain, asks focused questions instead of generic ones, and maintains concise, topic-based, version-controlled documentation readable by both humans and AI agents.
+description: Extract and preserve the reasoning code cannot explain - decisions, rejected alternatives, workarounds, incidents, and constraints. Not for what changed (see Keep a Changelog) - only why.
 license: MIT
 metadata:
   version: "0.10.0"
@@ -21,7 +21,16 @@ Four modes, all part of the same job:
 3. **Knowledge-transfer interview** — when a maintainer's knowledge is about to become unavailable, analyze the repository first, then either ask targeted questions about exactly what the code couldn't explain, or — for someone whose knowledge is broad and tacit, e.g. a long-tenured maintainer — let them narrate freely and extract rationale from that instead. See `references/interview-playbook.md` for both techniques.
 4. **Maintenance** — keep existing rationale current: resolve contradictions, mark superseded entries, merge duplicates, split files that have grown too large.
 
-**When not to use it:** routine implementation detail, generic formatting or style changes, or anything already fully and obviously explained by the code. Not every change is a decision worth a `context/` entry — see rule 13's proportionality gate.
+## Edge cases
+
+Don't create a `context/` entry for:
+
+- Routine implementation detail with no rejected alternative behind it.
+- Generic formatting or style changes.
+- Anything already fully and obviously explained by the code itself.
+- A correction — restoring something to what it should already have been (rule 6) — as opposed to a genuine fork between contending options.
+
+Not every change is a decision worth a `context/` entry — see rule 13's proportionality gate.
 
 ## Composition with other skills
 
@@ -105,6 +114,33 @@ Before the actual write, resolve the effective `capture-confirmation` setting (r
 ### 6. Maintain
 
 Update existing topics rather than accumulating new ones, resolve contradictions when found, mark superseded information instead of deleting it, split files once they get large. This is what keeps the system *living* instead of another pile of stale docs no one trusts. The same confirmation settings (rule 11) apply here too — and regardless of setting, `automatic` never permits silently deleting, reinterpreting, or replacing already-confirmed historical information with weaker evidence; maintenance changes to existing entries still get the same scrutiny superseding or contradicting something deserves.
+
+## Example
+
+Expected output of step 5 above — a `context/` topic file entry (full field reference: `references/repository-structure.md`):
+
+```markdown
+## Snapshot-before-buffer ordering
+
+**Type:** decision
+**Status:** active
+**Evidence:** confirmed
+**Source:** maintainer interview, 2026-03-14; incident postmortem 2025-11, `incidents.md`
+**Revisit when:** the sync protocol or snapshot mechanism changes
+
+The sync step always waits for a full snapshot before applying any
+buffered events, even though this adds latency on cold start.
+
+**Reason:** applying buffered events before the snapshot landed caused
+duplicate-then-overwritten state during a 2025-11 incident. The
+ordering constraint isn't visible in the code — it looks like it
+could safely be parallelized, and someone tried exactly that once.
+
+**Rejected alternative:** run snapshot and buffer replay in parallel,
+then reconcile. Rejected because reconciliation logic was hard to get
+right and the incident showed it wasn't actually needed if ordering
+was enforced instead.
+```
 
 ## Target repository structure
 


### PR DESCRIPTION
## Summary

An `asm eval` (agent-skill-manager) run scored this skill's `SKILL.md` 71/100 (C), mostly on the frontmatter `description`: 877 chars against that tool's ~250-char runtime-truncation budget, and starting with "Preserves" instead of a recognized imperative verb. This shortens the description without losing any information, and adds two additive sections the eval flagged as missing.

## Changes

- `description` shortened from 118 to 27 words, reworded to start with a recognized action verb ("Extract and preserve..."), with an explicit negative-trigger clause (Keep a Changelog for "what changed"). The dropped detail (four modes, the frustration/problem-report trigger) was already duplicated in the body's `## When to use this skill` and `## Feedback` sections.
- New `## Edge cases` section: the prior inline "When not to use it" sentence, restructured as bullets, plus one addition (corrections per rule 6 are out of scope).
- New `## Example` section: the expected `context/` output of workflow step 5, reusing the existing example already in `references/repository-structure.md`.
- `CHANGELOG.md` entry under `[Unreleased]`.

## Result

`asm eval`: 71/100 (C) → 90/100 (A). `skill-best-practice` sub-score: 86/100 → 100/100 pass.

Two lower-scoring categories (context efficiency, more imperative voice throughout `## Core rules`) were left alone — fixing those would mean splitting the core rules across files or flattening their intentionally precise wording, real trade-offs rather than free wins.

## Test plan

- [x] `asm eval` re-run confirms 90/100 (A)
- [x] Reviewed that no information from the old description was lost (cross-checked against body sections)