### PR TITLE
Prepare 0.13.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "keep-the-why",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Preserves or recovers the reasoning behind a codebase - decisions, rejected alternatives, workarounds, and incident learnings the code alone can't explain.",
   "author": {
     "name": "Oliver Zehentleitner",

--- a/.keep-the-why
+++ b/.keep-the-why
@@ -6,7 +6,7 @@ README, for what Keep the Why actually is.
 - id: oliver-zehentleitner---keep-the-why
 - context: `context/`
 - init: complete
-- context-schema: 0.13.0
+- context-schema: 0.13.1
 - capture-confirmation: confirm-always
 - source-reference: never
 <!-- /keep-the-why:config -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-09-07
+
 ### Added
 
 - `references/specification.md`, and keepthewhy.com/specification/: the normative definition of the format in one place — the three config files field by field with values and defaults, the block syntax, the resolution order, `context-schema` and the gate table, the context directory, the `index.md` grammar, the entry grammar with every field and value, the lifecycle transitions, what parsers ignore, what an entry must not contain, and a conformance section. Definitions and the worked examples moved out of `repository-structure.md`, which keeps the default layout, the routing table, the `AGENTS.md` example and retrofitting; `SKILL.md`, `setup.md`, the README and `llms.txt` point at the new file. The context README template the wizard writes names the fifth `Status` value. A convention needs a page that says what is valid without telling a story — maintainer request. Three fixes from an external read of the split, same day: the two pages' intros describe each other the same way (`repository-structure.md` is placement, routing, adoption; the specification is the format, with an example under each artifact — the global config and the guard files got theirs); `needs-review` is defined as "previously current, a `Revisit when` trigger fired, not yet re-checked", independent of `Evidence`, in the specification, rule 5 and `migrations.md`; and the specification's docs page includes the file without relative-URL rewriting, which had turned the index grammar line `- [<file>](<file>)` into a link to a non-existent path.
+
+### Changed
+
+- `keep-the-why-lint` 0.13.1.0: knows schema 0.13.1 — no new gate, nothing in this release changes what `context/` or `.keep-the-why` must look like; a project on 0.13.1 gets no `W003`. Published before the skill tag, per the checklist.
 
 ## [0.13.0] - 2026-09-07
 
@@ -554,7 +560,8 @@ Initial release.
 - Logo, wordmark, and favicon.
 - `context/repo-conventions.md`, dogfooding the skill on its own repository from day one.
 
-[Unreleased]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.13.1...HEAD
+[0.13.1]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.10.1...v0.11.0

--- a/lint/ktw_lint/__init__.py
+++ b/lint/ktw_lint/__init__.py
@@ -13,6 +13,6 @@ changes. PEP 440, not strict SemVer — PyPI rejects the SemVer build-
 metadata spelling this would otherwise use.
 """
 
-__version__ = "0.13.0.0"
+__version__ = "0.13.1.0"
 
-SUPPORTED_SCHEMA = (0, 13, 0)
+SUPPORTED_SCHEMA = (0, 13, 1)

--- a/lint/ktw_lint/config.py
+++ b/lint/ktw_lint/config.py
@@ -6,7 +6,7 @@ The config format is a delimited block of `- key: value` lines:
     - id: acme---widget-service
     - context: `context/`
     - init: complete
-    - context-schema: 0.13.0
+    - context-schema: 0.13.1
     - capture-confirmation: confirm-when-unsure
     - source-reference: never
     <!-- /keep-the-why:config -->

--- a/llms.txt
+++ b/llms.txt
@@ -37,7 +37,7 @@ get thrown away, not creating separate documentation effort. It isn't magic, tho
 prevents knowledge from decaying on its own. This lowers the friction of the discipline that
 keeps documentation honest; it doesn't replace it.
 
-Version: 0.13.0.
+Version: 0.13.1.
 
 ## Authorship & License
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "keep-the-why",
   "description": "Preserves or recovers the reasoning behind a codebase - architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "author": {
     "name": "Oliver Zehentleitner"
   },

--- a/skills/keep-the-why/SKILL.md
+++ b/skills/keep-the-why/SKILL.md
@@ -3,7 +3,7 @@ name: keep-the-why
 description: Extract and preserve the reasoning code cannot explain - decisions, rejected alternatives, workarounds, incidents, constraints - plus project setup and maintainer interviews. Not for what changed (see Keep a Changelog) - only why.
 license: MIT
 metadata:
-  version: "0.13.0"
+  version: "0.13.1"
   repository: "https://github.com/oliver-zehentleitner/keep-the-why"
   author: "Oliver Zehentleitner"
 ---

--- a/skills/keep-the-why/examples/first-time-setup.md
+++ b/skills/keep-the-why/examples/first-time-setup.md
@@ -113,7 +113,7 @@ This names the skill and its purpose directly — not a task that happens to mat
     - id: acme---widget-service
     - context: `context/`
     - init: complete
-    - context-schema: 0.13.0
+    - context-schema: 0.13.1
     - capture-confirmation: confirm-when-unsure
     - source-reference: never
     <!-- /keep-the-why:config -->

--- a/skills/keep-the-why/references/setup.md
+++ b/skills/keep-the-why/references/setup.md
@@ -17,7 +17,7 @@ README, for what Keep the Why actually is.
 - id: oliver-zehentleitner---keep-the-why
 - context: `context/`
 - init: complete
-- context-schema: 0.13.0
+- context-schema: 0.13.1
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->

--- a/skills/keep-the-why/references/specification.md
+++ b/skills/keep-the-why/references/specification.md
@@ -67,7 +67,7 @@ README, for what Keep the Why actually is.
 - id: acme---widget-service
 - context: `context/`
 - init: complete
-- context-schema: 0.13.0
+- context-schema: 0.13.1
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->


### PR DESCRIPTION
Docs-only patch release: the specification (#293–#296), the split of `repository-structure.md`, the landing-page MIT line. No behavior, no schema change — `migrations.md` gets no entry, a project on 0.13.0 advances silently.

Checklist steps 1–8: `SKILL.md`, `llms.txt`, both `plugin.json` → 0.13.1; linter 0.13.1.0 / `SUPPORTED_SCHEMA` 0.13.1 (no new gate, CHANGELOG line); `[Unreleased]` → `[0.13.1] - 2026-09-07` with compare links; this repo's `context-schema` → 0.13.1; illustrative `context-schema` values in `setup.md`, `specification.md`, `examples/first-time-setup.md` and the linter docstring → 0.13.1.

The `release.yml` gate script passes all seven file checks on this commit locally; the PyPI check is step 9. 65 linter tests, dogfood lint clean on schema 0.13.1, docs build strict. After merge: publish the linter, wait for pip, tag `v0.13.1`, then three full runs on the tag into `docs/evals.md`.