### PR TITLE
Prepare 0.13.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "keep-the-why",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Preserves or recovers the reasoning behind a codebase - decisions, rejected alternatives, workarounds, and incident learnings the code alone can't explain.",
   "author": {
     "name": "Oliver Zehentleitner",

--- a/.keep-the-why
+++ b/.keep-the-why
@@ -6,7 +6,7 @@ README, for what Keep the Why actually is.
 - id: oliver-zehentleitner---keep-the-why
 - context: `context/`
 - init: complete
-- context-schema: 0.13.1
+- context-schema: 0.13.2
 - capture-confirmation: confirm-always
 - source-reference: never
 <!-- /keep-the-why:config -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+## [0.13.2] - 2026-09-07
+
 ### Changed
 
 - `docs/security.md` says what is true now: two new sections — the linter as a CI tool on untrusted input (never reads outside the checkout, `id` is a file name, malformed input is a finding not a traceback, escaped findings, no network, no dependencies) and how this repository is protected (SHA-pinned actions with Dependabot, read-only tokens, trusted publishing, the release gate, required checks on `main`, CODEOWNERS, the external reviews and the audit) — and, in the same place, what is deliberately not hardened: the moving `latest` tags, the eval runner's permission bypass, floating build inputs. The attack-surface list gains the declared-unattended rule. The page had stopped at the 0.11.0 state.
+
+- `keep-the-why-lint` 0.13.2.0: knows schema 0.13.2 — no new gate. Published before the skill tag, per the checklist.
+
+- `SKILL.md`'s "Example: expected output" points at `references/specification.md` for the field reference — the last pointer the specification split had missed. Found by an external re-check of 0.13.1.
 
 ## [0.13.1] - 2026-09-07
 
@@ -564,7 +570,8 @@ Initial release.
 - Logo, wordmark, and favicon.
 - `context/repo-conventions.md`, dogfooding the skill on its own repository from day one.
 
-[Unreleased]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.13.1...HEAD
+[Unreleased]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.13.2...HEAD
+[0.13.2]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.13.1...v0.13.2
 [0.13.1]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.11.0...v0.12.0

--- a/lint/ktw_lint/__init__.py
+++ b/lint/ktw_lint/__init__.py
@@ -13,6 +13,6 @@ changes. PEP 440, not strict SemVer — PyPI rejects the SemVer build-
 metadata spelling this would otherwise use.
 """
 
-__version__ = "0.13.1.0"
+__version__ = "0.13.2.0"
 
-SUPPORTED_SCHEMA = (0, 13, 1)
+SUPPORTED_SCHEMA = (0, 13, 2)

--- a/lint/ktw_lint/config.py
+++ b/lint/ktw_lint/config.py
@@ -6,7 +6,7 @@ The config format is a delimited block of `- key: value` lines:
     - id: acme---widget-service
     - context: `context/`
     - init: complete
-    - context-schema: 0.13.1
+    - context-schema: 0.13.2
     - capture-confirmation: confirm-when-unsure
     - source-reference: never
     <!-- /keep-the-why:config -->

--- a/llms.txt
+++ b/llms.txt
@@ -37,7 +37,7 @@ get thrown away, not creating separate documentation effort. It isn't magic, tho
 prevents knowledge from decaying on its own. This lowers the friction of the discipline that
 keeps documentation honest; it doesn't replace it.
 
-Version: 0.13.1.
+Version: 0.13.2.
 
 ## Authorship & License
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "keep-the-why",
   "description": "Preserves or recovers the reasoning behind a codebase - architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "author": {
     "name": "Oliver Zehentleitner"
   },

--- a/skills/keep-the-why/SKILL.md
+++ b/skills/keep-the-why/SKILL.md
@@ -3,7 +3,7 @@ name: keep-the-why
 description: Extract and preserve the reasoning code cannot explain - decisions, rejected alternatives, workarounds, incidents, constraints - plus project setup and maintainer interviews. Not for what changed (see Keep a Changelog) - only why.
 license: MIT
 metadata:
-  version: "0.13.1"
+  version: "0.13.2"
   repository: "https://github.com/oliver-zehentleitner/keep-the-why"
   author: "Oliver Zehentleitner"
 ---

--- a/skills/keep-the-why/examples/first-time-setup.md
+++ b/skills/keep-the-why/examples/first-time-setup.md
@@ -113,7 +113,7 @@ This names the skill and its purpose directly — not a task that happens to mat
     - id: acme---widget-service
     - context: `context/`
     - init: complete
-    - context-schema: 0.13.1
+    - context-schema: 0.13.2
     - capture-confirmation: confirm-when-unsure
     - source-reference: never
     <!-- /keep-the-why:config -->

--- a/skills/keep-the-why/references/setup.md
+++ b/skills/keep-the-why/references/setup.md
@@ -17,7 +17,7 @@ README, for what Keep the Why actually is.
 - id: oliver-zehentleitner---keep-the-why
 - context: `context/`
 - init: complete
-- context-schema: 0.13.1
+- context-schema: 0.13.2
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->

--- a/skills/keep-the-why/references/specification.md
+++ b/skills/keep-the-why/references/specification.md
@@ -67,7 +67,7 @@ README, for what Keep the Why actually is.
 - id: acme---widget-service
 - context: `context/`
 - init: complete
-- context-schema: 0.13.1
+- context-schema: 0.13.2
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->


### PR DESCRIPTION
Docs-only patch release: the security page brought to the 0.13.x state and stripped of label history (#298, #299), the last specification-split pointer in `SKILL.md` (#300). No behavior, no schema change — no `migrations.md` entry, a project on 0.13.1 advances silently.

Checklist steps 1–8 as for 0.13.1: versions → 0.13.2 in `SKILL.md`, `llms.txt`, both `plugin.json`; linter 0.13.2.0 / `SUPPORTED_SCHEMA` 0.13.2, no new gate; `[Unreleased]` → `[0.13.2] - 2026-09-07` with compare links; this repo's `context-schema` and the illustrative values → 0.13.2. Gate script: seven file checks pass locally; PyPI is step 9. 65 linter tests, dogfood lint clean, docs build strict.

After merge, without further asking: publish the linter, wait for pip, tag `v0.13.2`, re-run the Link Check, move awesome-copilot #2975 to 0.13.2.