### PR TITLE
Landing page: open source under the MIT license

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,9 @@ hide:
 [GitHub](https://github.com/oliver-zehentleitner/keep-the-why){ .md-button }
 { .ktw-hero__actions }
 
+Open source under the [MIT license](https://github.com/oliver-zehentleitner/keep-the-why/blob/main/LICENSE) — the skill, the linter, and this site. Nothing to sign up for, nothing that phones home.
+{ .ktw-caption }
+
 </div>
 
 <div class="ktw-hero__demo">
@@ -144,7 +147,7 @@ The full list, and where Keep the Why fits next to ADRs, `AGENTS.md` and Keep a 
 
 <div class="ktw-footer" markdown>
 
-[README](readme.md) · [Installation](installation.md) · [Philosophy](philosophy.md) · [Security](security.md) · [FAQ](faq.md) · [Why I built this](why.md) · [llms.txt](https://keepthewhy.com/llms.txt) for AI agents
+[README](readme.md) · [Installation](installation.md) · [Philosophy](philosophy.md) · [Security](security.md) · [FAQ](faq.md) · [Why I built this](why.md) · [llms.txt](https://keepthewhy.com/llms.txt) for AI agents · [MIT license](https://github.com/oliver-zehentleitner/keep-the-why/blob/main/LICENSE)
 
 </div>
 


### PR DESCRIPTION
One muted line under the hero buttons — "Open source under the MIT license — the skill, the linter, and this site. Nothing to sign up for, nothing that phones home." — linking the LICENSE file, plus an "MIT license" entry in the footer link row. Build with `--strict` clean.