### PR TITLE
Prepare 0.14.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "keep-the-why",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Preserves the reasoning behind a codebase as project memory — decisions, rejected alternatives, workarounds, incident learnings, constraints the code alone can't explain — kept in the repo as Markdown, versioned and shared by Git.",
   "author": {
     "name": "Oliver Zehentleitner",

--- a/.keep-the-why
+++ b/.keep-the-why
@@ -6,7 +6,7 @@ README, for what Keep the Why actually is.
 - id: oliver-zehentleitner---keep-the-why
 - context: `context/`
 - init: complete
-- context-schema: 0.14.0
+- context-schema: 0.14.1
 - capture-confirmation: confirm-always
 - source-reference: never
 <!-- /keep-the-why:config -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,16 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+## [0.14.1] - 2026-09-08
+
 ### Fixed
 
 - The local-linting rule says three things it only implied, each caught by one eval case in the 0.14.0 release measurement (#321): `ask` gates the install and the update, never the run — an agent had asked permission to run a linter that was already at version; a value the linter rejects is resolved toward the weaker `Evidence` level or asked, never upgraded to make the line valid — an agent had collapsed `confirmed (…); unknown (…)` to `confirmed` after `E103`; and a finding the setup check owns is the setup check's job whichever file it names — `E002` for a field with a documented default is step 0's silent backfill, not "pre-existing", after an agent had left a missing `capture-confirmation` in place because `.keep-the-why` was "not written this session". "Local linting" in `setup.md`, step 5 in `SKILL.md`.
 - Evals: the fake `$HOME` fences tool installs (#322). `pipx`, `uv tool` and `pip --user` locate their install and bin directories through their own variables, not `$HOME` alone, so the `local-lint: auto` case's session installed `keep-the-why-lint` into the operator's real `~/.local` and every later session in the 0.14.0 measurement found the linter already present. Every driver now launches with `PIPX_HOME`, `PIPX_BIN_DIR`, `UV_TOOL_DIR`, `UV_TOOL_BIN_DIR` and `PYTHONUSERBASE` under the fake home and its `.local/bin` first on `PATH` (`common.fake_home_env`); `collect_diff` lists what a session installed, so the judge sees it without reading the transcript. Two tests; the evals README says so.
+
+### Changed
+
+- `keep-the-why-lint` 0.14.1.0: knows schema 0.14.1 — no new gate, nothing changes what `context/` or `.keep-the-why` must look like. Published before the skill tag, per the checklist.
 
 ## [0.14.0] - 2026-09-08
 
@@ -601,7 +607,8 @@ Initial release.
 - Logo, wordmark, and favicon.
 - `context/repo-conventions.md`, dogfooding the skill on its own repository from day one.
 
-[Unreleased]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.14.0...HEAD
+[Unreleased]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.14.1...HEAD
+[0.14.1]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.13.3...v0.14.0
 [0.13.3]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.13.2...v0.13.3
 [0.13.2]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.13.1...v0.13.2

--- a/lint/ktw_lint/__init__.py
+++ b/lint/ktw_lint/__init__.py
@@ -13,6 +13,6 @@ changes. PEP 440, not strict SemVer — PyPI rejects the SemVer build-
 metadata spelling this would otherwise use.
 """
 
-__version__ = "0.14.0.0"
+__version__ = "0.14.1.0"
 
-SUPPORTED_SCHEMA = (0, 14, 0)
+SUPPORTED_SCHEMA = (0, 14, 1)

--- a/lint/ktw_lint/config.py
+++ b/lint/ktw_lint/config.py
@@ -6,7 +6,7 @@ The config format is a delimited block of `- key: value` lines:
     - id: acme---widget-service
     - context: `context/`
     - init: complete
-    - context-schema: 0.14.0
+    - context-schema: 0.14.1
     - capture-confirmation: confirm-when-unsure
     - source-reference: never
     <!-- /keep-the-why:config -->

--- a/llms.txt
+++ b/llms.txt
@@ -39,7 +39,7 @@ get thrown away, not creating separate documentation effort. It isn't magic, tho
 prevents knowledge from decaying on its own. This lowers the friction of the discipline that
 keeps documentation honest; it doesn't replace it.
 
-Version: 0.14.0.
+Version: 0.14.1.
 
 ## Authorship & License
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "keep-the-why",
   "description": "Preserves the reasoning behind a codebase as project memory — decisions, rejected alternatives, workarounds, incident learnings, constraints the code alone can't explain — kept in the repo as Markdown, versioned and shared by Git.",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "author": {
     "name": "Oliver Zehentleitner"
   },

--- a/skills/keep-the-why/SKILL.md
+++ b/skills/keep-the-why/SKILL.md
@@ -3,7 +3,7 @@ name: keep-the-why
 description: Extract and preserve the reasoning code cannot explain - decisions, rejected alternatives, workarounds, incidents, constraints - plus project setup and maintainer interviews. Not for what changed (see Keep a Changelog) - only why.
 license: MIT
 metadata:
-  version: "0.14.0"
+  version: "0.14.1"
   repository: "https://github.com/oliver-zehentleitner/keep-the-why"
   author: "Oliver Zehentleitner"
 ---

--- a/skills/keep-the-why/examples/first-time-setup.md
+++ b/skills/keep-the-why/examples/first-time-setup.md
@@ -113,7 +113,7 @@ This names the skill and its purpose directly — not a task that happens to mat
     - id: acme---widget-service
     - context: `context/`
     - init: complete
-    - context-schema: 0.14.0
+    - context-schema: 0.14.1
     - capture-confirmation: confirm-when-unsure
     - source-reference: never
     <!-- /keep-the-why:config -->

--- a/skills/keep-the-why/references/setup.md
+++ b/skills/keep-the-why/references/setup.md
@@ -17,7 +17,7 @@ README, for what Keep the Why actually is.
 - id: oliver-zehentleitner---keep-the-why
 - context: `context/`
 - init: complete
-- context-schema: 0.14.0
+- context-schema: 0.14.1
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->

--- a/skills/keep-the-why/references/specification.md
+++ b/skills/keep-the-why/references/specification.md
@@ -67,7 +67,7 @@ README, for what Keep the Why actually is.
 - id: acme---widget-service
 - context: `context/`
 - init: complete
-- context-schema: 0.14.0
+- context-schema: 0.14.1
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->


### PR DESCRIPTION
Release-checklist steps 1–8 for the patch release that carries #324 (the three local-linting sentences) to `latest`.

1–3. `metadata.version`, `llms.txt`, both `plugin.json` → 0.14.1
4. Linter → `0.14.1.0`, `SUPPORTED_SCHEMA` (0, 14, 1), no new gate; CHANGELOG linter line.
5. `[Unreleased]` → `[0.14.1] - 2026-09-08` (the two Fixed entries from #324/#325), fresh empty `[Unreleased]`, compare links.
6. `migrations.md`: nothing to add — no format, placement or config change; the fix is skill text an existing project gets by updating.
7. This repo's `context-schema` → 0.14.1.
8. Illustrative `context-schema` values → 0.14.1.

Local checks: version consistency across the seven files, linter tests OK, evals tests OK, Black clean, dogfood lint `--strict --setup` clean at 0.14.1.

After merge: publish-lint, pip resolution, tag `v0.14.1`, link-check rerun, awesome-copilot bump, three full eval runs with the pipx fence in place.