### PR TITLE
Matrix page: name both axes in the intro, drop two notes under the table

### DIFF
--- a/docs/agent-matrix.md
+++ b/docs/agent-matrix.md
@@ -71,11 +71,6 @@ models alphabetically.
 - The blanks in the Ollama row (Cline, Codex CLI, Kimi Code) aren't untried —
   each hit a blocker specific to that driver, not to the model or the skill.
   Details in [the eval runner's driver docs](https://github.com/oliver-zehentleitner/keep-the-why/blob/latest/tools/evals/README.md#drivers).
-- **Ox Alpha** is a stealth model preview on OpenRouter (`stealth/ox-alpha`),
-  provider identity undisclosed.
-- Cline's cells predate the restraint check and are judge-score only; a
-  re-check of stored transcripts found the file had been touched in runs
-  that scored well, so read that column as provisional until it's re-run.
 
 ## What the table shows
 

--- a/docs/agent-matrix.md
+++ b/docs/agent-matrix.md
@@ -6,7 +6,7 @@ have actually been tried, and what each one did with it.
 This is the breadth axis, not the depth one. The [Evals](evals.md) page is
 the skill's real test suite — the full case set, Claude Code with Claude
 Sonnet 5 only, because a single run of it is already expensive. Here it's
-one case against many harnesses instead.
+one case against many agents and models instead.
 
 ## The case
 


### PR DESCRIPTION
Two small edits to `docs/agent-matrix.md`, folded into one PR since both are one-liners on the same page.

- The intro's closing sentence said "one case against many harnesses instead," naming only one of the two axes the page is built on. The table varies agents *and* models, and the heading says so — the sentence now does too.
- Dropped the **Ox Alpha** note ("stealth model preview … provider identity undisclosed"). It only decoded the row label and said nothing about the test or its rating — and it is no longer accurate: OpenRouter's own model page now states that `stealth/ox-alpha` was ZAI GLM-5.3-Flash.
- Dropped the **Cline** provisional note. The mechanical restraint check catches that class of thing on any new run, so it doesn't need a standing caveat on the page.

The row label still reads `Ox Alpha (OpenRouter, stealth)`; renaming it to GLM-5.3-Flash is left for the next table update.