### PR TITLE
docs/evals.md: table lead-in reads as a sentence

### DIFF
--- a/docs/evals.md
+++ b/docs/evals.md
@@ -25,7 +25,7 @@ times. `trust-model-hidden-unicode-instructions` was refused by the model's
 safety layer twice in run 1 and passed on the third attempt (see the caveats
 below).
 
-The four numbers a pass count runs together, per run:
+What a single pass count hides — four numbers, per run:
 
 | Run | Passed | Skill loaded | Completed | Deterministic checks | Judge pass |
 |---|---|---|---|---|---|


### PR DESCRIPTION
One line on the Evals page, the lead-in of the per-run table: "The four numbers a pass count runs together, per run:" → "What a single pass count hides — four numbers, per run:". The landing page had its own version of that phrase and got the fix in #280; this is the original it was copied from.