### PR TITLE
Landing page: Git and a host like GitHub or GitLab as the sharing layer, not GitHub alone

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -87,7 +87,7 @@ The agent notices rationale as it surfaces — a decision, an alternative that l
 
 ### Keep & Share
 
-Everything lives in `context/`, one file per topic, versioned with the code. A lean index tells an agent what to load. No daemon, no database, no service — anything that can read a repository can read it. Once merged, the why sits in the history under the same review, permissions and CI as the code. That layer — GitHub — is what turns a local file into shared knowledge.
+Everything lives in `context/`, one file per topic, versioned with the code. A lean index tells an agent what to load. No daemon, no database, no service — anything that can read a repository can read it. Once merged, the why sits in the history under the same review, permissions and CI as the code. That layer — Git, and a host like GitHub or GitLab — is what turns a local file into shared knowledge.
 
 [Repository structure →](repository-structure.md) · [Philosophy →](philosophy.md)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,7 +87,7 @@ The agent notices rationale as it surfaces — a decision, an alternative that l
 
 ### Keep & Share
 
-Everything lives in `context/`, one file per topic, versioned with the code. A lean index tells an agent what to load. No daemon, no database, no service — anything that can read a repository can read it. Once merged, the why sits in the history under the same review, permissions and CI as the code. That layer — Git, on GitHub or GitLab — is what turns a local file into shared knowledge.
+Everything lives in `context/`, one file per topic, versioned with the code. A lean index tells an agent what to load. No daemon, no database, no service — anything that can read a repository can read it. Once merged, the why sits in the history under the same review, permissions and CI as the code. That layer — Git, on GitHub, GitLab or any other host — is what turns a local file into shared knowledge.
 
 [Repository structure →](repository-structure.md) · [Philosophy →](philosophy.md)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,7 +87,7 @@ The agent notices rationale as it surfaces — a decision, an alternative that l
 
 ### Keep & Share
 
-Everything lives in `context/`, one file per topic, versioned with the code. A lean index tells an agent what to load. No daemon, no database, no service — anything that can read a repository can read it. Once merged, the why sits in the history under the same review, permissions and CI as the code. That layer — Git, and a host like GitHub or GitLab — is what turns a local file into shared knowledge.
+Everything lives in `context/`, one file per topic, versioned with the code. A lean index tells an agent what to load. No daemon, no database, no service — anything that can read a repository can read it. Once merged, the why sits in the history under the same review, permissions and CI as the code. That layer — Git, on GitHub or GitLab — is what turns a local file into shared knowledge.
 
 [Repository structure →](repository-structure.md) · [Philosophy →](philosophy.md)
 


### PR DESCRIPTION
Follow-up to #311, which was merged before this one-line change reached it. The Keep & Share card ended on "That layer — GitHub — is what turns a local file into shared knowledge."; now: "That layer — Git, and a host like GitHub or GitLab — …". Maintainer wording.