### PR TITLE
docs/index.md: badge caption gets its verbs — the skill is validated, context/ is linted, the package is scanned

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -109,7 +109,7 @@ Everything lives in `context/`, one file per topic, versioned with the code. A l
 <a href="https://skillsllm.com/security-check/IPmNycVdbOyq"><img src="https://skillsllm.com/security-check/badge.svg?owner=oliver-zehentleitner&repo=keep-the-why" alt="Security: SkillsLLM"></a>
 </p>
 
-The skill validated against the Agent Skills spec on every push; this repository's own `context/` linted by its own linter, in strict mode; the package scanned by an independent registry.
+The skill is validated against the Agent Skills spec on every push; this repository's own `context/` is linted by its own linter, in strict mode; the package is scanned by an independent registry.
 { .ktw-caption }
 
 </div>


### PR DESCRIPTION
The caption under the three badges on the landing page read as three verbless fragments ("The skill validated against …; context/ linted …; the package scanned …"). Adds "is" to each clause. No other landing-page change.