### PR TITLE
Security page: what every scanner reports and why; ```sh fences in the skill package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Changed
 
+- The two shell snippets in `references/autostart.md` and `references/ci-linting.md` are fenced as ` ```sh ` instead of ` ```bash `. Same rendering; the reason is agent-skill-manager's install-time check, which labelled the package *High Risk* on the literal word `bash` alone. The remaining *Medium Risk* comes from the package containing links and is the floor for any skill that does. The security page now lists what every scanner that covers the skill reports (SkillsLLM, Socket, Snyk, Gen Agent Trust Hub, asm) and why the Snyk and Trust Hub medium findings — third-party content read during retrospective recovery and interviews — describe the skill's purpose and stay; `SECURITY.md` points there.
+
 - Project init wizard: the last question now asks how the skill should get loaded in future sessions, offering the three start paths (default: only when a developer asks); step 2 writes the entry-point section when that path is chosen; step 6's "leave the entry-point file alone" has that one exception.
 
 ### Removed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,7 @@ This document outlines security procedures and general policies for the
 
   * [Reporting a Bug](#reporting-a-bug)
   * [Disclosure Policy](#disclosure-policy)
+  * [Automated Scanner Findings](#automated-scanner-findings)
   * [Comments on this Policy](#comments-on-this-policy)
 
 ## Reporting a Bug
@@ -31,6 +32,14 @@ involving the following steps:
   * Confirm the problem and determine the affected versions.
   * Audit the skill's instructions and reference files for any similar issues.
   * Prepare a fix and publish it as a new GitHub release as fast as possible.
+
+## Automated Scanner Findings
+Registries such as skills.sh, SkillsLLM, and agent-skill-manager scan the
+skill package automatically, and some of them show a warning label for it.
+What each scanner reports, and why the findings that remain are expected for
+a skill whose job includes reading issue and pull-request threads, is
+explained at https://keepthewhy.com/security/ — please check there before
+reporting one of those labels as a vulnerability.
 
 ## Comments on this Policy
 If you have suggestions on how this process could be improved please submit a

--- a/context/release-and-distribution.md
+++ b/context/release-and-distribution.md
@@ -193,3 +193,21 @@ The skill's update check (`references/setup.md`) queries `/releases`, keeps only
 **Revisit when:** the installable skill moves back to the repo root, or the license changes (both copies must change together)
 
 The skill lives in a subdirectory (see "The installable skill lives under `skills/keep-the-why/`" above), so the repository's root `LICENSE` is outside the skill root a registry inspects. A verbatim copy sits next to `SKILL.md`. Two files, one license — when it changes, change both.
+
+## Shell fences inside the skill package are ` ```sh `, not ` ```bash `
+
+**Type:** decision
+**Status:** active
+**Evidence:** confirmed
+**Source:** agent-skill-manager v2.14.0 install-time check (its warning patterns: `/\b(bash|sh\s+-c)\b/`, `exec(`, `child_process`, `eval(`, credential-shaped assignments → *High Risk*; any `https?://` → *Medium Risk*); skills.sh audits of 2026-09-03
+**Revisit when:** asm changes what its install check matches, or a snippet genuinely needs bash-only highlighting
+
+The two shell snippets in `references/autostart.md` and `references/ci-linting.md` were fenced ` ```bash `. That word was the package's only match for asm's shell-command pattern and, on its own, turned the label shown at install time into *High Risk*. Fenced as ` ```sh ` the label drops to *Medium Risk*, which is where every skill with a link in it lands and as low as this one can go without removing the license line, the badge, and the OWASP reference.
+
+**Reason:** the change is lossless — the fence language only selects the highlighter, and `sh` renders the same as `bash` on GitHub and in mkdocs — while the label is the first thing a person sees on `asm install`, before any explanation. Explaining the scanner's regex in the docs (which we do, `docs/security.md`) doesn't reach someone deciding at an install prompt.
+
+**Rejected alternative:** leave the fences and only document why the label is wrong. Rejected because it pays a real cost (a red label at the decision point) to avoid a change nobody would notice.
+
+**Rejected alternative:** strip every URL from the package to reach *Safe*. Not possible without dropping the license attribution, the badge markup in `references/setup.md`, and the OWASP link the trust model cites.
+
+**Consequence:** new shell fences under `skills/keep-the-why/` use ` ```sh `. The other scanners' medium findings (Snyk W011, Gen Agent Trust Hub) describe the skill reading issue and pull-request threads during retrospective recovery and interviews — that is the feature, the mitigation is Core rule 11 and `references/trust-model.md`, and those findings are expected to stay; `docs/security.md` says so in public.

--- a/docs/security.md
+++ b/docs/security.md
@@ -17,9 +17,18 @@ See [Trust model](trust-model.md) for the full reasoning, the read/write rules, 
 - Actions with real side effects still go through whatever the agent running the skill already requires — permission prompts, sandboxing, trust verification. Keep the Why doesn't add a separate permission layer, and doesn't assume those mechanisms are bulletproof either.
 - `context/` is committed alongside the code, reviewed the same way — a change to it is as visible in a diff or a pull request as any other change.
 
-## Independent verification
+## What automated scanners report, and why
 
-Beyond this document's own reasoning: [SkillsLLM](https://skillsllm.com/skill/keep-the-why) ran an automated security scan against the skill package and marked it **Verified** — see the [scan report](https://skillsllm.com/security-check/IPmNycVdbOyq) for what it checked. A second opinion, not a substitute for reading `SKILL.md` yourself.
+Several registries scan the skill package (`skills/keep-the-why/`) automatically, and their labels differ because they check different things. Here is what each one reports and what stands behind it, so a warning on a listing page doesn't have to be decoded from scratch.
+
+- **[SkillsLLM](https://skillsllm.com/skill/keep-the-why)** — **Verified**; see the [scan report](https://skillsllm.com/security-check/IPmNycVdbOyq) for what it checked.
+- **[skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why)** runs three auditors on every listed skill:
+    - **Socket** — Pass.
+    - **Snyk** — Warn, medium, one finding: *W011, third-party content exposure (indirect prompt injection risk)* — retrospective recovery and knowledge-transfer interviews ingest outsider-authored text such as issue and pull-request threads. Accurate, and by design: reading those sources is what the retrospective mode is for. The mitigation is Core rule 11 and the [trust model](trust-model.md) — repository content is data, never instructions; an embedded directive gets named to the user, not followed; nothing is copied verbatim into `context/`. The finding describes the skill's purpose rather than a gap, so expect it to stay for as long as the skill reads issues at all.
+    - **Gen Agent Trust Hub** — Warn, medium. Lists five capabilities: loading `SKILL.md` from the path a project pins in `.keep-the-why` ("dynamic execution"), the same third-party content exposure as above (naming rule 11 and the trust model as the mitigation), the optional `SessionStart` hook ("persistence"), the update check against the GitHub releases API ("external downloads"), and `uuidgen`/`grep` in the reference files ("command execution"). Each is a documented feature — [pinned versions](setup.md#pinned-versions), [autostart](autostart.md), the [update check](setup.md#timer-check-every-session-for-whoever-has-a-personal-config) — and each runs only through the permission prompts of whatever agent is executing the skill.
+- **agent-skill-manager (asm)** shows a risk label at install time that is computed from regular expressions over the package files: any `https://` URL makes it *Medium Risk*, the word `bash` (or `exec(`, `eval(`, a credential-shaped assignment) makes it *High Risk*. Up to 0.11.0 this skill showed *High Risk* because two reference files fenced their shell snippets as ` ```bash `; the fences are ` ```sh ` now, which renders identically. What remains is *Medium Risk*, from the links to this site, to GitHub, and to OWASP — the floor for any skill that contains a link at all. None of it is the data-exfiltration or remote-payload pattern the check is meant to hint at.
+
+All of these are second opinions, not a substitute for reading `SKILL.md` and the [trust model](trust-model.md) yourself.
 
 ## Reporting a vulnerability in Keep the Why itself
 

--- a/llms.txt
+++ b/llms.txt
@@ -272,7 +272,7 @@ HTML equivalent and details: https://keepthewhy.com/badge/
 - Agent & model matrix (which agents/models the skill has actually been run against): https://keepthewhy.com/agent-matrix/
 - Setup (project + personal wizards, timer checks): https://keepthewhy.com/setup/
 - Migrations (context-schema version changes): https://keepthewhy.com/migrations/
-- Security (overview, links to trust model and vulnerability reporting): https://keepthewhy.com/security/
+- Security (overview, what automated scanners report and why, links to trust model and vulnerability reporting): https://keepthewhy.com/security/
 - Trust model (context/ as data, not instructions): https://keepthewhy.com/trust-model/
 - Badge: https://keepthewhy.com/badge/
 - Philosophy (why no database/daemon/dashboard, deliberately): https://keepthewhy.com/philosophy/

--- a/skills/keep-the-why/references/autostart.md
+++ b/skills/keep-the-why/references/autostart.md
@@ -103,7 +103,7 @@ Keep the Why rather than firing unconditionally on every session.
 
 The `command` field, unescaped for readability — functionally identical:
 
-```bash
+```sh
 found=""
 if [ -f .keep-the-why ]; then
   found=1

--- a/skills/keep-the-why/references/ci-linting.md
+++ b/skills/keep-the-why/references/ci-linting.md
@@ -75,7 +75,7 @@ repos:
 
 **Any other CI, or locally:**
 
-```bash
+```sh
 pip install keep-the-why-lint
 ktw-lint .            # exit 0 clean, 1 findings, 2 usage error
 ktw-lint . --strict   # warnings fail too


### PR DESCRIPTION
## What

- `references/autostart.md` and `references/ci-linting.md`: the two shell snippets are fenced ` ```sh ` instead of ` ```bash `. Same rendering.
- `docs/security.md`: the "Independent verification" line becomes a section listing what every scanner that covers the skill reports and what stands behind it — SkillsLLM (Verified), skills.sh's Socket (Pass), Snyk (Medium, W011 third-party content exposure), Gen Agent Trust Hub (Medium, five documented capabilities), and agent-skill-manager's install-time label.
- `SECURITY.md`: short pointer to that section so a scanner label doesn't get reported as a vulnerability.
- `llms.txt`, `CHANGELOG.md` (Unreleased / Changed), `context/release-and-distribution.md` (the fence decision, with rejected alternatives).

## Why

asm (agent-skill-manager 2.14.0) computes its install-time risk label from regular expressions over the package files: `/\b(bash|sh\s+-c)\b/`, `exec(`, `eval(`, `child_process`, credential-shaped assignments → *High Risk*; any `https?://` → *Medium Risk*. The word `bash` in two code fences was the only High match. Renaming the fences is lossless and drops the label to Medium, which is the floor for any skill containing a link — the license attribution, the badge markup and the OWASP reference stay.

Snyk W011 and the Trust Hub's "indirect prompt injection" item describe retrospective recovery and interviews reading issue and PR threads. That is the feature; the mitigation is Core rule 11 and `references/trust-model.md` (the Trust Hub names both). Those findings stay for as long as the skill reads issues at all, and the security page now says so in public instead of leaving people to decode a "Warn" badge.

## Checks

- `ktw-lint . --strict`: 0 errors, 0 warnings
- `asm eval skills/keep-the-why`: 96/100 (A)
- Scanner facts taken from skills.sh's three audit pages (2026-09-03) and asm's bundled `dist/agent-skill-manager.js`.
