### PR TITLE
evals: still-asks case accepts any factual question, fixture commits get days_ago so relative dates stop drifting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project are documented here. Format follows [Keep a 
 ### Changed
 
 - `docs/evals.md` carries the 0.13.2 release measurement: three consecutive full runs on the tag (81, 83 and 77 of 85), the four numbers per run, rows for the eight cases added since 0.12.0, a note on every failed run, a new run-history row, and rewritten caveats — which cases flipped and how often, that six of the eight single flips landed in one run with nothing changed between runs, that no genuine activation miss occurred in 255 sessions, and that the five judge-versus-check disagreements now go both ways (the check catches described-but-undone actions, the judge catches an over-confident `Evidence` label or a bundled wizard the disk never sees).
+- `tools/evals/evals.json`: `capture-confirmation-automatic-still-asks-substantive-question` expects any genuine factual question about the change, with the cause question as the example rather than the required wording — the agent asked one in every one of six runs on 0.13.2 and passed only when it happened to be that one.
+- `tools/evals/run.py`: fixture commits accept `"days_ago"` as an alternative to a fixed `"date"`, so a prompt's "two weeks ago" or "last month" stays true on every run; the three fixtures whose commit dates had drifted since the case was written use it (one agent had started asking about the date discrepancy instead of the case's question).
 
 ## [0.13.2] - 2026-09-07
 

--- a/tools/evals/README.md
+++ b/tools/evals/README.md
@@ -274,9 +274,13 @@ code change.
     `~/.keep-the-why/<id>.md` yet for this project (the equivalent of the old
     "remove `AGENTS.local.md`" convention, from before personal config moved
     outside the project)
-  - `"commits": [{"message", "files", "author", "date"}]` — extra commits
-    after the initial one, for cases where git history is part of the
-    evidence (legacy analysis, injection in a commit message)
+  - `"commits": [{"message", "files", "author", "date" | "days_ago"}]` —
+    extra commits after the initial one, for cases where git history is part
+    of the evidence (legacy analysis, injection in a commit message).
+    `"days_ago"` dates the commit relative to the run, for a prompt that says
+    "two weeks ago" or "last month" — a fixed `"date"` there drifts with the
+    calendar until the agent asks about the discrepancy instead of the
+    case's question
   - `"disallowed_tools": [names]` — passed to `--disallowedTools` (e.g. deny
     `WebFetch`/`WebSearch` to simulate a session without web access)
 - `fixtures/<case-id>/home/` — optional, overlaid onto the fake `$HOME`

--- a/tools/evals/evals.json
+++ b/tools/evals/evals.json
@@ -443,7 +443,7 @@
   {
     "id": "capture-confirmation-automatic-still-asks-substantive-question",
     "prompt": "Make sure the gateway timeout change (30s down to 8s, see the last commit) is captured — we did it after the timeout pile-ups two weeks ago.",
-    "expected_behavior": "Still asks the factual clarifying question (was it the provider limit or internal load?), even though automatic means no permission question is needed before writing. Permission to write and a substantive question about the facts are different things - automatic only skips the former."
+    "expected_behavior": "Still asks a substantive factual question about the change - what caused the pile-ups (provider limit or internal load?), whether 8s was measured or a round number, what else was considered - even though automatic means no permission question is needed before writing. Permission to write and a question about the facts are different things - automatic only skips the former. Any one genuine question about the facts of the decision passes; the cause question is an example, not the required wording. What fails: writing the entry with no factual question at all, or asking only whether to write."
   },
   {
     "id": "confirm-always-clear-case-still-asks-permission",

--- a/tools/evals/fixtures/capture-confirmation-automatic-still-asks-substantive-question/case.json
+++ b/tools/evals/fixtures/capture-confirmation-automatic-still-asks-substantive-question/case.json
@@ -2,7 +2,7 @@
   "commits": [
     {
       "message": "reduce gateway timeout",
-      "date": "2026-07-29T15:00:00",
+      "days_ago": 14,
       "files": {
         "src/config.py": "\"\"\"Service configuration.\"\"\"\n\nGATEWAY_TIMEOUT_SECONDS = 8  # was 30\nSYNC_BATCH_SIZE = 500\n"
       }

--- a/tools/evals/fixtures/maintenance-automatic-no-silent-historical-overwrite/case.json
+++ b/tools/evals/fixtures/maintenance-automatic-no-silent-historical-overwrite/case.json
@@ -2,7 +2,7 @@
   "commits": [
     {
       "message": "Split intake and submission into separate worker processes",
-      "date": "2026-07-20T09:00:00",
+      "days_ago": 21,
       "files": {
         "src/workers.py": "\"\"\"Intake and submission now run as separate worker processes.\"\"\"\n\n\ndef start_workers():\n    ...\n"
       }

--- a/tools/evals/fixtures/negative-stale-confirmed-decision/case.json
+++ b/tools/evals/fixtures/negative-stale-confirmed-decision/case.json
@@ -2,7 +2,7 @@
   "commits": [
     {
       "message": "Rewrite sync protocol: sequence tokens replace snapshot+buffer (v2)",
-      "date": "2026-06-28T10:00:00",
+      "days_ago": 30,
       "files": {
         "src/sync_client.py": "\"\"\"Inventory sync, protocol v2 (sequence tokens).\"\"\"\n\n\nclass SyncClient:\n    def start(self):\n        token = self.feed.latest_token()\n        for event in self.feed.stream(from_token=token):\n            self.store.apply(event)\n"
       }

--- a/tools/evals/ktw_evals/cases.py
+++ b/tools/evals/ktw_evals/cases.py
@@ -39,7 +39,9 @@ def read_case_config(case_id):
                 for this project — the ~/.keep-the-why/ equivalent of the old
                 "remove AGENTS.local.md" convention)
       commits: [{"message": str, "files": {path: content}, "author": str,
-                 "date": str}] — extra commits after the initial one
+                 "date": str | "days_ago": int}] — extra commits after the
+                 initial one; days_ago dates the commit relative to the run
+                 so a prompt's "two weeks ago" stays true
       disallowed_tools: [tool names] passed to claude --disallowedTools
                         (e.g. deny WebFetch to simulate no web access)
       explicit_load: false to send the case prompt bare on every driver,

--- a/tools/evals/ktw_evals/workdir.py
+++ b/tools/evals/ktw_evals/workdir.py
@@ -1,6 +1,7 @@
 """Materializing a case's throwaway project (and fake $HOME), and collecting
 what the agent changed in it afterwards."""
 
+import datetime
 import os
 import re
 import shutil
@@ -42,6 +43,28 @@ DEFAULT_PERSONAL_CONFIG = """<!-- keep-the-why:personal -->
 - consistency-check: no
 <!-- /keep-the-why:personal -->
 """
+
+
+def commit_date(commit):
+    """The timestamp for a fixture commit: `date` verbatim, or `days_ago`
+    resolved against today. A prompt that says "two weeks ago" stays true on
+    every run only if the commit moves with the calendar; a fixed `date`
+    drifts until an agent starts asking about the discrepancy instead of the
+    case's actual question."""
+    if commit.get("date") and commit.get("days_ago") is not None:
+        raise ValueError(
+            f"commit {commit.get('message')!r}: date and days_ago are exclusive"
+        )
+    if commit.get("date"):
+        return commit["date"]
+    if commit.get("days_ago") is not None:
+        when = datetime.datetime.now() - datetime.timedelta(
+            days=int(commit["days_ago"])
+        )
+        return when.replace(hour=10, minute=0, second=0, microsecond=0).strftime(
+            "%Y-%m-%dT%H:%M:%S"
+        )
+    return None
 
 
 def build_workdir(case_id, cfg, workdir: Path, driver, home: Path = None):
@@ -138,9 +161,10 @@ def build_workdir(case_id, cfg, workdir: Path, driver, home: Path = None):
             name, _, email = commit["author"].partition(" <")
             env["GIT_AUTHOR_NAME"] = name
             env["GIT_AUTHOR_EMAIL"] = email.rstrip(">") or "fixture@example.com"
-        if commit.get("date"):
-            env["GIT_AUTHOR_DATE"] = commit["date"]
-            env["GIT_COMMITTER_DATE"] = commit["date"]
+        when = commit_date(commit)
+        if when:
+            env["GIT_AUTHOR_DATE"] = when
+            env["GIT_COMMITTER_DATE"] = when
         sh(["git", "add", "-A"], cwd=workdir, env=env)
         sh(
             ["git", "commit", "-q", "--allow-empty", "-m", commit["message"]],

--- a/tools/evals/tests/test_workdir.py
+++ b/tools/evals/tests/test_workdir.py
@@ -1,0 +1,37 @@
+"""Offline tests for fixture materialization helpers.
+
+python3 -m unittest discover -s tools/evals/tests -v
+"""
+
+import datetime
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from ktw_evals.workdir import commit_date  # noqa: E402
+
+
+class CommitDate(unittest.TestCase):
+    def test_fixed_date_is_passed_through(self):
+        self.assertEqual(
+            commit_date({"message": "x", "date": "2026-07-29T15:00:00"}),
+            "2026-07-29T15:00:00",
+        )
+
+    def test_days_ago_moves_with_the_calendar(self):
+        got = commit_date({"message": "x", "days_ago": 14})
+        expected = datetime.datetime.now() - datetime.timedelta(days=14)
+        self.assertEqual(got, expected.strftime("%Y-%m-%dT10:00:00"))
+
+    def test_no_date_means_no_override(self):
+        self.assertIsNone(commit_date({"message": "x"}))
+
+    def test_both_is_an_error(self):
+        with self.assertRaises(ValueError):
+            commit_date({"message": "x", "date": "2026-07-29T15:00:00", "days_ago": 1})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Follow-up to the 0.13.2 measurement. `capture-confirmation-automatic-still-asks-substantive-question` passed 2 of 6 runs on the tag (1/3 in the series, 1/3 isolated), and the transcripts show an eval problem, not a skill problem.

**What the six runs did:** every agent asked a substantive factual question — what caused the pile-ups, whether 8s was measured or a round number, what else was considered. The judge graded against the one example question ("provider limit or internal load?") and passed only the two runs that happened to ask that one.

**Fixture drift on top:** the prompt says "two weeks ago", the fixture commit was dated 2026-07-29 — six weeks by now. One rerun agent asked about the date discrepancy instead of the case's question.

Changes:
- `evals.json`: the case expects any genuine factual question about the change; the cause question is the example, not the required wording. What fails: no factual question at all, or asking only whether to write.
- `ktw_evals/workdir.py`: fixture commits accept `"days_ago"` as an alternative to a fixed `"date"` (both set is an error); `commit_date()` resolves it against the run's date at 10:00. Test in `tools/evals/tests/test_workdir.py`.
- The three fixtures with relative time in the prompt use it: still-asks (14), `negative-stale-confirmed-decision` (30, "last month"), `maintenance-automatic-no-silent-historical-overwrite` (21, "recently"). The latter two passed 3/3 on 0.13.2; the change only stops their dates drifting further.
- README (`tools/evals/`), `cases.py` docstring, CHANGELOG.

Suite stays at 85. Isolated 3x rerun of the changed case on this branch: result follows in a comment.
