### PR TITLE
Prepare 0.13.3: skill, plugin and linter versions, CHANGELOG section and compare links, context-schema 0.13.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "keep-the-why",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "Preserves or recovers the reasoning behind a codebase - decisions, rejected alternatives, workarounds, and incident learnings the code alone can't explain.",
   "author": {
     "name": "Oliver Zehentleitner",

--- a/.keep-the-why
+++ b/.keep-the-why
@@ -6,7 +6,7 @@ README, for what Keep the Why actually is.
 - id: oliver-zehentleitner---keep-the-why
 - context: `context/`
 - init: complete
-- context-schema: 0.13.2
+- context-schema: 0.13.3
 - capture-confirmation: confirm-always
 - source-reference: never
 <!-- /keep-the-why:config -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+## [0.13.3] - 2026-09-07
+
 ### Changed
 
 - `docs/evals.md` carries the 0.13.2 release measurement: three consecutive full runs on the tag (81, 83 and 77 of 85), the four numbers per run, rows for the eight cases added since 0.12.0, a note on every failed run, a new run-history row, and rewritten caveats — which cases flipped and how often, that six of the eight single flips landed in one run with nothing changed between runs, that no genuine activation miss occurred in 255 sessions, and that the five judge-versus-check disagreements now go both ways (the check catches described-but-undone actions, the judge catches an over-confident `Evidence` label or a bundled wizard the disk never sees).
+- `keep-the-why-lint` 0.13.3.0: knows schema 0.13.3 — no new gate. Published before the skill tag, per the checklist.
 - `SKILL.md` Maintain section, and `references/setup.md`'s maintenance bullet: a contradiction the consistency check itself turns up is surfaced — `Status: needs-review`, `Verification: contradicted`, or a question — not settled by superseding the entry on the agent's reading of the code; that was already the specification's lifecycle rule, and two agents in the 0.13.2 series followed the skill body's "resolve contradictions, mark superseded" literally into a fail.
 - `tools/evals/evals.json`: `capture-confirmation-automatic-still-asks-substantive-question` expects any genuine factual question about the change, with the cause question as the example rather than the required wording — the agent asked one in every one of six runs on 0.13.2 and passed only when it happened to be that one.
 - `tools/evals/run.py`: fixture commits accept `"days_ago"` as an alternative to a fixed `"date"`, so a prompt's "two weeks ago" or "last month" stays true on every run; the three fixtures whose commit dates had drifted since the case was written use it (one agent had started asking about the date discrepancy instead of the case's question).
@@ -577,7 +580,8 @@ Initial release.
 - Logo, wordmark, and favicon.
 - `context/repo-conventions.md`, dogfooding the skill on its own repository from day one.
 
-[Unreleased]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.13.2...HEAD
+[Unreleased]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.13.3...HEAD
+[0.13.3]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.13.2...v0.13.3
 [0.13.2]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.13.1...v0.13.2
 [0.13.1]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.12.0...v0.13.0

--- a/lint/ktw_lint/__init__.py
+++ b/lint/ktw_lint/__init__.py
@@ -13,6 +13,6 @@ changes. PEP 440, not strict SemVer — PyPI rejects the SemVer build-
 metadata spelling this would otherwise use.
 """
 
-__version__ = "0.13.2.0"
+__version__ = "0.13.3.0"
 
-SUPPORTED_SCHEMA = (0, 13, 2)
+SUPPORTED_SCHEMA = (0, 13, 3)

--- a/lint/ktw_lint/config.py
+++ b/lint/ktw_lint/config.py
@@ -6,7 +6,7 @@ The config format is a delimited block of `- key: value` lines:
     - id: acme---widget-service
     - context: `context/`
     - init: complete
-    - context-schema: 0.13.2
+    - context-schema: 0.13.3
     - capture-confirmation: confirm-when-unsure
     - source-reference: never
     <!-- /keep-the-why:config -->

--- a/llms.txt
+++ b/llms.txt
@@ -37,7 +37,7 @@ get thrown away, not creating separate documentation effort. It isn't magic, tho
 prevents knowledge from decaying on its own. This lowers the friction of the discipline that
 keeps documentation honest; it doesn't replace it.
 
-Version: 0.13.2.
+Version: 0.13.3.
 
 ## Authorship & License
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "keep-the-why",
   "description": "Preserves or recovers the reasoning behind a codebase - architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "author": {
     "name": "Oliver Zehentleitner"
   },

--- a/skills/keep-the-why/SKILL.md
+++ b/skills/keep-the-why/SKILL.md
@@ -3,7 +3,7 @@ name: keep-the-why
 description: Extract and preserve the reasoning code cannot explain - decisions, rejected alternatives, workarounds, incidents, constraints - plus project setup and maintainer interviews. Not for what changed (see Keep a Changelog) - only why.
 license: MIT
 metadata:
-  version: "0.13.2"
+  version: "0.13.3"
   repository: "https://github.com/oliver-zehentleitner/keep-the-why"
   author: "Oliver Zehentleitner"
 ---

--- a/skills/keep-the-why/examples/first-time-setup.md
+++ b/skills/keep-the-why/examples/first-time-setup.md
@@ -113,7 +113,7 @@ This names the skill and its purpose directly — not a task that happens to mat
     - id: acme---widget-service
     - context: `context/`
     - init: complete
-    - context-schema: 0.13.2
+    - context-schema: 0.13.3
     - capture-confirmation: confirm-when-unsure
     - source-reference: never
     <!-- /keep-the-why:config -->

--- a/skills/keep-the-why/references/setup.md
+++ b/skills/keep-the-why/references/setup.md
@@ -17,7 +17,7 @@ README, for what Keep the Why actually is.
 - id: oliver-zehentleitner---keep-the-why
 - context: `context/`
 - init: complete
-- context-schema: 0.13.2
+- context-schema: 0.13.3
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->

--- a/skills/keep-the-why/references/specification.md
+++ b/skills/keep-the-why/references/specification.md
@@ -67,7 +67,7 @@ README, for what Keep the Why actually is.
 - id: acme---widget-service
 - context: `context/`
 - init: complete
-- context-schema: 0.13.2
+- context-schema: 0.13.3
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->


### PR DESCRIPTION
Release prepare PR (CONTRIBUTING steps 1–8). Skill `metadata.version`, both `plugin.json`, `llms.txt`, linter `__version__` 0.13.3.0 and `SUPPORTED_SCHEMA`, this repo's `context-schema`, and the three illustrative config blocks (setup.md, specification.md, first-time-setup.md) plus the linter's own config docstring — all 0.13.3. CHANGELOG: `[Unreleased]` → `[0.13.3] - 2026-09-07` with the linter line, fresh empty `[Unreleased]`, compare-link footer. No new linter gate: 0.13.3 changes the Maintain wording (#305) and the eval tooling (#304), nothing the linter checks; `migrations.md` needs no entry. Four local checks and `mkdocs build --strict` green. After merge: publish-lint → pip check → tag v0.13.3 → link-check rerun → awesome-copilot PR → three full eval runs.