### PR TITLE
Docs: publish context/lint.md and context/evals.md under 'Why this project is built this way'

### DIFF
--- a/context/positioning.md
+++ b/context/positioning.md
@@ -30,6 +30,17 @@ README's and `llms.txt`'s "Related work" don't compare Keep the Why against spec
 
 **Rejected alternative:** a raw `index.html` in `docs/`. Full layout freedom, but it would have to rebuild the header, search, palette toggle and footer itself, and the include mechanism wouldn't reach into it — the facts would be typed in by hand. Also rejected: a custom Jinja page template (`template:` front matter) — real HTML inside the site chrome, but a second place where layout lives, for a gain (a wider column) the page doesn't need.
 
+## The project's own `context/` is published on the site through one-line include stubs
+
+**Type:** decision
+**Status:** active
+**Evidence:** confirmed
+**Source:** how the "Why this project is built this way" nav section has been built since the site exists; the gap noted by Oliver on 2026-09-08 ("are all context files under 'Why this project is built this way'?" — they weren't)
+
+Every topic file in `context/` gets a stub at `docs/context/<name>.md` holding a single `include-markdown` line, and a line in the nav section "Why this project is built this way" in `mkdocs.yml`. The stub is the only way a `context/` file reaches the site — MkDocs only builds what lives under `docs/`, and copying the file would create a second place to edit.
+
+**Consequence:** a new topic file is not on the site until someone adds its stub and nav line; nothing checks this. `lint.md` (2026-09-02) and `evals.md` (2026-09-05) were both missed for days and added on 2026-09-08. When adding a topic file, add the stub and the nav line in the same change.
+
 ## The format has a normative specification file, separate from the guidance that shows it in use
 
 **Type:** decision

--- a/docs/context/evals.md
+++ b/docs/context/evals.md
@@ -1,0 +1,1 @@
+{% include-markdown "../../context/evals.md" %}

--- a/docs/context/lint.md
+++ b/docs/context/lint.md
@@ -1,0 +1,1 @@
+{% include-markdown "../../context/lint.md" %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,3 +87,5 @@ nav:
       - Entry and layout format: context/entry-format.md
       - Positioning: context/positioning.md
       - Compatibility: context/compatibility.md
+      - Linter: context/lint.md
+      - Eval runner and suite: context/evals.md


### PR DESCRIPTION
Oliver asked on 2026-09-08 whether every context/ topic file is listed under the site's *Why this project is built this way* section. Two were missing:

- `context/lint.md` (7 entries, since 2026-09-02) and `context/evals.md` (4 entries, since 2026-09-05) had neither a `docs/context/` include stub nor a nav line.

This adds both stubs and nav lines, and records the stub mechanism plus the miss in `context/positioning.md` so the next topic file brings its stub along.

Verified with a local `mkdocs build`: both pages render with all entries.