### PR TITLE
Prepare 0.15.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "keep-the-why",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "Preserves the reasoning behind a codebase as project memory — decisions, rejected alternatives, workarounds, incident learnings, constraints the code alone can't explain — kept in the repo as Markdown, versioned and shared by Git.",
   "author": {
     "name": "Oliver Zehentleitner",

--- a/.keep-the-why
+++ b/.keep-the-why
@@ -6,7 +6,7 @@ README, for what Keep the Why actually is.
 - id: oliver-zehentleitner---keep-the-why
 - context: `context/`
 - init: complete
-- context-schema: 0.14.1
+- context-schema: 0.15.0
 - capture-confirmation: confirm-always
 - source-reference: never
 <!-- /keep-the-why:config -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-09-08
+
 ### Changed
 
 - The wizard defaults are the fully integrated setup, and a wizard is one list. Three defaults change, for new setups only: `confirmation-flow` proposes `batch` — each wizard is one message with every question and its default filled in, closed by "set it up like this, or change anything?", so a first setup is two answers, not a dozen, and `sequential` is chosen rather than assumed; `local-lint` proposes `auto` — the question names the install, so the answer, "defaults" included, is the go-ahead and a default setup installs the linter in the same turn; and the activation question defaults to *the project asks* — the "Keep the Why" section in the entry-point file, plus the project-scoped hook where `autostart.md` has a verified example for the current platform. The maintainer's line: the skill should work as automatically as it can, that is when it works best, and whoever wants less takes care of that. Deliberately unchanged: `capture-confirmation` stays `confirm-when-unsure`, `pending-confirmation-check` stays `no`, no `personal-defaults` block unless asked for. Existing files keep their values, and the absent-field rules stand — `confirmation-flow` absent is asked once, `local-lint` absent is `ask`, never `auto` (a skill update never installs a package on an existing machine on its own); the spec's Default column now says both. Both wizards and the "Both wizards" paragraph in `setup.md`, step 0 in `SKILL.md`, the field table in `specification.md`, a 0.15.0 `migrations.md` entry (informational), `docs/security.md` ("the wizard's answer is the yes"), README and `llms.txt`, the first-time-setup example rewritten as two lists with the section and hook written in step 7, the decision in `context/config-format.md`. Evals: `wizard-bundling-is-not-the-silent-default` replaced by `wizard-defaults-one-list-per-wizard` (two lists, project first, nothing written before the answer, never one merged list); `init-wizard-first-activation` and `negative-existing-good-structure-untouched` expect one list per wizard; `confirmation-flow-missing-field-asks-once` names `batch` as the default it must not backfill.
+- `keep-the-why-lint` 0.15.0.0: knows schema 0.15.0 — no new gate, nothing changes what `context/` or `.keep-the-why` must look like. Published before the skill tag, per the checklist.
 
 ## [0.14.1] - 2026-09-08
 
@@ -611,7 +614,8 @@ Initial release.
 - Logo, wordmark, and favicon.
 - `context/repo-conventions.md`, dogfooding the skill on its own repository from day one.
 
-[Unreleased]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.14.1...HEAD
+[Unreleased]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.15.0...HEAD
+[0.15.0]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.14.1...v0.15.0
 [0.14.1]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.13.3...v0.14.0
 [0.13.3]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.13.2...v0.13.3

--- a/lint/ktw_lint/__init__.py
+++ b/lint/ktw_lint/__init__.py
@@ -13,6 +13,6 @@ changes. PEP 440, not strict SemVer — PyPI rejects the SemVer build-
 metadata spelling this would otherwise use.
 """
 
-__version__ = "0.14.1.0"
+__version__ = "0.15.0.0"
 
-SUPPORTED_SCHEMA = (0, 14, 1)
+SUPPORTED_SCHEMA = (0, 15, 0)

--- a/lint/ktw_lint/config.py
+++ b/lint/ktw_lint/config.py
@@ -6,7 +6,7 @@ The config format is a delimited block of `- key: value` lines:
     - id: acme---widget-service
     - context: `context/`
     - init: complete
-    - context-schema: 0.14.1
+    - context-schema: 0.15.0
     - capture-confirmation: confirm-when-unsure
     - source-reference: never
     <!-- /keep-the-why:config -->

--- a/llms.txt
+++ b/llms.txt
@@ -39,7 +39,7 @@ get thrown away, not creating separate documentation effort. It isn't magic, tho
 prevents knowledge from decaying on its own. This lowers the friction of the discipline that
 keeps documentation honest; it doesn't replace it.
 
-Version: 0.14.1.
+Version: 0.15.0.
 
 ## Authorship & License
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "keep-the-why",
   "description": "Preserves the reasoning behind a codebase as project memory — decisions, rejected alternatives, workarounds, incident learnings, constraints the code alone can't explain — kept in the repo as Markdown, versioned and shared by Git.",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "author": {
     "name": "Oliver Zehentleitner"
   },

--- a/skills/keep-the-why/SKILL.md
+++ b/skills/keep-the-why/SKILL.md
@@ -3,7 +3,7 @@ name: keep-the-why
 description: Extract and preserve the reasoning code cannot explain - decisions, rejected alternatives, workarounds, incidents, constraints - plus project setup and maintainer interviews. Not for what changed (see Keep a Changelog) - only why.
 license: MIT
 metadata:
-  version: "0.14.1"
+  version: "0.15.0"
   repository: "https://github.com/oliver-zehentleitner/keep-the-why"
   author: "Oliver Zehentleitner"
 ---

--- a/skills/keep-the-why/examples/first-time-setup.md
+++ b/skills/keep-the-why/examples/first-time-setup.md
@@ -96,7 +96,7 @@ This names the skill and its purpose directly — not a task that happens to mat
     - id: acme---widget-service
     - context: `context/`
     - init: complete
-    - context-schema: 0.14.1
+    - context-schema: 0.15.0
     - capture-confirmation: confirm-when-unsure
     - source-reference: never
     <!-- /keep-the-why:config -->

--- a/skills/keep-the-why/references/setup.md
+++ b/skills/keep-the-why/references/setup.md
@@ -17,7 +17,7 @@ README, for what Keep the Why actually is.
 - id: oliver-zehentleitner---keep-the-why
 - context: `context/`
 - init: complete
-- context-schema: 0.14.1
+- context-schema: 0.15.0
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->

--- a/skills/keep-the-why/references/specification.md
+++ b/skills/keep-the-why/references/specification.md
@@ -67,7 +67,7 @@ README, for what Keep the Why actually is.
 - id: acme---widget-service
 - context: `context/`
 - init: complete
-- context-schema: 0.14.1
+- context-schema: 0.15.0
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->


### PR DESCRIPTION
Release-checklist steps 1–8 for the release that carries #330 (wizard defaults: batch, local-lint auto, the project asks) to `latest`.

1–3. `metadata.version`, `llms.txt`, both `plugin.json` → 0.15.0
4. Linter → `0.15.0.0`, `SUPPORTED_SCHEMA` (0, 15, 0), no new gate — no field, value set or placement changed; CHANGELOG linter line.
5. `[Unreleased]` → `[0.15.0] - 2026-09-08`, fresh empty `[Unreleased]`, compare links.
6. `migrations.md` has the 0.15.0 entry (informational — new setups only, absent-field rules unchanged).
7. This repo's `context-schema` → 0.15.0.
8. Illustrative `context-schema` values → 0.15.0.

Local checks: version consistency across the seven files, linter tests OK, evals tests OK, Black clean, dogfood lint `--strict --setup` clean at 0.15.0.

After merge: publish-lint, pip resolution, tag `v0.15.0`, link-check rerun, awesome-copilot bump. The three-run measurement is held back on the maintainer's call.