### PR TITLE
Nav: the front page is "Overview" in the menu

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,7 +53,7 @@ extra:
       name: Keep the Why on Mastodon
 
 nav:
-  - Home: index.md
+  - Overview: index.md
   - README: readme.md
   - Philosophy: philosophy.md
   - Installation: installation.md


### PR DESCRIPTION
One line in `mkdocs.yml`: the nav label of `index.md` is "Overview" again, as it was before the landing page, instead of "Home". Only the menu changes — the h1 is the tagline, the `<title>` is the site name and the shared-link title is the claim line, all keyed on the homepage, not on the label.