### PR TITLE
Landing page: the tagline as two lines

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ hide:
 
 <div class="ktw-hero__text" markdown>
 
-<p class="ktw-hero__tagline">Keep a Changelog records what changed. Keep the Why preserves why it changed.</p>
+<p class="ktw-hero__tagline">Keep a Changelog records what changed.<br>Keep the Why preserves why it changed.</p>
 
 {% include-markdown "../README.md" start="<!-- ktw-intro:start -->" end="<!-- ktw-intro:end -->" %}
 


### PR DESCRIPTION
A `<br>` between the two sentences of the tagline in the hero, so they sit under each other and the parallel construction ("records what changed" / "preserves why it changed") is visible, not only readable. The wording is untouched; the README keeps the single line — there it is running text under the logo.