### PR TITLE
feat: ship this repo's own SessionStart hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "found=\"\"; if [ -f .keep-the-why ]; then found=1; fi; if [ -z \"$found\" ]; then for f in */.keep-the-why; do if [ -f \"$f\" ]; then found=1; break; fi; done; fi; if [ -n \"$found\" ]; then echo '{\"hookSpecificOutput\":{\"hookEventName\":\"SessionStart\",\"additionalContext\":\"This project uses the keep-the-why skill (a .keep-the-why config file exists). Load the keep-the-why skill now, before other work.\"}}'; fi; exit 0"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+### Added
+
+- `.claude/settings.json` at the project root, committed: the `SessionStart` hook documented in `references/autostart.md`'s Claude Code section, checking for `.keep-the-why` and injecting a reminder to load the skill. This repo dogfooded the eval fixture's version of the hook but never actually shipped a live one of its own — caught after the `.keep-the-why` migration ([0.10.0](#0100---2026-09-01)) silently broke the *personal* variant of this same hook some developers had set up against the old `AGENTS.md`-embedded marker instead.
+
 ## [0.10.1] - 2026-09-01
 
 ### Changed

--- a/context/compatibility.md
+++ b/context/compatibility.md
@@ -66,3 +66,17 @@ An organic activation — the skill's own broad description happening to match a
 **Rejected alternative:** keep proposing setup on organic activation, but only once per project, remembering the decline (the design this replaces). Rejected — this still means the very first organic activation in a never-opted-in project interrupts with a setup question nobody asked for; remembering not to ask again is a mitigation, not a fix for the actual complaint.
 
 **Consequence:** `init: declined` still exists, but with a narrower job — it no longer needs to suppress organic re-asking (the gate already does that unconditionally), it only prevents a *later, separate* explicit request-then-retraction on the same project from re-running the wizard from scratch if resumed. See `references/setup.md`'s "Detection and the two independent wizards." This also makes a related, independently-reported finding largely moot: an agent that once substituted the skill's own `init: declined` mechanism with Claude Code's own out-of-repo auto-memory feature to suppress being asked again (issue #198) had nothing to suppress in the first place once organic activation stopped proposing setup — there's no longer a recurring, unwanted question to route around.
+
+## Marker-based SessionStart hooks checking only `AGENTS.md` silently broke after the `.keep-the-why` migration
+
+**Type:** incident
+**Status:** active
+**Evidence:** confirmed
+
+The 0.10.0 config relocation (`config-format.md`) moved the `<!-- keep-the-why:config -->` marker out of `AGENTS.md` into `.keep-the-why`. `references/autostart.md`'s documented Claude Code hook example was updated to check `.keep-the-why` in the same PR (#197) that did the migration — but a developer's own *personal*, machine-wide `SessionStart` hook, copied out of that example earlier and living outside any repo, isn't reachable by a project-level PR. It went silent for this repo the moment it migrated: no error, the activation nudge just stopped firing.
+
+**Reason:** `references/migrations.md`'s 0.10.0 entry tells a *project* what to update; it has no way to reach a developer's own already-copied automation built against the old marker location. Found live, after the release had already shipped, when this repo's own personal hook stopped nudging.
+
+**Consequence:** this repo's own `.claude/settings.json` now ships the project-scoped hook directly, rather than relying solely on a developer's personal setup for it. Worth a deliberate check next time a marker/detection-location change ships: a project migration note can tell a project what changed, but not a developer's personal tooling built against the old shape.
+
+**Revisit when:** the `.keep-the-why` marker or detection mechanism changes again.


### PR DESCRIPTION
## Summary
- Ships `.claude/settings.json` — the project-scoped `SessionStart` hook `references/autostart.md` documents and the eval suite dogfoods (`tools/evals/fixtures/_base/.claude/settings.json`), but this repo never actually shipped live for itself. Exact byte-for-byte copy of the documented, eval-verified example.
- Records an incident in `context/compatibility.md`: found this gap because a *personal*, machine-wide `SessionStart` hook built against the pre-0.10.0 `AGENTS.md` marker location went silent the moment this repo migrated to `.keep-the-why` — a project-level migration note can't reach a developer's own already-copied automation. Fixed that personal hook separately (outside this repo); this PR ships the project-scoped half so activation here no longer depends solely on any one developer's own setup.

## Test plan
- [x] Hook script tested locally against this repo (fires), a repo with no `.keep-the-why` (silent), and a repo still on the legacy `AGENTS.md`-embedded config (n/a to this exact hook, covered by the personal variant instead)
- [ ] Oliver reviews and merges