### PR TITLE
evals runner: short retry interval when unresolved cases are plain errors, not rate limits

### DIFF
--- a/tools/evals/README.md
+++ b/tools/evals/README.md
@@ -250,9 +250,14 @@ transcript turns out to actually be a limit message (e.g. from a run
 predating this check) is treated as unresolved too, not trusted.
 
 For a run that should survive account limits unattended, add
-`--retry-until-complete` (sleeps `--retry-interval` seconds, default 600,
-and retries only the unresolved cases, up to `--max-wait-hours`, default
-10) instead of babysitting it.
+`--retry-until-complete` (retries only the unresolved cases, up to
+`--max-wait-hours`, default 10) instead of babysitting it. The wait between
+retry passes depends on *why* cases are unresolved: while any case is
+`rate_limited` it sleeps `--retry-interval` seconds (default 600 — quota
+windows reset on an hours scale); when every unresolved case is a plain
+`error` — a safety-classifier refusal, a driver crash, a timeout — it sleeps
+only `--error-retry-interval` seconds (default 30), since those are retriable
+at once.
 
 ## Interpreting results
 

--- a/tools/evals/run.py
+++ b/tools/evals/run.py
@@ -116,7 +116,9 @@ API. This is what makes --retry-until-complete work — if the agent's own
 account hits its session/usage limit mid-run (a real message in the
 transcript, not a crash), the runner stops spending on further cases in that
 pass, marks them "rate_limited", and (with --retry-until-complete) sleeps and
-tries again later, picking up only what's still unresolved. It will not sit
+tries again later, picking up only what's still unresolved. Plain errors (a
+safety-classifier refusal, a crash, a timeout) with no rate limit in play are
+retried after the much shorter --error-retry-interval instead. It will not sit
 there hammering the API once the wall is hit, and it will not silently give
 up and leave a truncated result set either. (The rate-limit detection is
 Claude-account-specific; it simply won't fire for the other drivers.)
@@ -2124,7 +2126,19 @@ def main():
         "--retry-interval",
         type=int,
         default=600,
-        help="seconds to sleep between retry passes (default: 600)",
+        help="seconds to sleep before a retry pass when the account's "
+        "session/usage limit was hit (default: 600) — those windows reset "
+        "on an hours scale, polling faster is pure waste",
+    )
+    ap.add_argument(
+        "--error-retry-interval",
+        type=int,
+        default=30,
+        help="seconds to sleep before a retry pass when every unresolved case "
+        "is a plain error — a safety-classifier refusal, a driver crash, a "
+        "timeout — and nothing is rate-limited (default: 30). Such errors "
+        "are retriable at once; the long --retry-interval only applies "
+        "while a rate limit is in play",
     )
     ap.add_argument(
         "--max-wait-hours",
@@ -2212,12 +2226,24 @@ def main():
             )
             sys.exit(4)
 
+        # Two very different reasons a case can be unresolved, and they call
+        # for very different waits. A rate_limited verdict means the account
+        # itself is out of quota until its window resets — hours, so the long
+        # interval. A plain error (the model's safety classifier refusing a
+        # case, a driver crash, a timeout) is retriable right away; waiting
+        # the full rate-limit interval for it cost up to 50 minutes of idle
+        # time per full run before this distinction existed.
+        rate_limited = any(r.get("verdict") == "rate_limited" for r in records)
+        if rate_limited:
+            interval, why = args.retry_interval, "rate-limited"
+        else:
+            interval, why = args.error_retry_interval, "error, not rate-limited"
         print(
-            f"[{now}] {remaining} case(s) still unresolved (likely rate-limited) — "
-            f"sleeping {args.retry_interval}s before retrying",
+            f"[{now}] {remaining} case(s) still unresolved ({why}) — "
+            f"sleeping {interval}s before retrying",
             flush=True,
         )
-        time.sleep(args.retry_interval)
+        time.sleep(interval)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`--retry-until-complete` slept `--retry-interval` (600 s) before every retry pass, regardless of why cases were unresolved. That interval exists for the account's session/usage limit, which resets on an hours scale. But the other unresolved kind — a plain `error` such as the safety-classifier refusal on `trust-model-hidden-unicode-instructions`, a driver crash, a timeout — is retriable at once. In the three full runs on 2026-09-03 this cost 20, 10 and 40 minutes of idle time respectively; r9 needed five attempts for that one case.

- New `--error-retry-interval` (default 30 s). Used when no case in the pass has a `rate_limited` verdict.
- `--retry-interval` (still 600 s) now applies only while at least one case is rate-limited.
- Log line says which of the two it is (`rate-limited` / `error, not rate-limited`) instead of the blanket "likely rate-limited".
- Docstring and `tools/evals/README.md` updated.

Smoke-tested with a single fast case (`update-check-ignores-non-skill-releases`, pass). Black-formatted.