### PR TITLE
mkdocs site_description and the landing page's own description match the GitHub About text — the Git layer named, the payoffs kept

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 ---
-description: "Project memory for your codebase, kept in the repo: an agent skill and convention that preserves the reasoning behind the code — decisions, rejected alternatives, workarounds, constraints."
+description: "Keep the Why: a repo-native convention and agent skill that preserves the reasoning behind a codebase as project memory — Markdown in the repo, versioned and shared by Git, a byproduct of working with your agent — so it stops re-suggesting rejected approaches, gives better answers, speeds up onboarding, and makes legacy projects tractable again."
 hide:
   - toc
 ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Keep the Why
-site_description: "Keep the Why is a repo-native convention and agent skill that preserves the reasoning behind a codebase as project memory, kept in the repo — a byproduct of working with your agent, so your agent, and every other agent that works in the repository, understands not just the code but everything around it: why it is the way it is, what was tried and rejected, which constraints the source doesn't show."
+site_description: "Keep the Why: a repo-native convention and agent skill that preserves the reasoning behind a codebase as project memory — Markdown in the repo, versioned and shared by Git, a byproduct of working with your agent — so it stops re-suggesting rejected approaches, gives better answers, speeds up onboarding, and makes legacy projects tractable again."
 site_url: https://keepthewhy.com
 repo_url: https://github.com/oliver-zehentleitner/keep-the-why
 repo_name: oliver-zehentleitner/keep-the-why


### PR DESCRIPTION
Two meta descriptions carried the pre-Git-layer wording: `site_description` in `mkdocs.yml` (every page without its own) and the `description:` front matter of `docs/index.md`, which is what search snippets and link previews show for the homepage. Both now carry the same 347-character text as the repository's About: reasoning kept as project memory — Markdown in the repo, versioned and shared by Git, a byproduct of working with your agent — with the four payoffs. `mkdocs build --strict` clean, rendered meta tags verified on the homepage and a subpage.