### PR TITLE
Landing page: Marketplace and PyPI links on the Check card

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -85,7 +85,7 @@ Everything lives in `context/`, one file per topic, versioned with the code. A l
 
 `keep-the-why-lint` validates the structure in CI — required fields, valid values, index consistency — plus security checks such as hidden Unicode and others. It says plainly what it cannot check: whether a recorded reason is true. That part stays with review.
 
-[Linting →](linting.md) · [Security →](security.md)
+[Linting →](linting.md) · [GitHub Marketplace](https://github.com/marketplace/actions/keep-the-why-lint) · [PyPI](https://pypi.org/project/keep-the-why-lint/) · [Security →](security.md)
 
 </div>
 


### PR DESCRIPTION
The Check card, which introduces the linter, now links its two channels next to the Linting page: "Linting → · GitHub Marketplace · PyPI · Security →". The hero keeps its three buttons — Install, README, GitHub answer the first-five-seconds question about the skill; the linter's channels belong where the reader has met the linter.