### PR TITLE
Landing page: a fourth card, Use — How it works as a 2x2 grid

### DIFF
--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -85,8 +85,11 @@
 }
 .ktw-cards {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 1rem;
+}
+.ktw-cards--not {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 .ktw-card {
   border: 1px solid var(--ktw-border);

--- a/docs/index.md
+++ b/docs/index.md
@@ -95,6 +95,16 @@ Everything lives in `context/`, one file per topic, versioned with the code. A l
 
 </div>
 
+<div class="ktw-card" markdown>
+
+### Use
+
+The next session — yours, a colleague's, an agent's — loads the index first and reads the why before touching the code. An agent that finds the reason explains it and builds on it instead of repeating the attempt; one that finds nothing says so and asks, instead of guessing. That is what the capture was for.
+
+[Autostart →](autostart.md) · [Agent matrix →](agent-matrix.md) · [Trust model →](trust-model.md)
+
+</div>
+
 </div>
 
 </div>


### PR DESCRIPTION
Maintainer's point: "How it works" ended at Keep & Share and the payoff was a subordinate clause. Fourth card:

> **Use** — The next session — yours, a colleague's, an agent's — loads the index first and reads the why before touching the code. An agent that finds the reason explains it and builds on it instead of repeating the attempt; one that finds nothing says so and asks, instead of guessing. That is what the capture was for.
>
> Autostart → · Agent matrix → · Trust model →

Autostart because Use only happens when the skill is loaded in the next session; the matrix shows which agents demonstrably do that.

CSS: `.ktw-cards` goes to two columns (2×2 for the four steps); the "What this is not" row keeps its three via the existing `.ktw-cards--not` modifier; mobile stays one column. No mkdocs on this host, so the render is verified by the docs workflow on the PR.