### PR TITLE
SKILL.md: example section points at specification.md for the field reference

### DIFF
--- a/skills/keep-the-why/SKILL.md
+++ b/skills/keep-the-why/SKILL.md
@@ -142,7 +142,7 @@ Update existing topics rather than accumulating new ones, resolve contradictions
 
 ## Example: expected output
 
-A `context/` topic file entry (full field reference: `references/repository-structure.md`):
+A `context/` topic file entry (full field reference: `references/specification.md`):
 
 ```markdown
 ## Snapshot-before-buffer ordering


### PR DESCRIPTION
The last pointer the specification split missed: "Example: expected output" in `SKILL.md` still sent readers to `references/repository-structure.md` for the full field reference. Now `references/specification.md`. The remaining five references to `repository-structure.md` in `SKILL.md` are routing, layout and retrofitting — correct as they are. Found by the external re-check of v0.13.1.