### PR TITLE
Link the keep-the-why-lint GitHub Marketplace listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Full install detail for every method, including tools without a skill runtime at
 - [ASM](https://luongnv.com/asm/#/skills/oliver-zehentleitner%2Fkeep-the-why%3A%3Askills%2Fkeep-the-why%3A%3Akeep-the-why)
 - [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills#context-engineering)
 - [GitHub Copilot plugin marketplace](https://awesome-copilot.github.com/plugin/keep-the-why/)
+- [GitHub Marketplace](https://github.com/marketplace/actions/keep-the-why-lint) — the keep-the-why-lint action
 - [MCP Market](https://mcpmarket.com/tools/skills/keep-the-why)
 - [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why)
 - [SkillsLLM](https://skillsllm.com/skill/keep-the-why)
@@ -199,7 +200,7 @@ This isn't a new pattern, either. Docs and changelogs are already commonly kept 
 
 Not every field belongs on every entry — Status, Evidence, and the rejected alternative carry the most weight even in a minimal one. Full spec and a worked example: [`references/repository-structure.md`](https://keepthewhy.com/repository-structure/).
 
-The structural half of this format is CI-checkable: [keep-the-why-lint](https://pypi.org/project/keep-the-why-lint/) (developed in this repository under `lint/`) validates required fields, value sets, index consistency, and `.keep-the-why` integrity — schema-version-aware, so unmigrated projects don't fail on structure their version never defined. Content (whether the rationale is *true*) stays a human judgment; the linter doesn't pretend otherwise. One line in GitHub Actions (`uses: oliver-zehentleitner/keep-the-why@lint-latest`), or `pip install keep-the-why-lint` anywhere else — see [Linting](https://keepthewhy.com/linting/). This repository lints its own `context/` with it in CI.
+The structural half of this format is CI-checkable: [keep-the-why-lint](https://pypi.org/project/keep-the-why-lint/) (developed in this repository under `lint/`) validates required fields, value sets, index consistency, and `.keep-the-why` integrity — schema-version-aware, so unmigrated projects don't fail on structure their version never defined. Content (whether the rationale is *true*) stays a human judgment; the linter doesn't pretend otherwise. One line in GitHub Actions (`uses: oliver-zehentleitner/keep-the-why@lint-latest`, [on the GitHub Marketplace](https://github.com/marketplace/actions/keep-the-why-lint)), or `pip install keep-the-why-lint` anywhere else — see [Linting](https://keepthewhy.com/linting/). This repository lints its own `context/` with it in CI.
 
 ## Related work
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Validate Skill](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/validate-skill.yml/badge.svg)](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/validate-skill.yml)
 [![ktw-lint](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/ktw-lint.yml/badge.svg)](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/ktw-lint.yml)
 [![keep-the-why-lint (package)](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/lint-package.yml/badge.svg)](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/lint-package.yml)
+[![GitHub Marketplace](https://img.shields.io/badge/GitHub%20Marketplace-keep--the--why--lint-2088FF?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/keep-the-why-lint)
 [![Link Check](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/link-check.yml/badge.svg)](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/link-check.yml)
 [![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://keepthewhy.com/)
 [![Telegram](https://img.shields.io/badge/community-telegram-41ab8c)](https://t.me/unicorndevs)
@@ -119,7 +120,6 @@ Full install detail for every method, including tools without a skill runtime at
 - [ASM](https://luongnv.com/asm/#/skills/oliver-zehentleitner%2Fkeep-the-why%3A%3Askills%2Fkeep-the-why%3A%3Akeep-the-why)
 - [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills#context-engineering)
 - [GitHub Copilot plugin marketplace](https://awesome-copilot.github.com/plugin/keep-the-why/)
-- [GitHub Marketplace](https://github.com/marketplace/actions/keep-the-why-lint) — the keep-the-why-lint action
 - [MCP Market](https://mcpmarket.com/tools/skills/keep-the-why)
 - [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why)
 - [SkillsLLM](https://skillsllm.com/skill/keep-the-why)
@@ -200,7 +200,7 @@ This isn't a new pattern, either. Docs and changelogs are already commonly kept 
 
 Not every field belongs on every entry — Status, Evidence, and the rejected alternative carry the most weight even in a minimal one. Full spec and a worked example: [`references/repository-structure.md`](https://keepthewhy.com/repository-structure/).
 
-The structural half of this format is CI-checkable: [keep-the-why-lint](https://pypi.org/project/keep-the-why-lint/) (developed in this repository under `lint/`) validates required fields, value sets, index consistency, and `.keep-the-why` integrity — schema-version-aware, so unmigrated projects don't fail on structure their version never defined. Content (whether the rationale is *true*) stays a human judgment; the linter doesn't pretend otherwise. One line in GitHub Actions (`uses: oliver-zehentleitner/keep-the-why@lint-latest`, [on the GitHub Marketplace](https://github.com/marketplace/actions/keep-the-why-lint)), or `pip install keep-the-why-lint` anywhere else — see [Linting](https://keepthewhy.com/linting/). This repository lints its own `context/` with it in CI.
+The structural half of this format is CI-checkable: [keep-the-why-lint](https://pypi.org/project/keep-the-why-lint/) (developed in this repository under `lint/`) validates required fields, value sets, index consistency, and `.keep-the-why` integrity — schema-version-aware, so unmigrated projects don't fail on structure their version never defined. Content (whether the rationale is *true*) stays a human judgment; the linter doesn't pretend otherwise. One line in GitHub Actions (`uses: oliver-zehentleitner/keep-the-why@lint-latest`, published as [keep-the-why-lint on the GitHub Marketplace](https://github.com/marketplace/actions/keep-the-why-lint)), or `pip install keep-the-why-lint` anywhere else — see [Linting](https://keepthewhy.com/linting/). This repository lints its own `context/` with it in CI.
 
 ## Related work
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Validate Skill](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/validate-skill.yml/badge.svg)](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/validate-skill.yml)
 [![ktw-lint](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/ktw-lint.yml/badge.svg)](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/ktw-lint.yml)
 [![keep-the-why-lint (package)](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/lint-package.yml/badge.svg)](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/lint-package.yml)
+[![PyPI](https://img.shields.io/pypi/v/keep-the-why-lint.svg?label=pypi%20keep--the--why--lint)](https://pypi.org/project/keep-the-why-lint/)
 [![GitHub Marketplace](https://img.shields.io/badge/GitHub%20Marketplace-keep--the--why--lint-2088FF?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/keep-the-why-lint)
 [![Link Check](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/link-check.yml/badge.svg)](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/link-check.yml)
 [![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://keepthewhy.com/)
@@ -200,7 +201,7 @@ This isn't a new pattern, either. Docs and changelogs are already commonly kept 
 
 Not every field belongs on every entry — Status, Evidence, and the rejected alternative carry the most weight even in a minimal one. Full spec and a worked example: [`references/repository-structure.md`](https://keepthewhy.com/repository-structure/).
 
-The structural half of this format is CI-checkable: [keep-the-why-lint](https://pypi.org/project/keep-the-why-lint/) (developed in this repository under `lint/`) validates required fields, value sets, index consistency, and `.keep-the-why` integrity — schema-version-aware, so unmigrated projects don't fail on structure their version never defined. Content (whether the rationale is *true*) stays a human judgment; the linter doesn't pretend otherwise. One line in GitHub Actions (`uses: oliver-zehentleitner/keep-the-why@lint-latest`, published as [keep-the-why-lint on the GitHub Marketplace](https://github.com/marketplace/actions/keep-the-why-lint)), or `pip install keep-the-why-lint` anywhere else — see [Linting](https://keepthewhy.com/linting/). This repository lints its own `context/` with it in CI.
+The structural half of this format is CI-checkable: [keep-the-why-lint](https://pypi.org/project/keep-the-why-lint/) (developed in this repository under `lint/`) validates required fields, value sets, index consistency, and `.keep-the-why` integrity — schema-version-aware, so unmigrated projects don't fail on structure their version never defined. Content (whether the rationale is *true*) stays a human judgment; the linter doesn't pretend otherwise. One line in GitHub Actions (`uses: oliver-zehentleitner/keep-the-why@lint-latest`, published as [keep-the-why-lint on the GitHub Marketplace](https://github.com/marketplace/actions/keep-the-why-lint)), or [`pip install keep-the-why-lint`](https://pypi.org/project/keep-the-why-lint/) anywhere else — see [Linting](https://keepthewhy.com/linting/). This repository lints its own `context/` with it in CI.
 
 ## Related work
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,6 +37,7 @@ Either form prompts for which of its 70+ supported agents (Claude Code, Codex, O
 | [ASM](https://luongnv.com/asm/#/skills/oliver-zehentleitner%2Fkeep-the-why%3A%3Askills%2Fkeep-the-why%3A%3Akeep-the-why) | Curated skill index for the `asm` CLI; installable via `asm install keep-the-why` |
 | [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills#context-engineering) | Listed under "Context Engineering" |
 | [GitHub Copilot plugin marketplace](https://awesome-copilot.github.com/plugin/keep-the-why/) | Installable via `copilot plugin install keep-the-why@awesome-copilot` |
+| [GitHub Marketplace](https://github.com/marketplace/actions/keep-the-why-lint) | The keep-the-why-lint action — see [Linting](linting.md) |
 | [MCP Market](https://mcpmarket.com/tools/skills/keep-the-why) | Skill marketplace listing |
 | [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why) | Backs the `npx skills add` install method above |
 | [SkillsLLM](https://skillsllm.com/skill/keep-the-why) | Verified, passed [SkillsLLM's security scan](https://skillsllm.com/security-check/IPmNycVdbOyq) |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,7 +37,6 @@ Either form prompts for which of its 70+ supported agents (Claude Code, Codex, O
 | [ASM](https://luongnv.com/asm/#/skills/oliver-zehentleitner%2Fkeep-the-why%3A%3Askills%2Fkeep-the-why%3A%3Akeep-the-why) | Curated skill index for the `asm` CLI; installable via `asm install keep-the-why` |
 | [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills#context-engineering) | Listed under "Context Engineering" |
 | [GitHub Copilot plugin marketplace](https://awesome-copilot.github.com/plugin/keep-the-why/) | Installable via `copilot plugin install keep-the-why@awesome-copilot` |
-| [GitHub Marketplace](https://github.com/marketplace/actions/keep-the-why-lint) | The keep-the-why-lint action — see [Linting](linting.md) |
 | [MCP Market](https://mcpmarket.com/tools/skills/keep-the-why) | Skill marketplace listing |
 | [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why) | Backs the `npx skills add` install method above |
 | [SkillsLLM](https://skillsllm.com/skill/keep-the-why) | Verified, passed [SkillsLLM's security scan](https://skillsllm.com/security-check/IPmNycVdbOyq) |

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -2,7 +2,7 @@
 
 Nothing in Keep the Why is enforced the way a compiler enforces correctness — that's stated plainly in "What this skill is not." Part of that gap *is* mechanically closable, though: whether every entry carries its required fields, whether the values are from the documented sets, whether `index.md` is complete and sorted, whether `.keep-the-why` is internally consistent. That part has a linter:
 
-**keep-the-why-lint** — [on PyPI](https://pypi.org/project/keep-the-why-lint/), developed in this repository under [`lint/`](https://github.com/oliver-zehentleitner/keep-the-why/tree/main/lint). Python 3.10+, no dependencies beyond the standard library.
+**keep-the-why-lint** — [on PyPI](https://pypi.org/project/keep-the-why-lint/) as a package, [on the GitHub Marketplace](https://github.com/marketplace/actions/keep-the-why-lint) as an action, developed in this repository under [`lint/`](https://github.com/oliver-zehentleitner/keep-the-why/tree/main/lint). Python 3.10+, no dependencies beyond the standard library.
 
 What it deliberately does *not* check: content. Whether recorded rationale is true, complete, or honest isn't mechanically checkable, and the linter doesn't pretend otherwise — Evidence classification stays a judgment call; the linter only guarantees the field is there and holds a legal value.
 
@@ -30,7 +30,7 @@ The project init wizard offers to write these for you (GitHub Actions or GitLab 
 
 {% include-markdown "../skills/keep-the-why/references/ci-linting.md" start="<!-- snippets:start -->" end="<!-- snippets:end -->" %}
 
-Inside GitHub Actions, findings show up as file/line annotations on the PR. The action is [listed on the GitHub Marketplace](https://github.com/marketplace/actions/keep-the-why-lint); it always installs the latest linter from PyPI, and the `lint-latest` tag it's referenced by moves with every linter publish — nothing to pin on your side unless you want to (`@lint-v<version>` pins the action, the `version:` input pins the package).
+Inside GitHub Actions, findings show up as file/line annotations on the PR. The action always installs the latest linter from PyPI, and the `lint-latest` tag it's referenced by moves with every linter publish — nothing to pin on your side unless you want to (`@lint-v<version>` pins the action, the `version:` input pins the package).
 
 ## What it checks
 

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -30,7 +30,7 @@ The project init wizard offers to write these for you (GitHub Actions or GitLab 
 
 {% include-markdown "../skills/keep-the-why/references/ci-linting.md" start="<!-- snippets:start -->" end="<!-- snippets:end -->" %}
 
-Inside GitHub Actions, findings show up as file/line annotations on the PR. The action always installs the latest linter from PyPI, and the `lint-latest` tag it's referenced by moves with every linter publish — nothing to pin on your side unless you want to (`@lint-v<version>` pins the action, the `version:` input pins the package).
+Inside GitHub Actions, findings show up as file/line annotations on the PR. The action is [listed on the GitHub Marketplace](https://github.com/marketplace/actions/keep-the-why-lint); it always installs the latest linter from PyPI, and the `lint-latest` tag it's referenced by moves with every linter publish — nothing to pin on your side unless you want to (`@lint-v<version>` pins the action, the `version:` input pins the package).
 
 ## What it checks
 

--- a/lint/README.md
+++ b/lint/README.md
@@ -54,7 +54,7 @@ ktw-lint . --strict        # warnings fail too
 
 The Keep the Why [project init wizard](https://keepthewhy.com/setup/) offers to wire the linter into your CI during setup — detected from the repository, never guessed — and [CI linting setup](https://keepthewhy.com/ci-linting/) has the full detection rules. By hand, these are the same snippets:
 
-**GitHub Actions** — `.github/workflows/ktw-lint.yml`. The root of the `keep-the-why` repository is a composite action that installs the latest linter from PyPI; the `lint-latest` tag moves with every linter publish, so there's nothing to pin on your side (pin `@lint-v<version>` if you want a fixed action revision):
+**GitHub Actions** — `.github/workflows/ktw-lint.yml`. The root of the `keep-the-why` repository is a composite action ([on the GitHub Marketplace](https://github.com/marketplace/actions/keep-the-why-lint)) that installs the latest linter from PyPI; the `lint-latest` tag moves with every linter publish, so there's nothing to pin on your side (pin `@lint-v<version>` if you want a fixed action revision):
 
 ```yaml
 name: ktw-lint

--- a/lint/README.md
+++ b/lint/README.md
@@ -3,6 +3,7 @@
 [![Downloads](https://pepy.tech/badge/keep-the-why-lint)](https://pepy.tech/project/keep-the-why-lint)
 [![License](https://img.shields.io/github/license/oliver-zehentleitner/keep-the-why.svg?color=blue)](https://github.com/oliver-zehentleitner/keep-the-why/blob/latest/LICENSE)
 [![keep-the-why-lint (package)](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/lint-package.yml/badge.svg)](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/lint-package.yml)
+[![GitHub Marketplace](https://img.shields.io/badge/GitHub%20Marketplace-keep--the--why--lint-2088FF?logo=githubactions&logoColor=white)](https://github.com/marketplace/actions/keep-the-why-lint)
 [![ktw-lint](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/ktw-lint.yml/badge.svg)](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/ktw-lint.yml)
 [![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://keepthewhy.com/linting/)
 [![Telegram](https://img.shields.io/badge/community-telegram-41ab8c)](https://t.me/unicorndevs)

--- a/llms.txt
+++ b/llms.txt
@@ -102,6 +102,7 @@ the project back up without needing to be told again.
   https://github.com/VoltAgent/awesome-agent-skills#context-engineering
 - GitHub Copilot plugin marketplace: installable via `copilot plugin install
   keep-the-why@awesome-copilot` — https://awesome-copilot.github.com/plugin/keep-the-why/
+- GitHub Marketplace: the keep-the-why-lint action — https://github.com/marketplace/actions/keep-the-why-lint
 - MCP Market: skill marketplace listing — https://mcpmarket.com/tools/skills/keep-the-why
 - skills.sh: https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why — backs
   the `npx skills add` method above
@@ -205,7 +206,8 @@ project's `context-schema` and only enforces what that skill version defines, so
 projects don't fail on structure their version never had. Content-level truth is out of its
 scope by design. Versioned `<schema>.<revision>` (e.g. 0.10.1.0), independently of the skill.
 GitHub Actions: `uses: oliver-zehentleitner/keep-the-why@lint-latest` (installs latest from PyPI;
-the `lint-latest` tag moves with every linter publish, `lint-v<version>` pins the action);
+the `lint-latest` tag moves with every linter publish, `lint-v<version>` pins the action;
+Marketplace listing: https://github.com/marketplace/actions/keep-the-why-lint);
 anywhere else: `pip install keep-the-why-lint && ktw-lint .`. Usage, GitLab/pre-commit
 snippets, and every finding code: https://keepthewhy.com/linting/
 

--- a/llms.txt
+++ b/llms.txt
@@ -102,7 +102,6 @@ the project back up without needing to be told again.
   https://github.com/VoltAgent/awesome-agent-skills#context-engineering
 - GitHub Copilot plugin marketplace: installable via `copilot plugin install
   keep-the-why@awesome-copilot` — https://awesome-copilot.github.com/plugin/keep-the-why/
-- GitHub Marketplace: the keep-the-why-lint action — https://github.com/marketplace/actions/keep-the-why-lint
 - MCP Market: skill marketplace listing — https://mcpmarket.com/tools/skills/keep-the-why
 - skills.sh: https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why — backs
   the `npx skills add` method above
@@ -205,9 +204,10 @@ fields, valid values, index consistency, and `.keep-the-why` integrity. It reads
 project's `context-schema` and only enforces what that skill version defines, so unmigrated
 projects don't fail on structure their version never had. Content-level truth is out of its
 scope by design. Versioned `<schema>.<revision>` (e.g. 0.10.1.0), independently of the skill.
-GitHub Actions: `uses: oliver-zehentleitner/keep-the-why@lint-latest` (installs latest from PyPI;
-the `lint-latest` tag moves with every linter publish, `lint-v<version>` pins the action;
-Marketplace listing: https://github.com/marketplace/actions/keep-the-why-lint);
+GitHub Actions: `uses: oliver-zehentleitner/keep-the-why@lint-latest` — published on the GitHub
+Marketplace as keep-the-why-lint (https://github.com/marketplace/actions/keep-the-why-lint); installs
+latest from PyPI, the `lint-latest` tag moves with every linter publish, `lint-v<version>` pins
+the action;
 anywhere else: `pip install keep-the-why-lint && ktw-lint .`. Usage, GitLab/pre-commit
 snippets, and every finding code: https://keepthewhy.com/linting/
 


### PR DESCRIPTION
Adds https://github.com/marketplace/actions/keep-the-why-lint where the linter's GitHub Action is documented — it's a linter listing, so it stays out of the skill's "Also listed on" lists — and gives the linter's PyPI page the same visibility in the main README.

- README.md: PyPI badge + GitHub Marketplace badge for keep-the-why-lint next to the lint-package badge; Linting paragraph names the Marketplace listing and links `pip install keep-the-why-lint` to PyPI
- lint/README.md: Marketplace badge; GitHub Actions setup paragraph links the listing (lands on PyPI with the next linter publish)
- docs/linting.md: intro line now says where to get it — PyPI as a package, GitHub Marketplace as an action
- llms.txt: Linting section names the Marketplace listing

No functional changes.