### PR TITLE
Prepare 0.12.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "keep-the-why",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Preserves or recovers the reasoning behind a codebase - decisions, rejected alternatives, workarounds, and incident learnings the code alone can't explain.",
   "author": {
     "name": "Oliver Zehentleitner",

--- a/.keep-the-why
+++ b/.keep-the-why
@@ -6,7 +6,7 @@ README, for what Keep the Why actually is.
 - id: oliver-zehentleitner---keep-the-why
 - context: `context/`
 - init: complete
-- context-schema: 0.11.0
+- context-schema: 0.12.0
 - capture-confirmation: confirm-always
 - source-reference: never
 <!-- /keep-the-why:config -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-09-06
+
 ### Added
 
 - `case.json` keys `explicit_load: false` (send the prompt bare on every driver, without the "read SKILL.md first" prefix) and `skill_install` (pin the install path for every driver). `autostart-project-instruction-loads-skill` uses both, so it measures the same thing on every driver: does the agent load the skill because the project's `AGENTS.md` asks, unprompted. Its expected behavior now says what loading means outside Claude Code (reading `.claude/skills/keep-the-why/SKILL.md`, as the section itself instructs) — the judge had failed a Codex CLI run that did exactly that as its first action, on the words "Skill tool". Each result record carries `skill_loaded_at`, the ordinal of the tool call that loaded the skill.
@@ -17,6 +19,8 @@ All notable changes to this project are documented here. Format follows [Keep a 
 - Eval runner: refuses to start when the temp directory resolves to somewhere under the operator's home (`refuse_tempdir_inside_home()`, called by the single-run loop and `--matrix`). Found the hard way: with `/tmp` full and `TMPDIR` pointed inside the checkout, two of three runs of a case that writes the personal file wrote it to the operator's real `~/.keep-the-why/` — the case workdir path told the agent where the real home was, defeating the fake `$HOME`. The run's own deterministic check is what noticed. `tools/evals/README.md` documents `TMPDIR=/var/tmp` for a small `/tmp` and why it must be outside home; incident entry in `context/evals.md`.
 
 - Granular judge output: the judge now returns `expectations` (the expected behavior broken into its individual requirements, each marked met or not with the transcript/diff detail that decides it) and `deductions` (one entry per point below 10, naming the requirement and the evidence; empty at 10). Both land in the case record. `summary.md` shows one row per case — passes included — with the skill-load ordinal, checks passed/declared, the restraint code and a last column carrying the failed checks and violations of a fail, the deductions of a 9, or "nothing withheld". A run's result now says *why* a case scored 9 and whether the agent asked first and then acted anyway, without opening the JSON. `chestertons-fence-guard` gained the deterministic check `file_unchanged src/export.py` (the sleep may be questioned, never removed in a session that can't get an answer); 47 of 77 cases carry checks.
+
+- `keep-the-why-lint` 0.12.0.0: knows schema 0.12.0 — no new structural gate, since nothing in this release changes what `context/` or `.keep-the-why` must look like — so a project on 0.12.0 gets no `W003`; carries the path confinement (`E009`) to PyPI. Published before the skill tag, per the reordered release checklist.
 
 - `references/autostart.md` restructured around three start paths — every session machine-wide (developer-level, gated on `.keep-the-why`), the project asks (a project-scoped hook and/or a "Keep the Why" section in the project's entry-point file), or only when a developer asks — with per-agent sections stating what is verified how. New: the entry-point section, tool-neutral and the form to pick for a pinned, vendored skill. Verified for Claude Code by eval case `autostart-project-instruction-loads-skill` (hook removed, section in `AGENTS.md`, `CLAUDE.md` importing it, a plain code question: 3/3 invoked the skill first; same-day control without the section: 0/3) and for Hermes Agent by a single live run (reads `AGENTS.md` on its own, loaded `SKILL.md` first). Then, 2026-09-05, the same case run on three more harnesses with the prompt sent bare and the skill at `.claude/skills/keep-the-why/` (Claude Sonnet 5 via OpenRouter, three runs each plus three controls without the section): Codex CLI 3/3 read `SKILL.md` as the first or second call (control 1/3, as the seventh call while exploring), opencode 3/3 invoked it through its native `skill` tool as the very first call (control 0/3), Cline 3/3 read it first or second (control 0/3). Per-agent sections in `autostart.md`.
 
@@ -502,7 +506,8 @@ Initial release.
 - Logo, wordmark, and favicon.
 - `context/repo-conventions.md`, dogfooding the skill on its own repository from day one.
 
-[Unreleased]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.10.1...v0.11.0
 [0.10.1]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.9.2...v0.10.0

--- a/docs/linting.md
+++ b/docs/linting.md
@@ -45,7 +45,7 @@ The `uses:` ref decides both the action and the linter it installs, the way pinn
 Latest is the default on purpose: a skill release that adds a structural gate is followed by a linter release that knows it, and a workflow on `@lint-latest` picks that up on its own. The gating protects the other direction (an older project is never held to a newer schema), so rolling forward is the safe default. Pin when you have a reason — a linter release that misbehaves on your `context/`, a policy that wants every tool version fixed — and pin by ref, like any other action:
 
 ```yaml
-      - uses: oliver-zehentleitner/keep-the-why@lint-v0.11.0.0   # action and linter pinned together
+      - uses: oliver-zehentleitner/keep-the-why@lint-v0.12.0.0   # action and linter pinned together
 ```
 
 The `version:` input is for the odd case of mixing — a pinned action with a different linter, or `version: "latest"` on a pinned ref to keep the linter rolling anyway. Anywhere else (GitLab CI, pre-commit, a plain shell), `pip install keep-the-why-lint==<version>` is the pin.

--- a/lint/ktw_lint/__init__.py
+++ b/lint/ktw_lint/__init__.py
@@ -13,6 +13,6 @@ changes. PEP 440, not strict SemVer — PyPI rejects the SemVer build-
 metadata spelling this would otherwise use.
 """
 
-__version__ = "0.11.0.0"
+__version__ = "0.12.0.0"
 
-SUPPORTED_SCHEMA = (0, 11, 0)
+SUPPORTED_SCHEMA = (0, 12, 0)

--- a/lint/ktw_lint/config.py
+++ b/lint/ktw_lint/config.py
@@ -6,7 +6,7 @@ The config format is a delimited block of `- key: value` lines:
     - id: acme---widget-service
     - context: `context/`
     - init: complete
-    - context-schema: 0.11.0
+    - context-schema: 0.12.0
     - capture-confirmation: confirm-when-unsure
     - source-reference: never
     <!-- /keep-the-why:config -->

--- a/llms.txt
+++ b/llms.txt
@@ -30,7 +30,7 @@ get thrown away, not creating separate documentation effort. It isn't magic, tho
 prevents knowledge from decaying on its own. This lowers the friction of the discipline that
 keeps documentation honest; it doesn't replace it.
 
-Version: 0.11.0.
+Version: 0.12.0.
 
 ## Authorship & License
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "keep-the-why",
   "description": "Preserves or recovers the reasoning behind a codebase - architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "author": {
     "name": "Oliver Zehentleitner"
   },

--- a/skills/keep-the-why/SKILL.md
+++ b/skills/keep-the-why/SKILL.md
@@ -3,7 +3,7 @@ name: keep-the-why
 description: Extract and preserve the reasoning code cannot explain - decisions, rejected alternatives, workarounds, incidents, constraints - plus project setup and maintainer interviews. Not for what changed (see Keep a Changelog) - only why.
 license: MIT
 metadata:
-  version: "0.11.0"
+  version: "0.12.0"
   repository: "https://github.com/oliver-zehentleitner/keep-the-why"
   author: "Oliver Zehentleitner"
 ---

--- a/skills/keep-the-why/examples/first-time-setup.md
+++ b/skills/keep-the-why/examples/first-time-setup.md
@@ -113,7 +113,7 @@ This names the skill and its purpose directly — not a task that happens to mat
     - id: acme---widget-service
     - context: `context/`
     - init: complete
-    - context-schema: 0.11.0
+    - context-schema: 0.12.0
     - capture-confirmation: confirm-when-unsure
     - source-reference: never
     <!-- /keep-the-why:config -->

--- a/skills/keep-the-why/references/migrations.md
+++ b/skills/keep-the-why/references/migrations.md
@@ -4,7 +4,7 @@ What changed in each version that an existing project may need to know about or 
 
 Entries below assume 0.2.0 as the starting point — nothing before it tracked a `context-schema` at all, and 0.2.0 itself introduced no `context/` entry format change.
 
-## Unreleased — start paths, ephemeral environments, action refs (informational, no action required)
+## 0.12.0 — start paths, ephemeral environments, action refs (informational, no action required)
 
 **What changed:** three additions an existing project can adopt, none of which changes `.keep-the-why`, the personal file, or the `context/` entry format.
 
@@ -14,7 +14,7 @@ Entries below assume 0.2.0 as the starting point — nothing before it tracked a
 
 **Existing projects:** all optional. A project that wants the skill loaded without anyone asking picks a start path from `autostart.md` and, for the entry-point route, pastes the section into its `AGENTS.md` (or equivalent) — the wizard's step 2 wording, by hand or by asking the agent. A project whose developers work in throwaway environments bakes one of the two files. A project on `@lint-latest` does nothing; one that pinned the action for reproducibility now gets the reproducibility it pinned for on its next bump.
 
-## Unreleased — `init: declined` retired (informational; one optional deletion)
+## 0.12.0 — `init: declined` retired (informational; one optional deletion)
 
 **What changed:** a setup request that is called off no longer writes `init: declined` to a new `.keep-the-why` — it writes nothing at all. The flag dated from the time an organic activation could propose setup and needed a "don't ask again" marker; since 0.10.0 setup only ever starts from an explicit request, so there was nothing left for the flag to suppress, while the file it created made every `.keep-the-why`-gated autostart hook fire on a project that had just said no.
 

--- a/skills/keep-the-why/references/repository-structure.md
+++ b/skills/keep-the-why/references/repository-structure.md
@@ -77,7 +77,7 @@ README, for what Keep the Why actually is.
 - id: acme---widget-service
 - context: `context/`
 - init: complete
-- context-schema: 0.11.0
+- context-schema: 0.12.0
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->

--- a/skills/keep-the-why/references/setup.md
+++ b/skills/keep-the-why/references/setup.md
@@ -17,7 +17,7 @@ README, for what Keep the Why actually is.
 - id: oliver-zehentleitner---keep-the-why
 - context: `context/`
 - init: complete
-- context-schema: 0.11.0
+- context-schema: 0.12.0
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->


### PR DESCRIPTION
Release checklist, phase **Prepare**, steps 1–8 — version 0.12.0 confirmed by Oliver.

| Step | Done |
|---|---|
| 1 `metadata.version` in SKILL.md | 0.12.0 |
| 2 `Version:` in llms.txt | 0.12.0 |
| 3 `plugin.json`, `.claude-plugin/plugin.json` | 0.12.0 |
| 4 linter | `__version__` 0.12.0.0, `SUPPORTED_SCHEMA` (0, 12, 0), no new gate — nothing in this release changes what `context/` or `.keep-the-why` must look like; `test_version` holds; CHANGELOG line (also notes E009 reaches PyPI with this) |
| 5 CHANGELOG | `[0.12.0] - 2026-09-06`, fresh empty `[Unreleased]`, compare-link footer updated |
| 6 migrations.md | verified (#257 closed the gap); both Unreleased headers renamed to 0.12.0 |
| 7 own `context-schema` | 0.12.0, nothing to migrate |
| 8 illustrative `context-schema` values | setup.md, repository-structure.md, first-time-setup.md → 0.12.0 (and `config.py`'s docstring example) |

Also `docs/linting.md`'s pin example names `lint-v0.12.0.0`, which exists after step 9.

Local run of the CI version-consistency script: all seven files match; `ktw-lint --strict .` reports `0.12.0.0 … context-schema 0.12.0`, 0/0; both test suites green; Black clean; `skills_ref validate` valid.

**After merge, in this order:** step 9 run `publish-lint.yml` → step 10 wait until `pip install keep-the-why-lint==0.12.0.0` resolves → step 11 tag `v0.12.0` → step 12 awesome-copilot PR → step 13 three full eval runs on the tag into `docs/evals.md`. Steps 9, 11 and 12 are Oliver's; I take 13 on request.