### PR TITLE
Landing page: the Use card links to Installation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -101,7 +101,7 @@ Everything lives in `context/`, one file per topic, versioned with the code. A l
 
 The next session — yours, a colleague's, an agent's — loads the index first and reads the why before touching the code. An agent that finds the reason explains it and builds on it instead of repeating the attempt; one that finds nothing says so and asks, instead of guessing. That is what the capture was for.
 
-[Autostart →](autostart.md) · [Agent matrix →](agent-matrix.md) · [Trust model →](trust-model.md)
+[Install →](installation.md) · [Autostart →](autostart.md) · [Agent matrix →](agent-matrix.md) · [Trust model →](trust-model.md)
 
 </div>
 


### PR DESCRIPTION
Maintainer request: the Use card's link row starts with Install → (installation.md), before Autostart, Agent matrix and Trust model.