### PR TITLE
release: 0.10.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "keep-the-why",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Preserves or recovers the reasoning behind a codebase - decisions, rejected alternatives, workarounds, and incident learnings the code alone can't explain.",
   "author": {
     "name": "Oliver Zehentleitner",

--- a/.keep-the-why
+++ b/.keep-the-why
@@ -6,7 +6,7 @@ README, for what Keep the Why actually is.
 - id: oliver-zehentleitner---keep-the-why
 - context: `context/`
 - init: complete
-- context-schema: 0.10.0
+- context-schema: 0.10.1
 - capture-confirmation: confirm-always
 - source-reference: never
 <!-- /keep-the-why:config -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+## [0.10.1] - 2026-09-01
+
 ### Changed
 
 - `SKILL.md` frontmatter `description` shortened from 118 to 27 words and reworded to start with a recognized action verb ("Extract and preserve...", was "Preserves or recovers..."), with an explicit negative-trigger clause pointing to `CHANGELOG.md`/Keep a Changelog for "what changed" — the removed detail (the four modes, the frustration/problem-report trigger) was already duplicated in the body's `## When to use this skill` and `## Feedback` sections, so nothing was lost. Prompted by an `asm eval` (agent-skill-manager) run scoring this skill 71/100 (C), citing the 877-char description as both over that tool's ~250-char runtime-truncation budget and unrecognized as imperative.
@@ -404,7 +406,8 @@ Initial release.
 - Logo, wordmark, and favicon.
 - `context/repo-conventions.md`, dogfooding the skill on its own repository from day one.
 
-[Unreleased]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.10.1...HEAD
+[0.10.1]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.9.2...v0.10.0
 [0.9.2]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.9.0...v0.9.1

--- a/llms.txt
+++ b/llms.txt
@@ -30,7 +30,7 @@ get thrown away, not creating separate documentation effort. It isn't magic, tho
 prevents knowledge from decaying on its own. This lowers the friction of the discipline that
 keeps documentation honest; it doesn't replace it.
 
-Version: 0.10.0.
+Version: 0.10.1.
 
 ## Authorship & License
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "keep-the-why",
   "description": "Preserves or recovers the reasoning behind a codebase - architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "author": {
     "name": "Oliver Zehentleitner"
   },

--- a/skills/keep-the-why/SKILL.md
+++ b/skills/keep-the-why/SKILL.md
@@ -3,7 +3,7 @@ name: keep-the-why
 description: Extract and preserve the reasoning code cannot explain - decisions, rejected alternatives, workarounds, incidents, and constraints. Not for what changed (see Keep a Changelog) - only why.
 license: MIT
 metadata:
-  version: "0.10.0"
+  version: "0.10.1"
   repository: "https://github.com/oliver-zehentleitner/keep-the-why"
   author: "Oliver Zehentleitner"
 ---

--- a/skills/keep-the-why/examples/first-time-setup.md
+++ b/skills/keep-the-why/examples/first-time-setup.md
@@ -109,7 +109,7 @@ This names the skill and its purpose directly — not a task that happens to mat
     - id: acme---widget-service
     - context: `context/`
     - init: complete
-    - context-schema: 0.10.0
+    - context-schema: 0.10.1
     - capture-confirmation: confirm-when-unsure
     - source-reference: never
     <!-- /keep-the-why:config -->

--- a/skills/keep-the-why/references/repository-structure.md
+++ b/skills/keep-the-why/references/repository-structure.md
@@ -77,7 +77,7 @@ README, for what Keep the Why actually is.
 - id: acme---widget-service
 - context: `context/`
 - init: complete
-- context-schema: 0.10.0
+- context-schema: 0.10.1
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->

--- a/skills/keep-the-why/references/setup.md
+++ b/skills/keep-the-why/references/setup.md
@@ -17,7 +17,7 @@ README, for what Keep the Why actually is.
 - id: oliver-zehentleitner---keep-the-why
 - context: `context/`
 - init: complete
-- context-schema: 0.10.0
+- context-schema: 0.10.1
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->


### PR DESCRIPTION
## Summary

- Bumps `metadata.version` (`SKILL.md`), `plugin.json`, `.claude-plugin/plugin.json`, and `llms.txt`'s `Version:` line from 0.10.0 to 0.10.1.
- Rolls `[Unreleased]` into `[0.10.1] - 2026-09-01` in `CHANGELOG.md` (the description/edge-cases/example improvements from #205) and adds a fresh empty `[Unreleased]` above it, plus the compare-link footer entry.
- Advances this repo's own `context-schema` (`.keep-the-why`) to 0.10.1 and bumps the illustrative `context-schema` examples in `setup.md`, `repository-structure.md`, and `examples/first-time-setup.md` to match (release checklist steps 6-7) — nothing in `migrations.md` applied since #205 only touched `SKILL.md` prose/structure, not the `context/` format or a structural convention.
- Left the historical version markers alone on purpose: `migrations.md`'s 0.9.2→0.10.0 before/after migration example, `AGENTS.md`'s "migrated to `.keep-the-why` on 2026-09-01 - requires 0.10.0 or later" note, and `setup.md`'s `0.9.0 < 0.10.0` comparison example all describe a specific past version, not current state.

## Test plan

- [x] Re-ran the CI "Check version consistency across the repo" logic locally — all seven checked files agree on 0.10.1