### PR TITLE
plugin.json: one description for both plugin manifests, matching the About text — project memory, kept in the repo, versioned and shared by Git

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "keep-the-why",
   "version": "0.13.3",
-  "description": "Preserves or recovers the reasoning behind a codebase - decisions, rejected alternatives, workarounds, and incident learnings the code alone can't explain.",
+  "description": "Preserves the reasoning behind a codebase as project memory — decisions, rejected alternatives, workarounds, incident learnings, constraints the code alone can't explain — kept in the repo as Markdown, versioned and shared by Git.",
   "author": {
     "name": "Oliver Zehentleitner",
     "url": "https://github.com/oliver-zehentleitner"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. Format follows [Keep a 
 ### Changed
 
 - `docs/evals.md` carries the 0.13.3 release measurement: three consecutive full runs on the tag (82, 79 and 81 of 85), the four numbers per run, a note on every failed run, a new run-history row, and rewritten caveats — the two cases 0.13.3 was cut for went 3/3, one genuine activation miss in 255 sessions, and the six judge-versus-check disagreements split two ways (the check catches a described-but-undone write, the judge catches a correct tree with the wrong words around it).
+- `plugin.json` and `.claude-plugin/plugin.json`: one shared description, matching the repository's About text — project memory, kept in the repo as Markdown, versioned and shared by Git; the two files had drifted apart and neither named the Git layer.
 - `README.md` intro (and with it the landing page hero and `llms.txt`): names the Git layer in the first sentence — `context/` is plain Markdown committed with the code, so Git already provides the storage, the history and the distribution, and a pull request shows the reasoning diff beside the code diff.
 
 ## [0.13.3] - 2026-09-07

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "keep-the-why",
-  "description": "Preserves or recovers the reasoning behind a codebase - architectural decisions, rejected alternatives, workarounds, incident learnings, operational constraints, and historical context the code itself cannot explain.",
+  "description": "Preserves the reasoning behind a codebase as project memory — decisions, rejected alternatives, workarounds, incident learnings, constraints the code alone can't explain — kept in the repo as Markdown, versioned and shared by Git.",
   "version": "0.13.3",
   "author": {
     "name": "Oliver Zehentleitner"


### PR DESCRIPTION
Root `plugin.json` and `.claude-plugin/plugin.json` carried two different descriptions, both from before the Git layer was named anywhere. Now one text in both, aligned with the repository's About and the site meta description: reasoning kept as project memory — decisions, rejected alternatives, workarounds, incident learnings, constraints the code alone can't explain — in the repo as Markdown, versioned and shared by Git. CHANGELOG line under `[Unreleased]`. The awesome-copilot entry gets the same text in github/awesome-copilot#2975.