### PR TITLE
experiments/rejected-change: the experiment behind the rejected-change article

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+### Added
+
+- `experiments/rejected-change/`: the experiment behind the article *What happens when a coding agent forgets why a change was rejected?* — 10 control and 10 treatment sessions on the `abandoned-change-still-captured` fixture, identical except for `context/retries.md`, same prompt ("simplify this retry wrapper"), Claude Code 2.1.263 with Sonnet 5, built and isolated like the published evals. Runner (`run.py`, reuses `tools/evals`), design note (`README.md`, written before the run), and every session's transcript, disk diff, hand grade and metadata under `results/`, with the numbers and their reading in `results/SUMMARY.md`: no control session broke the wrapper, seven of ten offered the rejected simplification as an option, all ten treatment sessions cited the entry and declined. Published so the article's numbers can be checked instead of taken on faith; the link in the article points here.
+
 ## [0.15.0] - 2026-09-08
 
 ### Changed

--- a/experiments/rejected-change/README.md
+++ b/experiments/rejected-change/README.md
@@ -1,0 +1,89 @@
+# Experiment: does a fresh agent session repeat a rejected change?
+
+The experiment behind [What happens when a coding agent forgets why a change
+was rejected?](https://blog.technopathy.club/what-happens-when-a-coding-agent-forgets-why-a-change-was-rejected)
+(2026-09-08). Run on 2026-09-08: 10 control + 10 treatment sessions, Claude
+Code 2.1.263, Claude Sonnet 5. The numbers, the reading and what it is not:
+[`results/SUMMARY.md`](results/SUMMARY.md). Every session's transcript, disk
+diff, hand grade and metadata: `results/<arm>/<n>/`. The design below was
+written before the run and is left as written.
+
+Do not run this while a full eval series is in progress on the same host
+(shared Claude Code session quota).
+
+## Question
+
+A change was considered and rejected for a reason that never produced a diff.
+A later, fresh session gets the same instinct. Does it repeat the attempt?
+And does a `context/` entry written by Keep the Why change that outcome?
+
+## Setup
+
+Fixture: the eval fixture `_base` overlaid with
+`abandoned-change-still-captured` from the keep-the-why repo
+(`tools/evals/fixtures/`). It contains `src/gateway.py` with
+`retry_with_jitter`, a wrapper that reads a `Retry-After` header on 429 and
+does exponential backoff with jitter. The code shows *that* it reads
+`Retry-After`. It does not show that the limiter's value varies per request,
+or that a plain loop was already tried and rejected.
+
+Two arms, identical except for one file:
+
+- **Control:** no `context/retries.md`. `context/` exists (the fixture has
+  `architecture.md` and `index.md`) but records nothing about retries.
+- **Treatment:** `context/retries.md` contains the entry from
+  `skills/keep-the-why/examples/abandoned-change.md` ("Why retry_with_jitter
+  isn't a plain retry loop", Type constraint, Status active, Evidence
+  confirmed), and `context/index.md` lists it.
+
+Both arms are opted in (`.keep-the-why` present, AGENTS.md section present),
+so the skill loads in both. The only difference is whether the rationale is on
+disk.
+
+Prompt, identical in both arms, taken from the README example:
+
+> This retry wrapper in src/gateway.py looks over-engineered — a plain retry
+> loop would do the same thing. Simplify it.
+
+Runs: 10 per arm, fresh session each, Claude Code with Sonnet 5 as in the
+published evals, `--permission-mode acceptEdits` so the agent can actually
+edit. `TMPDIR=/var/tmp`, fixture copied to a fresh directory per run so no
+state leaks between runs.
+
+## What is measured per run
+
+Three yes/no outcomes, read from the transcript and `git diff` after the run:
+
+1. **Changed the wrapper.** `src/gateway.py` differs from the fixture in a way
+   that removes or weakens the `Retry-After` handling, the backoff, or the
+   jitter. Cosmetic edits that keep all three do not count.
+2. **Surfaced the constraint before editing.** The transcript names the
+   `Retry-After` / rate limiter behavior as a reason to keep the wrapper
+   (or to keep that part) *before* any edit.
+3. **Cited the recorded rationale.** Treatment arm only: the transcript
+   references `context/retries.md` or quotes its content.
+
+Grading is by hand from transcripts, not by an LLM judge. 20 transcripts is a
+size one person can read. Publish the raw transcripts alongside the article.
+
+## Expected shape of the result (written before the run — the data is in `results/SUMMARY.md`)
+
+- Control: the code partially explains itself, so a careful agent may keep the
+  `Retry-After` branch even without context. The interesting number is how
+  often it strips backoff or jitter, or proposes the plain loop anyway.
+- Treatment: expected to push back and cite the entry in most runs. Any run
+  that edits despite the entry is an honest finding and goes in the article.
+
+If the control arm keeps the wrapper in most runs, that is also a finding:
+then the argument in the article shifts from "the agent will break it" to
+"the agent had to re-derive it, and would have missed anything the code does
+not show". Write the article to survive either outcome.
+
+## Running
+
+`python3 experiments/rejected-change/run.py [--n 10] [--model sonnet] [--arm control|treatment]`
+from the repository root, with the Claude Code CLI on `PATH` and its
+credentials — it reuses `tools/evals`' fixture, fake-`$HOME` and driver code.
+It writes `results/<arm>/<n>/` with `transcript.txt`, `diff.txt`, `meta.json`
+and `outcome.md` (an empty template for the hand grade), and skips a run whose
+transcript already exists, so a series can be resumed.

--- a/experiments/rejected-change/results/SUMMARY.md
+++ b/experiments/rejected-change/results/SUMMARY.md
@@ -1,0 +1,50 @@
+# Results — rejected-change experiment (2026-09-08)
+
+20 fresh Claude Code sessions (CLI 2.1.263, Claude Sonnet 5), 10 per arm, on the
+keep-the-why eval fixture, built and isolated exactly like the published evals
+(fake $HOME, skill installed project-scoped, TMPDIR outside $HOME). Prompt in
+both arms: *"This retry wrapper in src/gateway.py looks over-engineered — a plain
+retry loop would do the same thing. Simplify it."* The skill loaded in 20/20
+sessions (SessionStart hook). No errors, no timeouts. Grades are by hand from
+the transcripts; the automated flags in meta.json agree with them.
+
+| | Control (no rationale on disk) | Treatment (`context/retries.md` present) |
+|---|---:|---:|
+| Edited the wrapper | 3/10 | 0/10 |
+| Removed Retry-After, backoff or jitter | 0/10 | 0/10 |
+| Named the rate-limiter constraint before or instead of editing | 10/10 | 10/10 |
+| Asked before touching the code | 7/10 | 0/10 (declined outright) |
+| Offered "drop Retry-After" as a selectable option | 7/10 | 0/10 |
+| Said explicitly that nothing on disk explains the wrapper | 8/10 | n/a |
+| Knew the simplification had already been considered and rejected | 0/10 | 10/10 |
+| Cited `context/retries.md` | n/a | 10/10 |
+| Offered to write a context/ entry afterwards | 3/10 | n/a |
+| Session wall time, median (min–max) | 43s (28–70s) | 18s (14–28s) |
+
+## Reading
+
+- **No control session broke the wrapper.** The code visibly reads `Retry-After`,
+  and every session found that branch and called it load-bearing. The three that
+  edited (1, 8, 9) merged the two backoff branches and kept all behavior.
+- **Every control session re-derived the reasoning from scratch**, took roughly
+  2.5x as long doing it, and eight of ten said in so many words that nothing in
+  the repository explains the wrapper (initial commit only, no `context/` entry),
+  so they could not tell deliberate design from accretion.
+- **Seven of ten control sessions put "drop Retry-After" on the menu** as option
+  (b), framed as a behavior change the user may want. A user who picks (b) gets
+  the rejected change. The agent had no way to say "that was tried".
+- **All ten treatment sessions declined the simplification**, cited the entry,
+  and stated that this exact change had already been considered and rejected.
+  Six offered a narrower, behavior-preserving dedup instead; none offered to
+  drop `Retry-After` as an equal option.
+- Three control sessions offered to write the missing entry after the fact —
+  the capture side of the skill working as designed, and the reason the
+  treatment file exists in the first place.
+
+## What this is not
+
+Twenty runs, one function, one model. It measures one mechanism — whether a
+recorded rejected decision changes what the next session does — not whether an
+agent would find the constraint in a larger codebase, and not session memory.
+
+Per-run transcripts, diffs and grades: `control/<n>/`, `treatment/<n>/`.

--- a/experiments/rejected-change/results/control/1/diff.txt
+++ b/experiments/rejected-change/results/control/1/diff.txt
@@ -1,0 +1,43 @@
+# git status --porcelain
+ M src/gateway.py
+
+
+# git diff (tracked files)
+diff --git a/src/gateway.py b/src/gateway.py
+index bedc830..85ede91 100644
+--- a/src/gateway.py
++++ b/src/gateway.py
+@@ -9,19 +9,15 @@ GATEWAY_URL = "https://gateway.example.com/v2/orders"
+ 
+ 
+ def retry_with_jitter(request_fn, max_attempts=6):
+-    """Retry wrapper for gateway calls. Looks heavier than a plain loop."""
++    """Retry wrapper for gateway calls."""
+     delay = 0.5
+     for attempt in range(max_attempts):
+         response = request_fn()
+-        if response.status_code == 429:
+-            retry_after = response.headers.get("Retry-After")
+-            wait = float(retry_after) if retry_after else delay
+-            time.sleep(wait + random.random() * 0.3)
+-            delay = min(delay * 2, 30)
+-            continue
+-        if response.status_code < 500:
++        if response.status_code < 500 and response.status_code != 429:
+             return response
+-        time.sleep(delay + random.random() * 0.3)
++        retry_after = response.headers.get("Retry-After") if response.status_code == 429 else None
++        wait = float(retry_after) if retry_after else delay
++        time.sleep(wait + random.random() * 0.3)
+         delay = min(delay * 2, 30)
+     return response
+ 
+
+
+# ~/.keep-the-why/ktw-eval-fixture---order-service.md (personal config, outside the project; SEEDED BY THE FIXTURE BEFORE THE RUN, UNCHANGED — the agent did not write this)
+<!-- keep-the-why:personal -->
+- capture-mode: proactive
+- confirmation-flow: sequential
+- update-check: no
+- consistency-check: no
+<!-- /keep-the-why:personal -->

--- a/experiments/rejected-change/results/control/1/meta.json
+++ b/experiments/rejected-change/results/control/1/meta.json
@@ -1,0 +1,10 @@
+{
+ "arm": "control",
+ "i": 1,
+ "model": "sonnet",
+ "seconds": 70,
+ "error": null,
+ "gateway_changed": true,
+ "retry_after_kept": true,
+ "mentions_context_retries": false
+}

--- a/experiments/rejected-change/results/control/1/outcome.md
+++ b/experiments/rejected-change/results/control/1/outcome.md
@@ -1,0 +1,8 @@
+changed: yes
+broke: no
+named: yes
+asked: no
+offered_drop: no
+no_record: yes
+offered_entry: yes
+notes: edited without asking: merged the two branches, kept Retry-After/backoff/jitter; then offered a context/ entry

--- a/experiments/rejected-change/results/control/1/transcript.txt
+++ b/experiments/rejected-change/results/control/1/transcript.txt
@@ -1,0 +1,99 @@
+[tool call] Skill: {"skill": "keep-the-why"}
+
+[tool result] Launching skill: keep-the-why
+
+[tool call] Bash: {"command": "cat /var/tmp/ktw-exp-control-1-xi6otps4/project/.keep-the-why 2>/dev/null; echo \"---\"; ls -la ~/.keep-the-why/ 2>/dev/null; echo \"---\"; cat /var/tmp/ktw-exp-control-1-xi6otps4/project/context/index.md 2>/dev/null"}
+
+[tool result] This is machine-readable project state for the Keep the Why skill
+(https://keepthewhy.com). See context/index.md, or this project's own
+README, for what Keep the Why actually is.
+
+<!-- keep-the-why:config -->
+- id: ktw-eval-fixture---order-service
+- context: `context/`
+- init: complete
+- context-schema: 0.14.0
+- capture-confirmation: confirm-when-unsure
+- source-reference: never
+<!-- /keep-the-why…(truncated)
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-control-1-xi6otps4/home/.claude/../../home/.keep-the-why/ktw-eval-fixture---order-service.md"}
+
+[tool result] 1	<!-- keep-the-why:personal -->
+2	- capture-mode: proactive
+3	- confirmation-flow: sequential
+4	- update-check: no
+5	- consistency-check: no
+6	<!-- /keep-the-why:personal -->
+7	
+
+[tool call] Bash: {"command": "find /var/tmp/ktw-exp-control-1-xi6otps4/project -maxdepth 2 -type d; echo ---; cat /var/tmp/ktw-exp-control-1-xi6otps4/project/context/architecture.md 2>/dev/null"}
+
+[tool result] /var/tmp/ktw-exp-control-1-xi6otps4/project
+/var/tmp/ktw-exp-control-1-xi6otps4/project/.git
+/var/tmp/ktw-exp-control-1-xi6otps4/project/context
+/var/tmp/ktw-exp-control-1-xi6otps4/project/docs
+/var/tmp/ktw-exp-control-1-xi6otps4/project/.claude
+/var/tmp/ktw-exp-control-1-xi6otps4/project/src
+/var/tmp/ktw-exp-control-1-xi6otps4/project/.git/refs
+/var/tmp/ktw-exp-control-1-xi6otps4/project/.git/bra…(truncated)
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-control-1-xi6otps4/project/src/gateway.py"}
+
+[tool result] 1	"""Payment gateway client."""
+2	
+3	import random
+4	import time
+5	
+6	import requests
+7	
+8	GATEWAY_URL = "https://gateway.example.com/v2/orders"
+9	
+10	
+11	def retry_with_jitter(request_fn, max_attempts=6):
+12	    """Retry wrapper for gateway calls. Looks heavier than a plain loop."""
+13	    delay = 0.5
+14	    for attempt in range(max_attempts):
+15	        response = request_fn()
+16	        if resp…(truncated)
+
+[tool call] Bash: {"command": "git log --oneline --all -- src/gateway.py; echo ---; git log -p -- src/gateway.py | head -200; echo ---; grep -ril \"retry\\|gateway\\|429\\|jitter\" context/ docs/ 2>/dev/null"}
+
+[tool result] 294636a Initial commit
+---
+commit 294636aa6d77c849199686eeb4e5a4c9ed529e5a
+Author: Eval Fixture <fixture@example.com>
+Date:   Tue Sep 8 13:24:43 2026 +0200
+
+    Initial commit
+
+diff --git a/src/gateway.py b/src/gateway.py
+new file mode 100644
+index 0000000..bedc830
+--- /dev/null
++++ b/src/gateway.py
+@@ -0,0 +1,35 @@
++"""Payment gateway client."""
++
++import random
++import time
++
++import requests
++
+…(truncated)
+
+[assistant]
+The 429 and 5xx branches aren't actually duplicating each other for no reason — the 429 path honors the gateway's `Retry-After` header when present, falling back to the exponential backoff only when the server doesn't specify a wait. That's a real behavioral difference (payment gateways commonly rate-limit harder if you ignore their `Retry-After`), not just padding. A truly "plain" loop that collapses both cases into one generic backoff would silently drop that.
+
+I'll simplify the structure but keep that distinction intact:
+
+[tool call] Edit: {"replace_all": false, "file_path": "/var/tmp/ktw-exp-control-1-xi6otps4/project/src/gateway.py", "old_string": "def retry_with_jitter(request_fn, max_attempts=6):\n    \"\"\"Retry wrapper for gateway calls. Looks heavier than a plain loop.\"\"\"\n    delay = 0.5\n    for attempt in range(max_attempts):\n        response = request_fn()\n        if response.status_code == 429:\n            retry_after = response.headers.get(\"Retry-After\")\n            wait = float(retry_after) if retry_after else delay\n            time.sleep(wait + random.random() * 0.3)\n            delay = min(delay * 2, 30)\n            continue\n        if response.status_code < 500:\n            return response\n        time.sleep(delay + random.random() * 0.3)\n        delay = min(delay * 2, 30)\n    return response", "new_string": "def retry_with_jitter(request_fn, max_attempts=6):\n    \"\"\"Retry wrapper for gateway calls.\"\"\"\n    delay = 0.5\n    for attempt in range(max_attempts):\n        response = request_fn()\n        if response.status_code < 500 and response.status_code != 429:\n            return response\n        retry_after = response.headers.get(\"Retry-After\") if response.status_code == 429 else None\n        wait = float(retry_after) if retry_after else delay\n        time.sleep(wait + random.random() * 0.3)\n        delay = min(delay * 2, 30)\n    return response"}
+
+[tool result] The file /var/tmp/ktw-exp-control-1-xi6otps4/project/src/gateway.py has been updated successfully. (file state is current in your context — no need to Read it back)
+
+[assistant]
+Simplified into a single loop — same behavior, no duplicated sleep/backoff logic. Nothing here explains *why* it honors `Retry-After` specifically, though, so a future pass could easily "clean up" the distinction away entirely.
+
+Worth adding a short `context/` note on that (honor gateway's `Retry-After` on 429, exponential backoff otherwise — dropping it risks harsher throttling from the gateway), or skip it?
+
+[session ended] subtype=success turns=9

--- a/experiments/rejected-change/results/control/10/diff.txt
+++ b/experiments/rejected-change/results/control/10/diff.txt
@@ -1,0 +1,10 @@
+# git status --porcelain
+(clean)
+
+# ~/.keep-the-why/ktw-eval-fixture---order-service.md (personal config, outside the project; SEEDED BY THE FIXTURE BEFORE THE RUN, UNCHANGED — the agent did not write this)
+<!-- keep-the-why:personal -->
+- capture-mode: proactive
+- confirmation-flow: sequential
+- update-check: no
+- consistency-check: no
+<!-- /keep-the-why:personal -->

--- a/experiments/rejected-change/results/control/10/meta.json
+++ b/experiments/rejected-change/results/control/10/meta.json
@@ -1,0 +1,10 @@
+{
+ "arm": "control",
+ "i": 10,
+ "model": "sonnet",
+ "seconds": 28,
+ "error": null,
+ "gateway_changed": false,
+ "retry_after_kept": true,
+ "mentions_context_retries": false
+}

--- a/experiments/rejected-change/results/control/10/outcome.md
+++ b/experiments/rejected-change/results/control/10/outcome.md
@@ -1,0 +1,8 @@
+changed: no
+broke: no
+named: yes
+asked: yes
+offered_drop: yes
+no_record: yes
+offered_entry: no
+notes: asked: tidy vs. collapse to uniform loop (would drop Retry-After compliance)

--- a/experiments/rejected-change/results/control/10/transcript.txt
+++ b/experiments/rejected-change/results/control/10/transcript.txt
@@ -1,0 +1,90 @@
+[tool call] Skill: {"skill": "keep-the-why"}
+
+[tool result] Launching skill: keep-the-why
+
+[tool call] Bash: {"command": "echo \"--- .keep-the-why ---\" && cat .keep-the-why 2>/dev/null; echo \"--- ~/.keep-the-why dir ---\" && ls -la ~/.keep-the-why 2>/dev/null; echo \"--- context dir ---\" && ls -la context 2>/dev/null; echo \"--- index.md ---\" && cat context/index.md 2>/dev/null"}
+
+[tool result] --- .keep-the-why ---
+This is machine-readable project state for the Keep the Why skill
+(https://keepthewhy.com). See context/index.md, or this project's own
+README, for what Keep the Why actually is.
+
+<!-- keep-the-why:config -->
+- id: ktw-eval-fixture---order-service
+- context: `context/`
+- init: complete
+- context-schema: 0.14.0
+- capture-confirmation: confirm-when-unsure
+- source-reference: ne…(truncated)
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-control-10-mkfbu3vl/project/src/gateway.py"}
+
+[tool result] 1	"""Payment gateway client."""
+2	
+3	import random
+4	import time
+5	
+6	import requests
+7	
+8	GATEWAY_URL = "https://gateway.example.com/v2/orders"
+9	
+10	
+11	def retry_with_jitter(request_fn, max_attempts=6):
+12	    """Retry wrapper for gateway calls. Looks heavier than a plain loop."""
+13	    delay = 0.5
+14	    for attempt in range(max_attempts):
+15	        response = request_fn()
+16	        if resp…(truncated)
+
+[tool call] Bash: {"command": "cat ~/.keep-the-why/ktw-eval-fixture---order-service.md; echo \"--- git log for gateway.py ---\"; git log --follow -p -- src/gateway.py | head -200"}
+
+[tool result] <!-- keep-the-why:personal -->
+- capture-mode: proactive
+- confirmation-flow: sequential
+- update-check: no
+- consistency-check: no
+<!-- /keep-the-why:personal -->
+--- git log for gateway.py ---
+commit cd4b99b422572c59879af43afe1d986d0637985c
+Author: Eval Fixture <fixture@example.com>
+Date:   Tue Sep 8 13:32:25 2026 +0200
+
+    Initial commit
+
+diff --git a/src/gateway.py b/src/gateway.py
+new file m…(truncated)
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-control-10-mkfbu3vl/project/context/architecture.md"}
+
+[tool result] 1	# Architecture
+2	
+3	## Single service, no queue between intake and gateway submission
+4	
+5	**Status:** active
+6	**Evidence:** confirmed
+7	**Source:** design discussion, 2026-05
+8	
+9	Orders are submitted to the payment gateway synchronously from the intake
+10	handler instead of going through a message queue.
+11	
+12	**Reason:** volume is low (hundreds per day), and a queue would add
+13	operational…(truncated)
+
+[assistant]
+Before simplifying, I want to flag what this "over-engineered" code is actually doing — it's not padding, it's three distinct behaviors baked into one loop:
+
+1. **429 (rate limited)** → honors the server's `Retry-After` header if present, otherwise falls back to the backoff delay.
+2. **Other 4xx (`< 500` non-429)** → returns immediately, no retry (these are treated as non-retryable client errors, e.g. bad request/auth).
+3. **5xx** → exponential backoff with jitter, capped at 30s.
+
+A "plain retry loop" would typically treat all failures the same way, which would either (a) start retrying on non-retryable 4xx errors like validation failures, or (b) ignore the gateway's `Retry-After` hint and hammer it on its own schedule during rate-limiting — both are meaningful behavior changes, not just style.
+
+There's no commit history or `context/` entry explaining this (this is the initial commit, so I can't trace back the original author's reasoning), and the docstring's own "looks heavier than a plain loop" comment reads like a deliberate flag rather than an oversight.
+
+Two ways I could go:
+- **Keep all three behaviors, just tidy the code** (e.g. small naming/structure cleanup) — no functional change.
+- **Actually collapse it to a uniform retry loop** — this would drop `Retry-After` compliance and start retrying non-retryable errors, which could cause real problems against a real gateway (rate-limit bans, retrying invalid orders).
+
+Which did you mean? If it's the latter, I'll also want to double check with you whether dropping `Retry-After` handling is intentional before I write it that way.
+
+[session ended] subtype=success turns=7

--- a/experiments/rejected-change/results/control/2/diff.txt
+++ b/experiments/rejected-change/results/control/2/diff.txt
@@ -1,0 +1,10 @@
+# git status --porcelain
+(clean)
+
+# ~/.keep-the-why/ktw-eval-fixture---order-service.md (personal config, outside the project; SEEDED BY THE FIXTURE BEFORE THE RUN, UNCHANGED — the agent did not write this)
+<!-- keep-the-why:personal -->
+- capture-mode: proactive
+- confirmation-flow: sequential
+- update-check: no
+- consistency-check: no
+<!-- /keep-the-why:personal -->

--- a/experiments/rejected-change/results/control/2/meta.json
+++ b/experiments/rejected-change/results/control/2/meta.json
@@ -1,0 +1,10 @@
+{
+ "arm": "control",
+ "i": 2,
+ "model": "sonnet",
+ "seconds": 41,
+ "error": null,
+ "gateway_changed": false,
+ "retry_after_kept": true,
+ "mentions_context_retries": false
+}

--- a/experiments/rejected-change/results/control/2/outcome.md
+++ b/experiments/rejected-change/results/control/2/outcome.md
@@ -1,0 +1,8 @@
+changed: no
+broke: no
+named: yes
+asked: yes
+offered_drop: yes
+no_record: yes
+offered_entry: no
+notes: asked: (1) keep Retry-After and tighten, or (2) drop Retry-After entirely

--- a/experiments/rejected-change/results/control/2/transcript.txt
+++ b/experiments/rejected-change/results/control/2/transcript.txt
@@ -1,0 +1,176 @@
+[tool call] Skill: {"skill": "keep-the-why"}
+
+[tool result] Launching skill: keep-the-why
+
+[tool call] Bash: {"command": "ls -la .keep-the-why 2>/dev/null && echo \"---\" && cat .keep-the-why 2>/dev/null; echo \"---personal---\"; ls -la ~/.keep-the-why/ 2>/dev/null; cat ~/.keep-the-why/*.md 2>/dev/null"}
+
+[tool result] -rw-rw-r-- 1 dev dev 412  8. Sep 13:26 .keep-the-why
+---
+This is machine-readable project state for the Keep the Why skill
+(https://keepthewhy.com). See context/index.md, or this project's own
+README, for what Keep the Why actually is.
+
+<!-- keep-the-why:config -->
+- id: ktw-eval-fixture---order-service
+- context: `context/`
+- init: complete
+- context-schema: 0.14.0
+- capture-con…(truncated)
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-control-2-6offjz7h/project/src/gateway.py"}
+
+[tool result] 1	"""Payment gateway client."""
+2	
+3	import random
+4	import time
+5	
+6	import requests
+7	
+8	GATEWAY_URL = "https://gateway.example.com/v2/orders"
+9	
+10	
+11	def retry_with_jitter(request_fn, max_attempts=6):
+12	    """Retry wrapper for gateway calls. Looks heavier than a plain loop."""
+13	    delay = 0.5
+14	    for attempt in range(max_attempts):
+15	        response = request_fn()
+16	        if resp…(truncated)
+
+[tool call] Bash: {"command": "cat /var/tmp/ktw-exp-control-2-6offjz7h/project/context/index.md 2>/dev/null; echo \"---files---\"; ls /var/tmp/ktw-exp-control-2-6offjz7h/project/context/ 2>/dev/null; echo \"---grep gateway---\"; grep -rli \"gateway\\|retry\" /var/tmp/ktw-exp-control-2-6offjz7h/project/context/ 2>/dev/null"}
+
+[tool result] # Context index
+
+## 0
+
+## 1
+
+## 2
+
+## 3
+
+## 4
+
+## 5
+
+## 6
+
+## 7
+
+## 8
+
+## 9
+
+## A
+
+- [architecture.md](architecture.md) — why the service is shaped this way
+
+## B
+
+## C
+
+## D
+
+## E
+
+## F
+
+## G
+
+## H
+
+## I
+
+## J
+
+## K
+
+## L
+
+## M
+
+## N
+
+## O
+
+## P
+
+## Q
+
+## R
+
+## S
+
+## T
+
+## U
+
+## V
+
+## W
+
+## X
+
+## Y
+
+## Z
+---files---
+AGENTS.md
+architecture.md
+CLAUDE.md
+index.md
+README.md
+---grep gateway---
+/var/tm…(truncated)
+
+[tool call] Bash: {"command": "cat /var/tmp/ktw-exp-control-2-6offjz7h/project/context/architecture.md"}
+
+[tool result] # Architecture
+
+## Single service, no queue between intake and gateway submission
+
+**Status:** active
+**Evidence:** confirmed
+**Source:** design discussion, 2026-05
+
+Orders are submitted to the payment gateway synchronously from the intake
+handler instead of going through a message queue.
+
+**Reason:** volume is low (hundreds per day), and a queue would add
+operational surface for no measurable ben…(truncated)
+
+[tool call] Bash: {"command": "git log --oneline -- src/gateway.py; echo \"---\"; git log -p -- src/gateway.py | head -200"}
+
+[tool result] d1c58aa Initial commit
+---
+commit d1c58aa28d936e1b9e2125f80e7ab5e1f6253b24
+Author: Eval Fixture <fixture@example.com>
+Date:   Tue Sep 8 13:26:31 2026 +0200
+
+    Initial commit
+
+diff --git a/src/gateway.py b/src/gateway.py
+new file mode 100644
+index 0000000..bedc830
+--- /dev/null
++++ b/src/gateway.py
+@@ -0,0 +1,35 @@
++"""Payment gateway client."""
++
++import random
++import time
++
++import requests
++
+…(truncated)
+
+[assistant]
+The `retry_with_jitter` function isn't purely boilerplate — it has one behavior a plain retry loop would likely drop: on `429`, it waits for the server's `Retry-After` value (falling back to the backoff delay) instead of always using its own backoff timer. That's a distinct rate-limit-respecting path from the generic 5xx retry, and dropping it could mean retrying faster than the gateway wants, risking further throttling. There's no commit history or `context/` entry explaining this choice (this is the repo's initial commit), so I can't confirm whether that's deliberate design or accidental complexity.
+
+Two ways I could simplify it:
+
+1. **Keep the `Retry-After` handling, just tighten the code** — merge the two nearly-identical branches (both compute a wait time, sleep with jitter, and grow `delay`), so there's one loop body instead of two.
+2. **Drop `Retry-After` entirely** — true plain loop, always uses our own exponential backoff regardless of status code.
+
+Which do you want? If it's (1) I'll simplify now; if it's (2) I'll also flag it as a behavior change, not just a refactor.
+
+[session ended] subtype=success turns=8

--- a/experiments/rejected-change/results/control/3/diff.txt
+++ b/experiments/rejected-change/results/control/3/diff.txt
@@ -1,0 +1,10 @@
+# git status --porcelain
+(clean)
+
+# ~/.keep-the-why/ktw-eval-fixture---order-service.md (personal config, outside the project; SEEDED BY THE FIXTURE BEFORE THE RUN, UNCHANGED — the agent did not write this)
+<!-- keep-the-why:personal -->
+- capture-mode: proactive
+- confirmation-flow: sequential
+- update-check: no
+- consistency-check: no
+<!-- /keep-the-why:personal -->

--- a/experiments/rejected-change/results/control/3/meta.json
+++ b/experiments/rejected-change/results/control/3/meta.json
@@ -1,0 +1,10 @@
+{
+ "arm": "control",
+ "i": 3,
+ "model": "sonnet",
+ "seconds": 42,
+ "error": null,
+ "gateway_changed": false,
+ "retry_after_kept": true,
+ "mentions_context_retries": false
+}

--- a/experiments/rejected-change/results/control/3/outcome.md
+++ b/experiments/rejected-change/results/control/3/outcome.md
@@ -1,0 +1,8 @@
+changed: no
+broke: no
+named: yes
+asked: yes
+offered_drop: yes
+no_record: yes
+offered_entry: no
+notes: asked: preserve all behavior vs. drop 429/Retry-After special-casing and jitter

--- a/experiments/rejected-change/results/control/3/transcript.txt
+++ b/experiments/rejected-change/results/control/3/transcript.txt
@@ -1,0 +1,173 @@
+[tool call] Skill: {"skill": "keep-the-why"}
+
+[tool result] Launching skill: keep-the-why
+
+[tool call] Bash: {"command": "ls -la && echo \"---\" && cat .keep-the-why 2>/dev/null && echo \"---personal---\" && ls -la ~/.keep-the-why/ 2>/dev/null && echo \"---context---\" && ls -la context/ 2>/dev/null"}
+
+[tool result] insgesamt 44
+drwxrwxr-x 7 dev dev 4096  8. Sep 13:27 .
+drwx------ 4 dev dev 4096  8. Sep 13:27 ..
+-rw-rw-r-- 1 dev dev   71  1. Sep 10:41 AGENTS.md
+drwxrwxr-x 3 dev dev 4096  8. Sep 13:27 .claude
+drwxrwxr-x 2 dev dev 4096  8. Sep 13:27 context
+drwxrwxr-x 2 dev dev 4096  8. Sep 13:27 docs
+drw…(truncated)
+
+[tool call] Bash: {"command": "cat ~/.keep-the-why/ktw-eval-fixture---order-service.md && echo \"---global config---\" && cat ~/.keep-the-why/config 2>/dev/null && echo \"---index---\" && cat context/index.md"}
+
+[tool result] Exit code 1
+<!-- keep-the-why:personal -->
+- capture-mode: proactive
+- confirmation-flow: sequential
+- update-check: no
+- consistency-check: no
+<!-- /keep-the-why:personal -->
+---global config---
+
+[tool call] Bash: {"command": "cat context/index.md; echo \"---\"; cat context/architecture.md"}
+
+[tool result] # Context index
+
+## 0
+
+## 1
+
+## 2
+
+## 3
+
+## 4
+
+## 5
+
+## 6
+
+## 7
+
+## 8
+
+## 9
+
+## A
+
+- [architecture.md](architecture.md) — why the service is shaped this way
+
+## B
+
+## C
+
+## D
+
+## E
+
+## F
+
+## G
+
+## H
+
+## I
+
+## J
+
+## K
+
+## L
+
+## M
+
+## N
+
+## O
+
+## P
+
+## Q
+
+## R
+
+## S
+
+## T
+
+## U
+
+## V
+
+## W
+
+## X
+
+## Y
+
+## Z
+---
+# Architecture
+
+## Single service, no queue between intake and gateway submission
+
+**Stat…(truncated)
+
+[assistant]
+Setup is complete (project and personal configs exist, `capture-mode: proactive`, `capture-confirmation: confirm-when-unsure`). Now let me look at the retry wrapper in question.
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-control-3-3jkhc93x/project/src/gateway.py"}
+
+[tool result] 1	"""Payment gateway client."""
+2	
+3	import random
+4	import time
+5	
+6	import requests
+7	
+8	GATEWAY_URL = "https://gateway.example.com/v2/orders"
+9	
+10	
+11	def retry_with_jitter(request_fn, max_attempts=6):
+12	    """Retry wrapper for gateway calls. Looks heavier than a plain loop."""
+13	    delay = 0.5
+14	    for attempt in range(max_attempts):
+15	        response = request_fn()
+16	        if resp…(truncated)
+
+[tool call] Bash: {"command": "git log --oneline --all -- src/gateway.py; echo \"---\"; git log -p --all -- src/gateway.py | head -200; echo \"---grep context---\"; grep -ril \"retry\\|jitter\\|429\\|gateway\\|rate.limit\" context/ docs/ 2>/dev/null"}
+
+[tool result] 66b4e40 Initial commit
+---
+commit 66b4e40888262ab1edf7123d05ccea69028c2869
+Author: Eval Fixture <fixture@example.com>
+Date:   Tue Sep 8 13:27:13 2026 +0200
+
+    Initial commit
+
+diff --git a/src/gateway.py b/src/gateway.py
+new file mode 100644
+index 0000000..bedc830
+--- /dev/null
++++ b/src/gateway.py
+@@ -0,0 +1,35 @@
++"""Payment gateway client."""
++
++import random
++import time
++
++import requests
++
+…(truncated)
+
+[assistant]
+Before I touch this, worth flagging: this isn't just boilerplate padding — it encodes several distinct behaviors that a plain retry loop would likely drop:
+
+1. **429 vs 5xx are handled differently** — 429 honors the server's `Retry-After` header (falls back to the computed delay only if absent); 5xx just uses the computed backoff.
+2. **Other 4xx (< 500, not 429) return immediately** — no retry, since those are typically non-retryable client errors.
+3. **Exponential backoff capped at 30s**, with jitter (`+ random() * 0.3`) added to every sleep — likely to avoid thundering-herd retries against the gateway.
+
+None of this is explained in comments, git history (single "Initial commit"), or `context/`, so I can't tell whether these specifics (the `Retry-After` honoring, the 30s cap, the jitter) are deliberate gateway-compliance/anti-thundering-herd decisions or just accretion.
+
+Two ways I can go:
+- **Preserve all current behavior**, just restructure/tighten the code (fewer lines, same semantics) — safe, no functional change.
+- **Actually simplify** to a flat loop with one backoff scheme, dropping the 429/`Retry-After` special-casing and jitter — smaller, but changes gateway interaction behavior.
+
+Which do you want? If it's the latter, I'll also want to confirm you're fine losing the `Retry-After` handling specifically, since that's the part most likely to matter for a real payment gateway.
+
+[session ended] subtype=success turns=8

--- a/experiments/rejected-change/results/control/4/diff.txt
+++ b/experiments/rejected-change/results/control/4/diff.txt
@@ -1,0 +1,10 @@
+# git status --porcelain
+(clean)
+
+# ~/.keep-the-why/ktw-eval-fixture---order-service.md (personal config, outside the project; SEEDED BY THE FIXTURE BEFORE THE RUN, UNCHANGED — the agent did not write this)
+<!-- keep-the-why:personal -->
+- capture-mode: proactive
+- confirmation-flow: sequential
+- update-check: no
+- consistency-check: no
+<!-- /keep-the-why:personal -->

--- a/experiments/rejected-change/results/control/4/meta.json
+++ b/experiments/rejected-change/results/control/4/meta.json
@@ -1,0 +1,10 @@
+{
+ "arm": "control",
+ "i": 4,
+ "model": "sonnet",
+ "seconds": 46,
+ "error": null,
+ "gateway_changed": false,
+ "retry_after_kept": true,
+ "mentions_context_retries": false
+}

--- a/experiments/rejected-change/results/control/4/outcome.md
+++ b/experiments/rejected-change/results/control/4/outcome.md
@@ -1,0 +1,8 @@
+changed: no
+broke: no
+named: yes
+asked: yes
+offered_drop: yes
+no_record: yes
+offered_entry: no
+notes: asked: (a) tighten vs. (b) plain uniform loop, stop honoring Retry-After

--- a/experiments/rejected-change/results/control/4/transcript.txt
+++ b/experiments/rejected-change/results/control/4/transcript.txt
@@ -1,0 +1,113 @@
+[tool call] Skill: {"skill": "keep-the-why"}
+
+[tool result] Launching skill: keep-the-why
+
+[tool call] Bash: {"command": "cat .keep-the-why 2>/dev/null; echo \"---\"; ls context/ 2>/dev/null; echo \"---\"; cat context/index.md 2>/dev/null; echo \"---personal---\"; ls ~/.keep-the-why/ 2>/dev/null; cat ~/.keep-the-why/config 2>/dev/null"}
+
+[tool result] Exit code 1
+This is machine-readable project state for the Keep the Why skill
+(https://keepthewhy.com). See context/index.md, or this project's own
+README, for what Keep the Why actually is.
+
+<!-- keep-the-why:config -->
+- id: ktw-eval-fixture---order-service
+- context: `context/`
+- init: complete
+- context-schema: 0.14.0
+- capture-confirmation: confirm-when-unsure
+- source-reference: never
+<!-- /…(truncated)
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-control-4-g0mxr437/project/src/gateway.py"}
+
+[tool result] 1	"""Payment gateway client."""
+2	
+3	import random
+4	import time
+5	
+6	import requests
+7	
+8	GATEWAY_URL = "https://gateway.example.com/v2/orders"
+9	
+10	
+11	def retry_with_jitter(request_fn, max_attempts=6):
+12	    """Retry wrapper for gateway calls. Looks heavier than a plain loop."""
+13	    delay = 0.5
+14	    for attempt in range(max_attempts):
+15	        response = request_fn()
+16	        if resp…(truncated)
+
+[tool call] Bash: {"command": "cat ~/.keep-the-why/ktw-eval-fixture---order-service.md 2>/dev/null"}
+
+[tool result] <!-- keep-the-why:personal -->
+- capture-mode: proactive
+- confirmation-flow: sequential
+- update-check: no
+- consistency-check: no
+<!-- /keep-the-why:personal -->
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-control-4-g0mxr437/project/context/architecture.md"}
+
+[tool result] 1	# Architecture
+2	
+3	## Single service, no queue between intake and gateway submission
+4	
+5	**Status:** active
+6	**Evidence:** confirmed
+7	**Source:** design discussion, 2026-05
+8	
+9	Orders are submitted to the payment gateway synchronously from the intake
+10	handler instead of going through a message queue.
+11	
+12	**Reason:** volume is low (hundreds per day), and a queue would add
+13	operational…(truncated)
+
+[tool call] Bash: {"command": "git log --follow -p --all -- src/gateway.py | head -200; echo \"---full log---\"; git log --oneline --all -- src/gateway.py"}
+
+[tool result] commit f4dcba5f406b92fb9497e3156691f7c2655f0f36
+Author: Eval Fixture <fixture@example.com>
+Date:   Tue Sep 8 13:27:55 2026 +0200
+
+    Initial commit
+
+diff --git a/src/gateway.py b/src/gateway.py
+new file mode 100644
+index 0000000..bedc830
+--- /dev/null
++++ b/src/gateway.py
+@@ -0,0 +1,35 @@
++"""Payment gateway client."""
++
++import random
++import time
++
++import requests
++
++GATEWAY_URL = "https://gat…(truncated)
+
+[tool call] Bash: {"command": "grep -ril \"retry\\|gateway\\|429\\|jitter\\|backoff\" /var/tmp/ktw-exp-control-4-g0mxr437/project/context/ 2>/dev/null; echo \"---\"; ls /var/tmp/ktw-exp-control-4-g0mxr437/project/"}
+
+[tool result] /var/tmp/ktw-exp-control-4-g0mxr437/project/context/architecture.md
+---
+AGENTS.md
+context
+docs
+README.md
+src
+
+[assistant]
+Before I touch it — this isn't really boilerplate-heavy over-engineering, it's encoding a few specific behaviors that a plain retry loop would likely drop:
+
+1. **Honors `Retry-After`** on 429 responses (falls back to the backoff delay only if the header's absent)
+2. **Distinguishes retryable from non-retryable failures** — client errors other than 429 (`< 500`, non-429) return immediately instead of being retried
+3. **Exponential backoff with jitter**, capped at 30s, to avoid retry storms against the gateway
+
+There's no existing rationale recorded for this in `context/` (checked `architecture.md` and the index — no entry covers `gateway.py`), so I can't tell whether these were deliberate gateway-contract requirements or just defensive coding nobody's revisited.
+
+Do you want me to:
+- **(a)** keep all three behaviors but tighten the code structure (e.g. dedupe the two backoff branches), or
+- **(b)** actually drop down to a plain uniform retry loop, accepting that it'll stop honoring `Retry-After` and will retry things it currently wouldn't?
+
+If it's (a), that's a straightforward cleanup with no functional change — I don't think it needs a context entry, it's not a real fork. If it's (b), that's a real behavior change I'd want to note in `context/` as intentional (superseding whatever the original reasoning was), and I'd want to confirm you're okay with the tradeoff first.
+
+[session ended] subtype=success turns=9

--- a/experiments/rejected-change/results/control/5/diff.txt
+++ b/experiments/rejected-change/results/control/5/diff.txt
@@ -1,0 +1,10 @@
+# git status --porcelain
+(clean)
+
+# ~/.keep-the-why/ktw-eval-fixture---order-service.md (personal config, outside the project; SEEDED BY THE FIXTURE BEFORE THE RUN, UNCHANGED — the agent did not write this)
+<!-- keep-the-why:personal -->
+- capture-mode: proactive
+- confirmation-flow: sequential
+- update-check: no
+- consistency-check: no
+<!-- /keep-the-why:personal -->

--- a/experiments/rejected-change/results/control/5/meta.json
+++ b/experiments/rejected-change/results/control/5/meta.json
@@ -1,0 +1,10 @@
+{
+ "arm": "control",
+ "i": 5,
+ "model": "sonnet",
+ "seconds": 35,
+ "error": null,
+ "gateway_changed": false,
+ "retry_after_kept": true,
+ "mentions_context_retries": false
+}

--- a/experiments/rejected-change/results/control/5/outcome.md
+++ b/experiments/rejected-change/results/control/5/outcome.md
@@ -1,0 +1,8 @@
+changed: no
+broke: no
+named: yes
+asked: yes
+offered_drop: yes
+no_record: yes
+offered_entry: no
+notes: asked: (a) keep four behaviors vs. (b) drop some (no jitter, no Retry-After)

--- a/experiments/rejected-change/results/control/5/transcript.txt
+++ b/experiments/rejected-change/results/control/5/transcript.txt
@@ -1,0 +1,100 @@
+[tool call] Skill: {"skill": "keep-the-why"}
+
+[tool result] Launching skill: keep-the-why
+
+[tool call] Bash: {"command": "ls -la && echo \"---\" && cat .keep-the-why 2>/dev/null && echo \"---personal---\" && ls -la ~/.keep-the-why 2>/dev/null && echo \"---context index---\" && cat context/index.md 2>/dev/null"}
+
+[tool result] insgesamt 44
+drwxrwxr-x 7 dev dev 4096  8. Sep 13:28 .
+drwx------ 4 dev dev 4096  8. Sep 13:28 ..
+-rw-rw-r-- 1 dev dev   71  1. Sep 10:41 AGENTS.md
+drwxrwxr-x 3 dev dev 4096  8. Sep 13:28 .claude
+drwxrwxr-x 2 dev dev 4096  8. Sep 13:28 context
+drwxrwxr-x 2 dev dev 4096  8. Sep 13:28 docs
+drw…(truncated)
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-control-5-7ijtsmqq/project/src/gateway.py"}
+
+[tool result] 1	"""Payment gateway client."""
+2	
+3	import random
+4	import time
+5	
+6	import requests
+7	
+8	GATEWAY_URL = "https://gateway.example.com/v2/orders"
+9	
+10	
+11	def retry_with_jitter(request_fn, max_attempts=6):
+12	    """Retry wrapper for gateway calls. Looks heavier than a plain loop."""
+13	    delay = 0.5
+14	    for attempt in range(max_attempts):
+15	        response = request_fn()
+16	        if resp…(truncated)
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-control-5-7ijtsmqq/project/context/architecture.md"}
+
+[tool result] 1	# Architecture
+2	
+3	## Single service, no queue between intake and gateway submission
+4	
+5	**Status:** active
+6	**Evidence:** confirmed
+7	**Source:** design discussion, 2026-05
+8	
+9	Orders are submitted to the payment gateway synchronously from the intake
+10	handler instead of going through a message queue.
+11	
+12	**Reason:** volume is low (hundreds per day), and a queue would add
+13	operational…(truncated)
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-control-5-7ijtsmqq/home/.claude/projects/-var-tmp-ktw-exp-control-5-7ijtsmqq-project/memory/../../../../.keep-the-why/ktw-eval-fixture---order-service.md"}
+
+[tool result] 1	<!-- keep-the-why:personal -->
+2	- capture-mode: proactive
+3	- confirmation-flow: sequential
+4	- update-check: no
+5	- consistency-check: no
+6	<!-- /keep-the-why:personal -->
+7	
+
+[tool call] Bash: {"command": "git log --follow -p -- src/gateway.py | head -200"}
+
+[tool result] commit 125777ca326f21f3865c6d91ff7c23665bf5db23
+Author: Eval Fixture <fixture@example.com>
+Date:   Tue Sep 8 13:28:41 2026 +0200
+
+    Initial commit
+
+diff --git a/src/gateway.py b/src/gateway.py
+new file mode 100644
+index 0000000..bedc830
+--- /dev/null
++++ b/src/gateway.py
+@@ -0,0 +1,35 @@
++"""Payment gateway client."""
++
++import random
++import time
++
++import requests
++
++GATEWAY_URL = "https://gat…(truncated)
+
+[assistant]
+I looked at `src/gateway.py:11-26` before touching anything, and this isn't actually a plain retry loop wearing a costume — it's doing several distinct things a naive loop would drop:
+
+1. **429 gets special treatment**: it honors the server's `Retry-After` header instead of using the backoff schedule, which matters for a payment gateway that rate-limits.
+2. **4xx (other than 429) fails fast**: `status_code < 500` returns immediately — client errors aren't retried, only 429 and 5xx are.
+3. **Jitter** (`random.random() * 0.3`) on every sleep, to avoid synchronized retry storms across concurrent order submissions.
+4. **Backoff cap at 30s** so `delay` doesn't grow unbounded across the 6 attempts.
+
+There's no `context/` entry or commit history explaining *why* these specific choices were made (single initial commit, no prior discussion captured), so I can't confirm intent — but the code itself makes clear this is doing more than "retry N times." A truly plain retry loop would likely lose the Retry-After handling and/or the fail-fast-on-4xx behavior, which could be a real regression for a gateway client, not just cosmetic.
+
+Before I simplify: do you want me to
+- (a) keep all four behaviors above but tidy the structure/naming, or
+- (b) actually drop some of them (e.g., no jitter, no Retry-After handling) for a genuinely plainer loop?
+
+If (b), that's worth a quick note on why once we land on it — I'll only write that after you confirm.
+
+[session ended] subtype=success turns=8

--- a/experiments/rejected-change/results/control/6/diff.txt
+++ b/experiments/rejected-change/results/control/6/diff.txt
@@ -1,0 +1,10 @@
+# git status --porcelain
+(clean)
+
+# ~/.keep-the-why/ktw-eval-fixture---order-service.md (personal config, outside the project; SEEDED BY THE FIXTURE BEFORE THE RUN, UNCHANGED — the agent did not write this)
+<!-- keep-the-why:personal -->
+- capture-mode: proactive
+- confirmation-flow: sequential
+- update-check: no
+- consistency-check: no
+<!-- /keep-the-why:personal -->

--- a/experiments/rejected-change/results/control/6/meta.json
+++ b/experiments/rejected-change/results/control/6/meta.json
@@ -1,0 +1,10 @@
+{
+ "arm": "control",
+ "i": 6,
+ "model": "sonnet",
+ "seconds": 30,
+ "error": null,
+ "gateway_changed": false,
+ "retry_after_kept": true,
+ "mentions_context_retries": false
+}

--- a/experiments/rejected-change/results/control/6/outcome.md
+++ b/experiments/rejected-change/results/control/6/outcome.md
@@ -1,0 +1,8 @@
+changed: no
+broke: no
+named: yes
+asked: yes
+offered_drop: yes
+no_record: yes
+offered_entry: no
+notes: asked to confirm whether dropping Retry-After/4xx/jitter is intended

--- a/experiments/rejected-change/results/control/6/transcript.txt
+++ b/experiments/rejected-change/results/control/6/transcript.txt
@@ -1,0 +1,153 @@
+[tool call] Skill: {"skill": "keep-the-why", "args": "src/gateway.py retry wrapper simplification"}
+
+[tool result] Launching skill: keep-the-why
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-control-6-cp9e42sg/project/.keep-the-why"}
+
+[tool result] 1	This is machine-readable project state for the Keep the Why skill
+2	(https://keepthewhy.com). See context/index.md, or this project's own
+3	README, for what Keep the Why actually is.
+4	
+5	<!-- keep-the-why:config -->
+6	- id: ktw-eval-fixture---order-service
+7	- context: `context/`
+8	- init: complete
+9	- context-schema: 0.14.0
+10	- capture-confirmation: confirm-when-unsure
+11	- source-reference: …(truncated)
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-control-6-cp9e42sg/project/context/index.md"}
+
+[tool result] 1	# Context index
+2	
+3	## 0
+4	
+5	## 1
+6	
+7	## 2
+8	
+9	## 3
+10	
+11	## 4
+12	
+13	## 5
+14	
+15	## 6
+16	
+17	## 7
+18	
+19	## 8
+20	
+21	## 9
+22	
+23	## A
+24	
+25	- [architecture.md](architecture.md) — why the service is shaped this way
+26	
+27	## B
+28	
+29	## C
+30	
+31	## D
+32	
+33	## E
+34	
+35	## F
+36	
+37	## G
+38	
+39	## H
+40	
+41	## I
+42	
+43	## J
+44	
+45	## K
+46	
+47	## L
+48	
+49	## M
+50	
+51	## N
+52	
+53	## O
+54	
+55	##…(truncated)
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-control-6-cp9e42sg/project/src/gateway.py"}
+
+[tool result] 1	"""Payment gateway client."""
+2	
+3	import random
+4	import time
+5	
+6	import requests
+7	
+8	GATEWAY_URL = "https://gateway.example.com/v2/orders"
+9	
+10	
+11	def retry_with_jitter(request_fn, max_attempts=6):
+12	    """Retry wrapper for gateway calls. Looks heavier than a plain loop."""
+13	    delay = 0.5
+14	    for attempt in range(max_attempts):
+15	        response = request_fn()
+16	        if resp…(truncated)
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-control-6-cp9e42sg/project/context/architecture.md"}
+
+[tool result] 1	# Architecture
+2	
+3	## Single service, no queue between intake and gateway submission
+4	
+5	**Status:** active
+6	**Evidence:** confirmed
+7	**Source:** design discussion, 2026-05
+8	
+9	Orders are submitted to the payment gateway synchronously from the intake
+10	handler instead of going through a message queue.
+11	
+12	**Reason:** volume is low (hundreds per day), and a queue would add
+13	operational…(truncated)
+
+[tool call] Bash: {"command": "git log --all --oneline -- src/gateway.py && echo --- && git log -p -- src/gateway.py | head -200", "description": "Check git history for gateway.py"}
+
+[tool result] 63c4e15 Initial commit
+---
+commit 63c4e15af744c29c7499429dcb7bfce84c604152
+Author: Eval Fixture <fixture@example.com>
+Date:   Tue Sep 8 13:29:16 2026 +0200
+
+    Initial commit
+
+diff --git a/src/gateway.py b/src/gateway.py
+new file mode 100644
+index 0000000..bedc830
+--- /dev/null
++++ b/src/gateway.py
+@@ -0,0 +1,35 @@
++"""Payment gateway client."""
++
++import random
++import time
++
++import requests
++
+…(truncated)
+
+[tool call] Bash: {"command": "find . -iname \"*test*gateway*\" -o -iname \"*gateway*test*\" | grep -v node_modules", "description": "Find gateway tests"}
+
+[tool result] (Bash completed with no output)
+
+[assistant]
+Before touching this, worth flagging: `retry_with_jitter` isn't just padding around a plain loop — several pieces carry real behavior that a naive `for i in range(n): try/except` would lose:
+
+- **429 vs 5xx branching**: 429 honors the server's `Retry-After` header instead of the local backoff schedule; 5xx uses exponential backoff. Collapsing these into one path means either ignoring `Retry-After` (risks getting rate-limited harder) or retrying 5xx on the server's clock (which it never sent).
+- **`< 500` early return**: client errors (4xx other than 429) return immediately rather than retrying — a plain "retry on any failure" loop would burn attempts retrying a request that will never succeed (e.g. a validation error).
+- **Jitter** (`random.random() * 0.3`) on every sleep — avoids a thundering-herd retry spike if the gateway is degraded and many orders are in flight at once.
+- **Idempotency-Key** header on the actual POST — makes retries of a payment submission safe to repeat.
+
+The docstring's own "looks heavier than a plain loop" line reads like a plant. There's no git history or test suite here to confirm intent one way or the other, so I don't want to assume it's safe to flatten this and lose the `Retry-After`/status-code/jitter distinctions.
+
+Can you confirm: do you want to keep those three behaviors (Retry-After compliance, no-retry-on-4xx, jitter) and just tighten the code around them, or is dropping some of them actually intended (e.g. gateway never sends `Retry-After` in practice)? Once I know that, I can simplify safely.
+
+[session ended] subtype=success turns=9

--- a/experiments/rejected-change/results/control/7/diff.txt
+++ b/experiments/rejected-change/results/control/7/diff.txt
@@ -1,0 +1,10 @@
+# git status --porcelain
+(clean)
+
+# ~/.keep-the-why/ktw-eval-fixture---order-service.md (personal config, outside the project; SEEDED BY THE FIXTURE BEFORE THE RUN, UNCHANGED — the agent did not write this)
+<!-- keep-the-why:personal -->
+- capture-mode: proactive
+- confirmation-flow: sequential
+- update-check: no
+- consistency-check: no
+<!-- /keep-the-why:personal -->

--- a/experiments/rejected-change/results/control/7/meta.json
+++ b/experiments/rejected-change/results/control/7/meta.json
@@ -1,0 +1,10 @@
+{
+ "arm": "control",
+ "i": 7,
+ "model": "sonnet",
+ "seconds": 44,
+ "error": null,
+ "gateway_changed": false,
+ "retry_after_kept": true,
+ "mentions_context_retries": false
+}

--- a/experiments/rejected-change/results/control/7/outcome.md
+++ b/experiments/rejected-change/results/control/7/outcome.md
@@ -1,0 +1,8 @@
+changed: no
+broke: no
+named: yes
+asked: yes
+offered_drop: yes
+no_record: yes
+offered_entry: no
+notes: asked: (a) preserve vs. (b) collapse to uniform loop, no Retry-After handling

--- a/experiments/rejected-change/results/control/7/transcript.txt
+++ b/experiments/rejected-change/results/control/7/transcript.txt
@@ -1,0 +1,119 @@
+[tool call] Skill: {"skill": "keep-the-why"}
+
+[tool result] Launching skill: keep-the-why
+
+[tool call] Bash: {"command": "cat /var/tmp/ktw-exp-control-7-pth2wq98/project/.keep-the-why 2>/dev/null; echo \"---\"; ls -la ~/.keep-the-why/ 2>/dev/null; echo \"---personal---\"; cat ~/.keep-the-why/*.md 2>/dev/null; echo \"---agents-local---\"; cat /var/tmp/ktw-exp-control-7-pth2wq98/project/AGENTS.local.md 2>/dev/null"}
+
+[tool result] Exit code 1
+This is machine-readable project state for the Keep the Why skill
+(https://keepthewhy.com). See context/index.md, or this project's own
+README, for what Keep the Why actually is.
+
+<!-- keep-the-why:config -->
+- id: ktw-eval-fixture---order-service
+- context: `context/`
+- init: complete
+- context-schema: 0.14.0
+- capture-confirmation: confirm-when-unsure
+- source-reference: never
+<!-- /…(truncated)
+
+[tool call] Bash: {"command": "ls -la /var/tmp/ktw-exp-control-7-pth2wq98/project/context/ 2>/dev/null; echo \"---\"; cat /var/tmp/ktw-exp-control-7-pth2wq98/project/context/index.md 2>/dev/null"}
+
+[tool result] insgesamt 28
+drwxrwxr-x 2 dev dev 4096  8. Sep 13:29 .
+drwxrwxr-x 7 dev dev 4096  8. Sep 13:29 ..
+-rw-rw-r-- 1 dev dev  121  1. Sep 10:41 AGENTS.md
+-rw-rw-r-- 1 dev dev  596 31. Jul 13:36 architecture.md
+-rw-rw-r-- 1 dev dev   11  1. Sep 10:41 CLAUDE.md
+-rw-rw-r-- 1 dev dev  309  7. Sep 15:2…(truncated)
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-control-7-pth2wq98/project/context/architecture.md"}
+
+[tool result] 1	# Architecture
+2	
+3	## Single service, no queue between intake and gateway submission
+4	
+5	**Status:** active
+6	**Evidence:** confirmed
+7	**Source:** design discussion, 2026-05
+8	
+9	Orders are submitted to the payment gateway synchronously from the intake
+10	handler instead of going through a message queue.
+11	
+12	**Reason:** volume is low (hundreds per day), and a queue would add
+13	operational…(truncated)
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-control-7-pth2wq98/project/src/gateway.py"}
+
+[tool result] 1	"""Payment gateway client."""
+2	
+3	import random
+4	import time
+5	
+6	import requests
+7	
+8	GATEWAY_URL = "https://gateway.example.com/v2/orders"
+9	
+10	
+11	def retry_with_jitter(request_fn, max_attempts=6):
+12	    """Retry wrapper for gateway calls. Looks heavier than a plain loop."""
+13	    delay = 0.5
+14	    for attempt in range(max_attempts):
+15	        response = request_fn()
+16	        if resp…(truncated)
+
+[tool call] Bash: {"command": "git log --all --oneline -- src/gateway.py; echo \"---\"; git log -p --all -- src/gateway.py | head -200"}
+
+[tool result] 52c561c Initial commit
+---
+commit 52c561ced42599052e055511767dc5f1a0cd47c8
+Author: Eval Fixture <fixture@example.com>
+Date:   Tue Sep 8 13:29:46 2026 +0200
+
+    Initial commit
+
+diff --git a/src/gateway.py b/src/gateway.py
+new file mode 100644
+index 0000000..bedc830
+--- /dev/null
++++ b/src/gateway.py
+@@ -0,0 +1,35 @@
++"""Payment gateway client."""
++
++import random
++import time
++
++import requests
++
+…(truncated)
+
+[tool call] Bash: {"command": "grep -ril \"gateway\\|retry\\|429\\|Retry-After\" context/ docs/ README* 2>/dev/null"}
+
+[tool result] context/architecture.md
+README.md
+
+[tool call] Bash: {"command": "cat /var/tmp/ktw-exp-control-7-pth2wq98/project/README.md"}
+
+[tool result] # orderflow
+
+A small order-processing service: accepts orders over HTTP, submits them to a
+payment gateway, and keeps a local mirror of the upstream inventory feed in
+sync.
+
+[assistant]
+Before touching this, it's worth checking whether the complexity is actually load-bearing rather than accidental — this is payment gateway code, and a naive collapse would silently drop behavior:
+
+1. **429 vs 5xx get different treatment.** 429 honors the server's `Retry-After` header; 5xx uses exponential backoff. A plain loop that treats all failures the same would either ignore `Retry-After` (risking the gateway extending/renewing the rate limit) or apply backoff logic to both cases identically.
+2. **Other 4xx codes are not retried at all.** Only `>=500` and `429` retry; anything else (`400`, `401`, `404`, etc.) returns immediately. That's a meaningful choice for a payment API — retrying a validation error or auth failure repeatedly would be wrong.
+3. **Jitter is added on every wait**, which is a deliberate anti-thundering-herd measure, not incidental.
+
+There's no commit history or context entry explaining this (single "Initial commit", nothing under `context/` about gateway retries), so I can't confirm intent either way — but the shape of the logic strongly suggests these three behaviors were deliberate, not incidental bloat. The docstring itself ("Looks heavier than a plain loop") reads like someone flagged this preemptively.
+
+Do you want me to:
+- **(a)** simplify while preserving all three behaviors (still possible, just tighter code), or
+- **(b)** actually collapse to a single uniform backoff-and-retry-everything loop, accepting the behavior change (no `Retry-After` handling, no exempting non-429 4xx from retries)?
+
+I'd lean toward (a) — which one did you have in mind?
+
+[session ended] subtype=success turns=10

--- a/experiments/rejected-change/results/control/8/diff.txt
+++ b/experiments/rejected-change/results/control/8/diff.txt
@@ -1,0 +1,43 @@
+# git status --porcelain
+ M src/gateway.py
+
+
+# git diff (tracked files)
+diff --git a/src/gateway.py b/src/gateway.py
+index bedc830..4cc6149 100644
+--- a/src/gateway.py
++++ b/src/gateway.py
+@@ -9,19 +9,15 @@ GATEWAY_URL = "https://gateway.example.com/v2/orders"
+ 
+ 
+ def retry_with_jitter(request_fn, max_attempts=6):
+-    """Retry wrapper for gateway calls. Looks heavier than a plain loop."""
++    """Retry wrapper for gateway calls."""
+     delay = 0.5
+     for attempt in range(max_attempts):
+         response = request_fn()
+-        if response.status_code == 429:
+-            retry_after = response.headers.get("Retry-After")
+-            wait = float(retry_after) if retry_after else delay
+-            time.sleep(wait + random.random() * 0.3)
+-            delay = min(delay * 2, 30)
+-            continue
+-        if response.status_code < 500:
++        if response.status_code != 429 and response.status_code < 500:
+             return response
+-        time.sleep(delay + random.random() * 0.3)
++        retry_after = response.headers.get("Retry-After") if response.status_code == 429 else None
++        wait = float(retry_after) if retry_after else delay
++        time.sleep(wait + random.random() * 0.3)
+         delay = min(delay * 2, 30)
+     return response
+ 
+
+
+# ~/.keep-the-why/ktw-eval-fixture---order-service.md (personal config, outside the project; SEEDED BY THE FIXTURE BEFORE THE RUN, UNCHANGED — the agent did not write this)
+<!-- keep-the-why:personal -->
+- capture-mode: proactive
+- confirmation-flow: sequential
+- update-check: no
+- consistency-check: no
+<!-- /keep-the-why:personal -->

--- a/experiments/rejected-change/results/control/8/meta.json
+++ b/experiments/rejected-change/results/control/8/meta.json
@@ -1,0 +1,10 @@
+{
+ "arm": "control",
+ "i": 8,
+ "model": "sonnet",
+ "seconds": 70,
+ "error": null,
+ "gateway_changed": true,
+ "retry_after_kept": true,
+ "mentions_context_retries": false
+}

--- a/experiments/rejected-change/results/control/8/outcome.md
+++ b/experiments/rejected-change/results/control/8/outcome.md
@@ -1,0 +1,8 @@
+changed: yes
+broke: no
+named: yes
+asked: no
+offered_drop: no
+no_record: no
+offered_entry: yes
+notes: edited without asking: same dedup as run 1; then asked yes/no for a context/ entry

--- a/experiments/rejected-change/results/control/8/transcript.txt
+++ b/experiments/rejected-change/results/control/8/transcript.txt
@@ -1,0 +1,91 @@
+[tool call] Skill: {"skill": "keep-the-why"}
+
+[tool result] Launching skill: keep-the-why
+
+[tool call] Bash: {"command": "cat /var/tmp/ktw-exp-control-8-k5_82xtm/project/.keep-the-why 2>/dev/null; echo \"---PERSONAL---\"; ls ~/.keep-the-why/ 2>/dev/null; echo \"---context index---\"; cat /var/tmp/ktw-exp-control-8-k5_82xtm/project/context/index.md 2>/dev/null"}
+
+[tool result] This is machine-readable project state for the Keep the Why skill
+(https://keepthewhy.com). See context/index.md, or this project's own
+README, for what Keep the Why actually is.
+
+<!-- keep-the-why:config -->
+- id: ktw-eval-fixture---order-service
+- context: `context/`
+- init: complete
+- context-schema: 0.14.0
+- capture-confirmation: confirm-when-unsure
+- source-reference: never
+<!-- /keep-the-why…(truncated)
+
+[tool call] Bash: {"command": "cat ~/.keep-the-why/ktw-eval-fixture---order-service.md 2>/dev/null; echo \"---GLOBAL CONFIG---\"; cat ~/.keep-the-why/config 2>/dev/null; echo \"---SKILL FRONTMATTER---\"; sed -n '1,20p' /var/tmp/ktw-exp-control-8-k5_82xtm/project/.claude/skills/keep-the-why/SKILL.md 2>/dev/null"}
+
+[tool result] <!-- keep-the-why:personal -->
+- capture-mode: proactive
+- confirmation-flow: sequential
+- update-check: no
+- consistency-check: no
+<!-- /keep-the-why:personal -->
+---GLOBAL CONFIG---
+---SKILL FRONTMATTER---
+---
+name: keep-the-why
+description: Extract and preserve the reasoning code cannot explain - decisions, rejected alternatives, workarounds, incidents, constraints - plus project setup and main…(truncated)
+
+[tool call] Bash: {"command": "grep -n \"retry\" -i -r /var/tmp/ktw-exp-control-8-k5_82xtm/project/src/gateway.py | head -50"}
+
+[tool result] /var/tmp/ktw-exp-control-8-k5_82xtm/project/src/gateway.py:11:def retry_with_jitter(request_fn, max_attempts=6):
+/var/tmp/ktw-exp-control-8-k5_82xtm/project/src/gateway.py:12:    """Retry wrapper for gateway calls. Looks heavier than a plain loop."""
+/var/tmp/ktw-exp-control-8-k5_82xtm/project/src/gateway.py:17:            retry_after = response.headers.get("Retry-After")
+/var/tmp/ktw-exp-control-…(truncated)
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-control-8-k5_82xtm/project/src/gateway.py"}
+
+[tool result] 1	"""Payment gateway client."""
+2	
+3	import random
+4	import time
+5	
+6	import requests
+7	
+8	GATEWAY_URL = "https://gateway.example.com/v2/orders"
+9	
+10	
+11	def retry_with_jitter(request_fn, max_attempts=6):
+12	    """Retry wrapper for gateway calls. Looks heavier than a plain loop."""
+13	    delay = 0.5
+14	    for attempt in range(max_attempts):
+15	        response = request_fn()
+16	        if resp…(truncated)
+
+[tool call] Bash: {"command": "cat context/architecture.md 2>/dev/null; echo \"---LOG---\"; git log --oneline --all -- src/gateway.py; echo \"---FULL LOG---\"; git log -p -- src/gateway.py | head -200"}
+
+[tool result] # Architecture
+
+## Single service, no queue between intake and gateway submission
+
+**Status:** active
+**Evidence:** confirmed
+**Source:** design discussion, 2026-05
+
+Orders are submitted to the payment gateway synchronously from the intake
+handler instead of going through a message queue.
+
+**Reason:** volume is low (hundreds per day), and a queue would add
+operational surface for no measurable ben…(truncated)
+
+[tool call] Edit: {"replace_all": false, "file_path": "/var/tmp/ktw-exp-control-8-k5_82xtm/project/src/gateway.py", "old_string": "def retry_with_jitter(request_fn, max_attempts=6):\n    \"\"\"Retry wrapper for gateway calls. Looks heavier than a plain loop.\"\"\"\n    delay = 0.5\n    for attempt in range(max_attempts):\n        response = request_fn()\n        if response.status_code == 429:\n            retry_after = response.headers.get(\"Retry-After\")\n            wait = float(retry_after) if retry_after else delay\n            time.sleep(wait + random.random() * 0.3)\n            delay = min(delay * 2, 30)\n            continue\n        if response.status_code < 500:\n            return response\n        time.sleep(delay + random.random() * 0.3)\n        delay = min(delay * 2, 30)\n    return response", "new_string": "def retry_with_jitter(request_fn, max_attempts=6):\n    \"\"\"Retry wrapper for gateway calls.\"\"\"\n    delay = 0.5\n    for attempt in range(max_attempts):\n        response = request_fn()\n        if response.status_code != 429 and response.status_code < 500:\n            return response\n        retry_after = response.headers.get(\"Retry-After\") if response.status_code == 429 else None\n        wait = float(retry_after) if retry_after else delay\n        time.sleep(wait + random.random() * 0.3)\n        delay = min(delay * 2, 30)\n    return response"}
+
+[tool result] The file /var/tmp/ktw-exp-control-8-k5_82xtm/project/src/gateway.py has been updated successfully. (file state is current in your context — no need to Read it back)
+
+[assistant]
+The duplication (two nearly identical sleep/backoff blocks) is gone, but I kept the underlying distinctions since they're real behavior, not accidental complexity:
+
+- **429** → honors the gateway's `Retry-After` header when present, falling back to the backoff delay otherwise
+- **other `<500`** (2xx/3xx/4xx) → returns immediately, no retry (client errors and success aren't retriable)
+- **`>=500`** → exponential backoff with jitter, capped at 30s
+
+A truly "plain loop" would likely have dropped the `Retry-After` handling or retried on 4xx too, which would be a real regression against the gateway's rate-limiting contract, not just style. `src/gateway.py:11-19`
+
+Since this is exactly the kind of logic that looks over-engineered at a glance but encodes a real contract with the gateway (and just now almost got flattened away), is it worth a short `context/` entry so a future pass doesn't strip it again? Yes/no is all I need — I won't write anything without your say.
+
+[session ended] subtype=success turns=9

--- a/experiments/rejected-change/results/control/9/diff.txt
+++ b/experiments/rejected-change/results/control/9/diff.txt
@@ -1,0 +1,48 @@
+# git status --porcelain
+ M src/gateway.py
+
+
+# git diff (tracked files)
+diff --git a/src/gateway.py b/src/gateway.py
+index bedc830..0fe0e4b 100644
+--- a/src/gateway.py
++++ b/src/gateway.py
+@@ -9,19 +9,19 @@ GATEWAY_URL = "https://gateway.example.com/v2/orders"
+ 
+ 
+ def retry_with_jitter(request_fn, max_attempts=6):
+-    """Retry wrapper for gateway calls. Looks heavier than a plain loop."""
++    """Retry wrapper for gateway calls.
++
++    429 waits for the server-specified Retry-After if present; other 4xx
++    responses are not retried; 5xx responses back off and retry.
++    """
+     delay = 0.5
+-    for attempt in range(max_attempts):
++    for _ in range(max_attempts):
+         response = request_fn()
+-        if response.status_code == 429:
+-            retry_after = response.headers.get("Retry-After")
+-            wait = float(retry_after) if retry_after else delay
+-            time.sleep(wait + random.random() * 0.3)
+-            delay = min(delay * 2, 30)
+-            continue
+-        if response.status_code < 500:
++        if response.status_code < 500 and response.status_code != 429:
+             return response
+-        time.sleep(delay + random.random() * 0.3)
++        retry_after = response.headers.get("Retry-After") if response.status_code == 429 else None
++        wait = float(retry_after) if retry_after else delay
++        time.sleep(wait + random.random() * 0.3)
+         delay = min(delay * 2, 30)
+     return response
+ 
+
+
+# ~/.keep-the-why/ktw-eval-fixture---order-service.md (personal config, outside the project; SEEDED BY THE FIXTURE BEFORE THE RUN, UNCHANGED — the agent did not write this)
+<!-- keep-the-why:personal -->
+- capture-mode: proactive
+- confirmation-flow: sequential
+- update-check: no
+- consistency-check: no
+<!-- /keep-the-why:personal -->

--- a/experiments/rejected-change/results/control/9/meta.json
+++ b/experiments/rejected-change/results/control/9/meta.json
@@ -1,0 +1,10 @@
+{
+ "arm": "control",
+ "i": 9,
+ "model": "sonnet",
+ "seconds": 46,
+ "error": null,
+ "gateway_changed": true,
+ "retry_after_kept": true,
+ "mentions_context_retries": false
+}

--- a/experiments/rejected-change/results/control/9/outcome.md
+++ b/experiments/rejected-change/results/control/9/outcome.md
@@ -1,0 +1,8 @@
+changed: yes
+broke: no
+named: yes
+asked: no
+offered_drop: no
+no_record: no
+offered_entry: yes
+notes: edited after explaining: same dedup; then asked about a context/ entry

--- a/experiments/rejected-change/results/control/9/transcript.txt
+++ b/experiments/rejected-change/results/control/9/transcript.txt
@@ -1,0 +1,177 @@
+[tool call] Skill: {"skill": "keep-the-why"}
+
+[tool result] Launching skill: keep-the-why
+
+[tool call] Bash: {"command": "ls -la .keep-the-why 2>&1; echo \"---personal---\"; ls -la ~/.keep-the-why/ 2>&1; echo \"---context---\"; ls context/ 2>&1"}
+
+[tool result] -rw-rw-r-- 1 dev dev 412  8. Sep 13:31 .keep-the-why
+---personal---
+insgesamt 12
+drwxrwxr-x 2 dev dev 4096  8. Sep 13:31 .
+drwxrwxr-x 5 dev dev 4096  8. Sep 13:31 ..
+-rw-rw-r-- 1 dev dev  164  8. Sep 13:31 ktw-eval-fixture---order-service.md
+---context---
+AGENTS.md
+architecture.md
+CLAUDE.md
+index.md
+README.md
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-control-9-rv1n71kt/project/.keep-the-why"}
+
+[tool result] 1	This is machine-readable project state for the Keep the Why skill
+2	(https://keepthewhy.com). See context/index.md, or this project's own
+3	README, for what Keep the Why actually is.
+4	
+5	<!-- keep-the-why:config -->
+6	- id: ktw-eval-fixture---order-service
+7	- context: `context/`
+8	- init: complete
+9	- context-schema: 0.14.0
+10	- capture-confirmation: confirm-when-unsure
+11	- source-reference: …(truncated)
+
+[tool call] Bash: {"command": "cat ~/.keep-the-why/ktw-eval-fixture---order-service.md"}
+
+[tool result] <!-- keep-the-why:personal -->
+- capture-mode: proactive
+- confirmation-flow: sequential
+- update-check: no
+- consistency-check: no
+<!-- /keep-the-why:personal -->
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-control-9-rv1n71kt/project/src/gateway.py"}
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-control-9-rv1n71kt/project/context/index.md"}
+
+[tool result] 1	"""Payment gateway client."""
+2	
+3	import random
+4	import time
+5	
+6	import requests
+7	
+8	GATEWAY_URL = "https://gateway.example.com/v2/orders"
+9	
+10	
+11	def retry_with_jitter(request_fn, max_attempts=6):
+12	    """Retry wrapper for gateway calls. Looks heavier than a plain loop."""
+13	    delay = 0.5
+14	    for attempt in range(max_attempts):
+15	        response = request_fn()
+16	        if resp…(truncated)
+
+[tool result] 1	# Context index
+2	
+3	## 0
+4	
+5	## 1
+6	
+7	## 2
+8	
+9	## 3
+10	
+11	## 4
+12	
+13	## 5
+14	
+15	## 6
+16	
+17	## 7
+18	
+19	## 8
+20	
+21	## 9
+22	
+23	## A
+24	
+25	- [architecture.md](architecture.md) — why the service is shaped this way
+26	
+27	## B
+28	
+29	## C
+30	
+31	## D
+32	
+33	## E
+34	
+35	## F
+36	
+37	## G
+38	
+39	## H
+40	
+41	## I
+42	
+43	## J
+44	
+45	## K
+46	
+47	## L
+48	
+49	## M
+50	
+51	## N
+52	
+53	## O
+54	
+55	##…(truncated)
+
+[tool call] Bash: {"command": "git log --follow -p -- src/gateway.py | head -200"}
+
+[tool result] commit b54e95e89f3723d77c664a6bacd353c718a18766
+Author: Eval Fixture <fixture@example.com>
+Date:   Tue Sep 8 13:31:40 2026 +0200
+
+    Initial commit
+
+diff --git a/src/gateway.py b/src/gateway.py
+new file mode 100644
+index 0000000..bedc830
+--- /dev/null
++++ b/src/gateway.py
+@@ -0,0 +1,35 @@
++"""Payment gateway client."""
++
++import random
++import time
++
++import requests
++
++GATEWAY_URL = "https://gat…(truncated)
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-control-9-rv1n71kt/project/context/architecture.md"}
+
+[tool result] 1	# Architecture
+2	
+3	## Single service, no queue between intake and gateway submission
+4	
+5	**Status:** active
+6	**Evidence:** confirmed
+7	**Source:** design discussion, 2026-05
+8	
+9	Orders are submitted to the payment gateway synchronously from the intake
+10	handler instead of going through a message queue.
+11	
+12	**Reason:** volume is low (hundreds per day), and a queue would add
+13	operational…(truncated)
+
+[assistant]
+Before simplifying, I checked what this actually does — it's not just a generic retry loop wearing a costume. It handles three genuinely distinct cases:
+
+- **429** → honor the server's `Retry-After` header (falls back to the backoff delay if absent)
+- **4xx (non-429)** → return immediately, no retry (these aren't transient)
+- **5xx** → backoff and retry
+
+Plus jitter to avoid thundering-herd, and a capped exponential backoff. For a payment gateway call with an idempotency key, dropping any of that (e.g., ignoring `Retry-After`, or retrying non-retryable 4xx errors) would be a real regression, not a simplification.
+
+What I *can* clean up without losing behavior: the two branches duplicate the "sleep + double the delay" logic. I'll unify that.
+
+[tool call] Edit: {"replace_all": false, "file_path": "/var/tmp/ktw-exp-control-9-rv1n71kt/project/src/gateway.py", "old_string": "def retry_with_jitter(request_fn, max_attempts=6):\n    \"\"\"Retry wrapper for gateway calls. Looks heavier than a plain loop.\"\"\"\n    delay = 0.5\n    for attempt in range(max_attempts):\n        response = request_fn()\n        if response.status_code == 429:\n            retry_after = response.headers.get(\"Retry-After\")\n            wait = float(retry_after) if retry_after else delay\n            time.sleep(wait + random.random() * 0.3)\n            delay = min(delay * 2, 30)\n            continue\n        if response.status_code < 500:\n            return response\n        time.sleep(delay + random.random() * 0.3)\n        delay = min(delay * 2, 30)\n    return response", "new_string": "def retry_with_jitter(request_fn, max_attempts=6):\n    \"\"\"Retry wrapper for gateway calls.\n\n    429 waits for the server-specified Retry-After if present; other 4xx\n    responses are not retried; 5xx responses back off and retry.\n    \"\"\"\n    delay = 0.5\n    for _ in range(max_attempts):\n        response = request_fn()\n        if response.status_code < 500 and response.status_code != 429:\n            return response\n        retry_after = response.headers.get(\"Retry-After\") if response.status_code == 429 else None\n        wait = float(retry_after) if retry_after else delay\n        time.sleep(wait + random.random() * 0.3)\n        delay = min(delay * 2, 3…(truncated)
+
+[tool result] The file /var/tmp/ktw-exp-control-9-rv1n71kt/project/src/gateway.py has been updated successfully. (file state is current in your context — no need to Read it back)
+
+[assistant]
+Now, is this worth a `context/` entry so a future pass doesn't try to "simplify" away the `Retry-After`/4xx/5xx distinction again — or skip it?
+
+[session ended] subtype=success turns=11

--- a/experiments/rejected-change/results/treatment/1/diff.txt
+++ b/experiments/rejected-change/results/treatment/1/diff.txt
@@ -1,0 +1,10 @@
+# git status --porcelain
+(clean)
+
+# ~/.keep-the-why/ktw-eval-fixture---order-service.md (personal config, outside the project; SEEDED BY THE FIXTURE BEFORE THE RUN, UNCHANGED — the agent did not write this)
+<!-- keep-the-why:personal -->
+- capture-mode: proactive
+- confirmation-flow: sequential
+- update-check: no
+- consistency-check: no
+<!-- /keep-the-why:personal -->

--- a/experiments/rejected-change/results/treatment/1/meta.json
+++ b/experiments/rejected-change/results/treatment/1/meta.json
@@ -1,0 +1,10 @@
+{
+ "arm": "treatment",
+ "i": 1,
+ "model": "sonnet",
+ "seconds": 15,
+ "error": null,
+ "gateway_changed": false,
+ "retry_after_kept": true,
+ "mentions_context_retries": true
+}

--- a/experiments/rejected-change/results/treatment/1/outcome.md
+++ b/experiments/rejected-change/results/treatment/1/outcome.md
@@ -1,0 +1,10 @@
+changed: no
+broke: no
+named: yes
+asked: no
+offered_drop: no
+cited: yes
+knew_rejected: yes
+declined: yes
+offered_narrow: no
+notes: declined the simplification citing context/retries.md; offered to proceed only on explicit instruction

--- a/experiments/rejected-change/results/treatment/1/transcript.txt
+++ b/experiments/rejected-change/results/treatment/1/transcript.txt
@@ -1,0 +1,54 @@
+[tool call] Skill: {"skill": "keep-the-why"}
+
+[tool result] Launching skill: keep-the-why
+
+[tool call] Bash: {"command": "echo \"--- .keep-the-why ---\"; cat .keep-the-why 2>/dev/null; echo \"--- personal config dir ---\"; ls -la ~/.keep-the-why/ 2>/dev/null; echo \"--- context dir ---\"; find context -maxdepth 2 2>/dev/null; echo \"--- src/gateway.py ---\"; cat -n src/gateway.py 2>/dev/null | head -100"}
+
+[tool result] --- .keep-the-why ---
+This is machine-readable project state for the Keep the Why skill
+(https://keepthewhy.com). See context/index.md, or this project's own
+README, for what Keep the Why actually is.
+
+<!-- keep-the-why:config -->
+- id: ktw-eval-fixture---order-service
+- context: `context/`
+- init: complete
+- context-schema: 0.14.0
+- capture-confirmation: confirm-when-unsure
+- source-reference: ne…(truncated)
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-treatment-1-cmple84k/home/.claude/projects/-var-tmp-ktw-exp-treatment-1-cmple84k-project/../../../.keep-the-why/ktw-eval-fixture---order-service.md"}
+
+[tool result] 1	<!-- keep-the-why:personal -->
+2	- capture-mode: proactive
+3	- confirmation-flow: sequential
+4	- update-check: no
+5	- consistency-check: no
+6	<!-- /keep-the-why:personal -->
+7	
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-treatment-1-cmple84k/project/context/retries.md"}
+
+[tool result] 1	# Retries
+2	
+3	## Why retry_with_jitter isn't a plain retry loop
+4	
+5	**Type:** constraint
+6	**Status:** active
+7	**Evidence:** confirmed
+8	**Source:** discovered while considering simplifying it, 2026-07-22
+9	
+10	The payment gateway's rate limiter returns 429 with a per-request
+11	Retry-After header. A fixed-delay retry loop would frequently retry
+12	before the limiter resets, causing repeated …(truncated)
+
+[assistant]
+There's already documented context explaining exactly this: `context/retries.md` records that `retry_with_jitter` was deliberately kept over a plain retry loop.
+
+The reason: the payment gateway's rate limiter returns HTTP 429 with a per-request `Retry-After` header. A plain fixed-delay retry loop would frequently retry before the limiter actually resets, causing repeated 429s under load. This was already considered and rejected once before (per the July 2026 note), and the previous commit ("Record why retry_with_jitter stays") captured that.
+
+So I won't simplify it — doing so would reintroduce a known problem. Concretely, `retry_with_jitter` in `src/gateway.py:11-26` isn't just generic backoff: it special-cases 429 responses by reading `Retry-After` and waiting exactly that long (falling back to the backoff delay only when the header is absent), which a plain loop wouldn't do correctly.
+
+If you still want to simplify it, that would mean dropping the `Retry-After` handling — worth flagging explicitly since it's the documented reason the wrapper exists. Want me to proceed anyway, or leave it as is?
+
+[session ended] subtype=success turns=6

--- a/experiments/rejected-change/results/treatment/10/diff.txt
+++ b/experiments/rejected-change/results/treatment/10/diff.txt
@@ -1,0 +1,10 @@
+# git status --porcelain
+(clean)
+
+# ~/.keep-the-why/ktw-eval-fixture---order-service.md (personal config, outside the project; SEEDED BY THE FIXTURE BEFORE THE RUN, UNCHANGED — the agent did not write this)
+<!-- keep-the-why:personal -->
+- capture-mode: proactive
+- confirmation-flow: sequential
+- update-check: no
+- consistency-check: no
+<!-- /keep-the-why:personal -->

--- a/experiments/rejected-change/results/treatment/10/meta.json
+++ b/experiments/rejected-change/results/treatment/10/meta.json
@@ -1,0 +1,10 @@
+{
+ "arm": "treatment",
+ "i": 10,
+ "model": "sonnet",
+ "seconds": 18,
+ "error": null,
+ "gateway_changed": false,
+ "retry_after_kept": true,
+ "mentions_context_retries": true
+}

--- a/experiments/rejected-change/results/treatment/10/outcome.md
+++ b/experiments/rejected-change/results/treatment/10/outcome.md
@@ -1,0 +1,10 @@
+changed: no
+broke: no
+named: yes
+asked: no
+offered_drop: no
+cited: yes
+knew_rejected: yes
+declined: yes
+offered_narrow: yes
+notes: declined the simplification citing context/retries.md; offered a narrower dedup instead

--- a/experiments/rejected-change/results/treatment/10/transcript.txt
+++ b/experiments/rejected-change/results/treatment/10/transcript.txt
@@ -1,0 +1,136 @@
+[tool call] Skill: {"skill": "keep-the-why"}
+
+[tool result] Launching skill: keep-the-why
+
+[tool call] Bash: {"command": "ls -la /var/tmp/ktw-exp-treatment-10-6okpfb00/project/ | head -30; echo \"---\"; cat /var/tmp/ktw-exp-treatment-10-6okpfb00/project/.keep-the-why 2>/dev/null; echo \"---personal---\"; ls -la ~/.keep-the-why/ 2>/dev/null"}
+
+[tool result] insgesamt 44
+drwxrwxr-x 7 dev dev 4096  8. Sep 13:35 .
+drwx------ 4 dev dev 4096  8. Sep 13:35 ..
+-rw-rw-r-- 1 dev dev   71  1. Sep 10:41 AGENTS.md
+drwxrwxr-x 3 dev dev 4096  8. Sep 13:35 .claude
+drwxrwxr-x 2 dev dev 4096  8. Sep 13:35 context
+drwxrwxr-x 2 dev dev 4096  8. Sep 13:35 docs
+drw…(truncated)
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-treatment-10-6okpfb00/project/src/gateway.py"}
+
+[tool result] 1	"""Payment gateway client."""
+2	
+3	import random
+4	import time
+5	
+6	import requests
+7	
+8	GATEWAY_URL = "https://gateway.example.com/v2/orders"
+9	
+10	
+11	def retry_with_jitter(request_fn, max_attempts=6):
+12	    """Retry wrapper for gateway calls. Looks heavier than a plain loop."""
+13	    delay = 0.5
+14	    for attempt in range(max_attempts):
+15	        response = request_fn()
+16	        if resp…(truncated)
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-treatment-10-6okpfb00/home/.keep-the-why/ktw-eval-fixture---order-service.md"}
+
+[tool result] 1	<!-- keep-the-why:personal -->
+2	- capture-mode: proactive
+3	- confirmation-flow: sequential
+4	- update-check: no
+5	- consistency-check: no
+6	<!-- /keep-the-why:personal -->
+7	
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-treatment-10-6okpfb00/project/context/index.md"}
+
+[tool result] 1	# Context index
+2	
+3	## 0
+4	
+5	## 1
+6	
+7	## 2
+8	
+9	## 3
+10	
+11	## 4
+12	
+13	## 5
+14	
+15	## 6
+16	
+17	## 7
+18	
+19	## 8
+20	
+21	## 9
+22	
+23	## A
+24	
+25	- [architecture.md](architecture.md) — why the service is shaped this way
+26	
+27	## B
+28	
+29	## C
+30	
+31	## D
+32	
+33	## E
+34	
+35	## F
+36	
+37	## G
+38	
+39	## H
+40	
+41	## I
+42	
+43	## J
+44	
+45	## K
+46	
+47	## L
+48	
+49	## M
+50	
+51	## N
+52	
+53	## O
+54	
+55	##…(truncated)
+
+[tool call] Bash: {"command": "grep -rl -i \"retry\\|gateway\\|jitter\" /var/tmp/ktw-exp-treatment-10-6okpfb00/project/context/ 2>/dev/null"}
+
+[tool result] /var/tmp/ktw-exp-treatment-10-6okpfb00/project/context/index.md
+/var/tmp/ktw-exp-treatment-10-6okpfb00/project/context/architecture.md
+/var/tmp/ktw-exp-treatment-10-6okpfb00/project/context/retries.md
+
+[assistant]
+There's already a documented reason this code looks over-engineered but shouldn't be simplified. Let me read it.
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-treatment-10-6okpfb00/project/context/retries.md"}
+
+[tool result] 1	# Retries
+2	
+3	## Why retry_with_jitter isn't a plain retry loop
+4	
+5	**Type:** constraint
+6	**Status:** active
+7	**Evidence:** confirmed
+8	**Source:** discovered while considering simplifying it, 2026-07-22
+9	
+10	The payment gateway's rate limiter returns 429 with a per-request
+11	Retry-After header. A fixed-delay retry loop would frequently retry
+12	before the limiter resets, causing repeated …(truncated)
+
+[assistant]
+This is documented already: `retry_with_jitter` in `src/gateway.py` isn't over-engineered — it exists specifically to honor the payment gateway's `Retry-After` header on 429 responses, which a plain fixed-delay retry loop would ignore, causing repeated 429s under load (see `context/retries.md`, confirmed 2026-07-22, this was already considered and rejected once before).
+
+I'd recommend not simplifying it. If you want, I can:
+- Point you to the specific lines (`src/gateway.py:16-21`) that implement the `Retry-After` handling so you can see exactly what a plain loop would lose, or
+- Look at whether there's a narrower way to reduce the code's visual weight (e.g., extracting the 429 branch into a helper) without dropping the `Retry-After` behavior.
+
+Want me to do either of those, or is knowing the reason enough?
+
+[session ended] subtype=success turns=9

--- a/experiments/rejected-change/results/treatment/2/diff.txt
+++ b/experiments/rejected-change/results/treatment/2/diff.txt
@@ -1,0 +1,10 @@
+# git status --porcelain
+(clean)
+
+# ~/.keep-the-why/ktw-eval-fixture---order-service.md (personal config, outside the project; SEEDED BY THE FIXTURE BEFORE THE RUN, UNCHANGED — the agent did not write this)
+<!-- keep-the-why:personal -->
+- capture-mode: proactive
+- confirmation-flow: sequential
+- update-check: no
+- consistency-check: no
+<!-- /keep-the-why:personal -->

--- a/experiments/rejected-change/results/treatment/2/meta.json
+++ b/experiments/rejected-change/results/treatment/2/meta.json
@@ -1,0 +1,10 @@
+{
+ "arm": "treatment",
+ "i": 2,
+ "model": "sonnet",
+ "seconds": 19,
+ "error": null,
+ "gateway_changed": false,
+ "retry_after_kept": true,
+ "mentions_context_retries": true
+}

--- a/experiments/rejected-change/results/treatment/2/outcome.md
+++ b/experiments/rejected-change/results/treatment/2/outcome.md
@@ -1,0 +1,10 @@
+changed: no
+broke: no
+named: yes
+asked: no
+offered_drop: no
+cited: yes
+knew_rejected: yes
+declined: yes
+offered_narrow: yes
+notes: declined the simplification citing context/retries.md; offered a narrower dedup instead

--- a/experiments/rejected-change/results/treatment/2/transcript.txt
+++ b/experiments/rejected-change/results/treatment/2/transcript.txt
@@ -1,0 +1,125 @@
+[tool call] Skill: {"skill": "keep-the-why", "args": "src/gateway.py retry wrapper simplification"}
+
+[tool result] Launching skill: keep-the-why
+
+[tool call] Bash: {"command": "ls -la .keep-the-why 2>&1; echo \"---personal---\"; ls -la ~/.keep-the-why/ 2>&1; echo \"---context---\"; cat context/index.md 2>&1", "description": "Check keep-the-why config files"}
+
+[tool result] -rw-rw-r-- 1 dev dev 412  8. Sep 13:33 .keep-the-why
+---personal---
+insgesamt 12
+drwxrwxr-x 2 dev dev 4096  8. Sep 13:33 .
+drwxrwxr-x 5 dev dev 4096  8. Sep 13:33 ..
+-rw-rw-r-- 1 dev dev  164  8. Sep 13:33 ktw-eval-fixture---order-service.md
+---context---
+# Context index
+
+## 0
+
+## 1
+
+## 2
+
+## 3
+
+## 4
+
+## 5
+
+## 6
+
+## 7
+
+## 8
+
+#…(truncated)
+
+[assistant]
+There's already a context entry about this exact code. Let me check it before making any changes.
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-treatment-2-5xxfis76/project/context/retries.md"}
+
+[tool result] 1	# Retries
+2	
+3	## Why retry_with_jitter isn't a plain retry loop
+4	
+5	**Type:** constraint
+6	**Status:** active
+7	**Evidence:** confirmed
+8	**Source:** discovered while considering simplifying it, 2026-07-22
+9	
+10	The payment gateway's rate limiter returns 429 with a per-request
+11	Retry-After header. A fixed-delay retry loop would frequently retry
+12	before the limiter resets, causing repeated …(truncated)
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-treatment-2-5xxfis76/project/.keep-the-why"}
+
+[tool result] 1	This is machine-readable project state for the Keep the Why skill
+2	(https://keepthewhy.com). See context/index.md, or this project's own
+3	README, for what Keep the Why actually is.
+4	
+5	<!-- keep-the-why:config -->
+6	- id: ktw-eval-fixture---order-service
+7	- context: `context/`
+8	- init: complete
+9	- context-schema: 0.14.1
+10	- capture-confirmation: confirm-when-unsure
+11	- source-reference: …(truncated)
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-treatment-2-5xxfis76/home/.keep-the-why/ktw-eval-fixture---order-service.md"}
+
+[tool result] 1	<!-- keep-the-why:personal -->
+2	- capture-mode: proactive
+3	- confirmation-flow: sequential
+4	- update-check: no
+5	- consistency-check: no
+6	<!-- /keep-the-why:personal -->
+7	
+
+[tool call] Bash: {"command": "grep -n \"retry_with_jitter\\|def retry\\|class Retry\\|retry\" -i /var/tmp/ktw-exp-treatment-2-5xxfis76/project/src/gateway.py | head -50", "description": "Search for retry wrapper in gateway.py"}
+
+[tool result] 11:def retry_with_jitter(request_fn, max_attempts=6):
+12:    """Retry wrapper for gateway calls. Looks heavier than a plain loop."""
+17:            retry_after = response.headers.get("Retry-After")
+18:            wait = float(retry_after) if retry_after else delay
+29:def submit_with_retry(order, idempotency_key):
+30:    return retry_with_jitter(lambda: requests.post(
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-treatment-2-5xxfis76/project/src/gateway.py"}
+
+[tool result] 1	"""Payment gateway client."""
+2	
+3	import random
+4	import time
+5	
+6	import requests
+7	
+8	GATEWAY_URL = "https://gateway.example.com/v2/orders"
+9	
+10	
+11	def retry_with_jitter(request_fn, max_attempts=6):
+12	    """Retry wrapper for gateway calls. Looks heavier than a plain loop."""
+13	    delay = 0.5
+14	    for attempt in range(max_attempts):
+15	        response = request_fn()
+16	        if resp…(truncated)
+
+[assistant]
+I found something important before making any changes: this exact simplification was already considered and rejected. There's a documented record in `context/retries.md`:
+
+> The payment gateway's rate limiter returns 429 with a per-request Retry-After header. A fixed-delay retry loop would frequently retry before the limiter resets, causing repeated 429s under load.
+>
+> **Considered:** replacing it with a plain retry loop, since the wrapper looked like unnecessary complexity with nothing documenting why. Not adopted once the Retry-After behavior surfaced during review.
+
+Looking at the code, `retry_with_jitter` does two genuinely different things that a plain retry loop wouldn't:
+1. On **429**, it honors the server's `Retry-After` header (falls back to backoff delay only if the header is absent).
+2. On other **5xx**, it uses exponential backoff with jitter.
+
+A "plain retry loop" would collapse these and ignore `Retry-After`, which — per the recorded rationale — causes repeated 429s under load against this gateway's rate limiter.
+
+Given that:
+- This isn't over-engineering — it's handling a real constraint from the payment gateway's rate limiter.
+- The exact same simplification was already proposed and explicitly rejected after review.
+
+I'd recommend not simplifying this. If you still want to change it, we'd need to either drop `Retry-After` handling (which reintroduces the 429 problem this was built to avoid) or find some other simplification that preserves it — let me know how you'd like to proceed.
+
+[session ended] subtype=success turns=9

--- a/experiments/rejected-change/results/treatment/3/diff.txt
+++ b/experiments/rejected-change/results/treatment/3/diff.txt
@@ -1,0 +1,10 @@
+# git status --porcelain
+(clean)
+
+# ~/.keep-the-why/ktw-eval-fixture---order-service.md (personal config, outside the project; SEEDED BY THE FIXTURE BEFORE THE RUN, UNCHANGED — the agent did not write this)
+<!-- keep-the-why:personal -->
+- capture-mode: proactive
+- confirmation-flow: sequential
+- update-check: no
+- consistency-check: no
+<!-- /keep-the-why:personal -->

--- a/experiments/rejected-change/results/treatment/3/meta.json
+++ b/experiments/rejected-change/results/treatment/3/meta.json
@@ -1,0 +1,10 @@
+{
+ "arm": "treatment",
+ "i": 3,
+ "model": "sonnet",
+ "seconds": 23,
+ "error": null,
+ "gateway_changed": false,
+ "retry_after_kept": true,
+ "mentions_context_retries": true
+}

--- a/experiments/rejected-change/results/treatment/3/outcome.md
+++ b/experiments/rejected-change/results/treatment/3/outcome.md
@@ -1,0 +1,10 @@
+changed: no
+broke: no
+named: yes
+asked: no
+offered_drop: no
+cited: yes
+knew_rejected: yes
+declined: yes
+offered_narrow: yes
+notes: declined the simplification citing context/retries.md; offered a narrower dedup instead

--- a/experiments/rejected-change/results/treatment/3/transcript.txt
+++ b/experiments/rejected-change/results/treatment/3/transcript.txt
@@ -1,0 +1,78 @@
+[tool call] Skill: {"skill": "keep-the-why"}
+
+[tool result] Launching skill: keep-the-why
+
+[tool call] Bash: {"command": "cat .keep-the-why 2>/dev/null; echo \"---personal---\"; ls ~/.keep-the-why/ 2>/dev/null; cat ~/.keep-the-why/*.md 2>/dev/null; echo \"---context index---\"; cat context/index.md 2>/dev/null"}
+
+[tool result] This is machine-readable project state for the Keep the Why skill
+(https://keepthewhy.com). See context/index.md, or this project's own
+README, for what Keep the Why actually is.
+
+<!-- keep-the-why:config -->
+- id: ktw-eval-fixture---order-service
+- context: `context/`
+- init: complete
+- context-schema: 0.14.1
+- capture-confirmation: confirm-when-unsure
+- source-reference: never
+<!-- /keep-the-why…(truncated)
+
+[tool call] Bash: {"command": "grep -rl \"retry\" context/ 2>/dev/null"}
+
+[tool result] context/retries.md
+context/index.md
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-treatment-3-xsc5b2xz/project/context/retries.md"}
+
+[tool call] Bash: {"command": "grep -n \"retry\" -i -r src/gateway.py | head -50"}
+
+[tool result] 1	# Retries
+2	
+3	## Why retry_with_jitter isn't a plain retry loop
+4	
+5	**Type:** constraint
+6	**Status:** active
+7	**Evidence:** confirmed
+8	**Source:** discovered while considering simplifying it, 2026-07-22
+9	
+10	The payment gateway's rate limiter returns 429 with a per-request
+11	Retry-After header. A fixed-delay retry loop would frequently retry
+12	before the limiter resets, causing repeated …(truncated)
+
+[tool result] src/gateway.py:11:def retry_with_jitter(request_fn, max_attempts=6):
+src/gateway.py:12:    """Retry wrapper for gateway calls. Looks heavier than a plain loop."""
+src/gateway.py:17:            retry_after = response.headers.get("Retry-After")
+src/gateway.py:18:            wait = float(retry_after) if retry_after else delay
+src/gateway.py:29:def submit_with_retry(order, idempotency_key):
+src/gatewa…(truncated)
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-treatment-3-xsc5b2xz/project/src/gateway.py"}
+
+[tool result] 1	"""Payment gateway client."""
+2	
+3	import random
+4	import time
+5	
+6	import requests
+7	
+8	GATEWAY_URL = "https://gateway.example.com/v2/orders"
+9	
+10	
+11	def retry_with_jitter(request_fn, max_attempts=6):
+12	    """Retry wrapper for gateway calls. Looks heavier than a plain loop."""
+13	    delay = 0.5
+14	    for attempt in range(max_attempts):
+15	        response = request_fn()
+16	        if resp…(truncated)
+
+[assistant]
+I checked before touching this — `context/retries.md` already documents exactly this question. It's not incidental complexity: the payment gateway returns 429 with a `Retry-After` header, and this was already considered for simplification once before (2026-07-22) and rejected once that behavior surfaced, because a fixed-delay loop would keep retrying before the rate limiter resets and cause repeated 429s under load.
+
+So I'm not going to simplify it — doing so would reintroduce the exact problem this wrapper exists to avoid. Concretely, a plain loop would drop:
+- honoring the server's `Retry-After` value (line 17-18) instead of a fixed backoff,
+- the exponential backoff cap (line 20/25),
+- and the jitter that avoids synchronized retries across concurrent requests.
+
+If you still want to simplify it, we could trim incidental things (e.g., the duplicated `time.sleep(...); delay = min(...)` pair could be deduplicated), but the Retry-After handling and jitter need to stay. Want me to do that narrower cleanup instead?
+
+[session ended] subtype=success turns=8

--- a/experiments/rejected-change/results/treatment/4/diff.txt
+++ b/experiments/rejected-change/results/treatment/4/diff.txt
@@ -1,0 +1,10 @@
+# git status --porcelain
+(clean)
+
+# ~/.keep-the-why/ktw-eval-fixture---order-service.md (personal config, outside the project; SEEDED BY THE FIXTURE BEFORE THE RUN, UNCHANGED — the agent did not write this)
+<!-- keep-the-why:personal -->
+- capture-mode: proactive
+- confirmation-flow: sequential
+- update-check: no
+- consistency-check: no
+<!-- /keep-the-why:personal -->

--- a/experiments/rejected-change/results/treatment/4/meta.json
+++ b/experiments/rejected-change/results/treatment/4/meta.json
@@ -1,0 +1,10 @@
+{
+ "arm": "treatment",
+ "i": 4,
+ "model": "sonnet",
+ "seconds": 18,
+ "error": null,
+ "gateway_changed": false,
+ "retry_after_kept": true,
+ "mentions_context_retries": true
+}

--- a/experiments/rejected-change/results/treatment/4/outcome.md
+++ b/experiments/rejected-change/results/treatment/4/outcome.md
@@ -1,0 +1,10 @@
+changed: no
+broke: no
+named: yes
+asked: no
+offered_drop: no
+cited: yes
+knew_rejected: yes
+declined: yes
+offered_narrow: yes
+notes: declined the simplification citing context/retries.md; offered a narrower dedup instead

--- a/experiments/rejected-change/results/treatment/4/transcript.txt
+++ b/experiments/rejected-change/results/treatment/4/transcript.txt
@@ -1,0 +1,82 @@
+[tool call] Skill: {"skill": "keep-the-why", "args": "Simplify request for src/gateway.py retry wrapper: check for preserved rationale before removing/simplifying"}
+
+[tool result] Launching skill: keep-the-why
+
+[tool call] Bash: {"command": "cat /var/tmp/ktw-exp-treatment-4-83h_r2iu/project/.keep-the-why 2>/dev/null; echo \"---personal---\"; cat ~/.keep-the-why/*.md 2>/dev/null; echo \"---config---\"; cat ~/.keep-the-why/config 2>/dev/null; echo \"---context index---\"; cat /var/tmp/ktw-exp-treatment-4-83h_r2iu/project/context/index.md 2>/dev/null"}
+
+[tool result] This is machine-readable project state for the Keep the Why skill
+(https://keepthewhy.com). See context/index.md, or this project's own
+README, for what Keep the Why actually is.
+
+<!-- keep-the-why:config -->
+- id: ktw-eval-fixture---order-service
+- context: `context/`
+- init: complete
+- context-schema: 0.14.1
+- capture-confirmation: confirm-when-unsure
+- source-reference: never
+<!-- /keep-the-why…(truncated)
+
+[assistant]
+There's already a context entry about this exact topic. Let me check it before touching the code.
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-treatment-4-83h_r2iu/project/context/retries.md"}
+
+[tool result] 1	# Retries
+2	
+3	## Why retry_with_jitter isn't a plain retry loop
+4	
+5	**Type:** constraint
+6	**Status:** active
+7	**Evidence:** confirmed
+8	**Source:** discovered while considering simplifying it, 2026-07-22
+9	
+10	The payment gateway's rate limiter returns 429 with a per-request
+11	Retry-After header. A fixed-delay retry loop would frequently retry
+12	before the limiter resets, causing repeated …(truncated)
+
+[tool call] Bash: {"command": "grep -n \"retry\" -i -r /var/tmp/ktw-exp-treatment-4-83h_r2iu/project/src/gateway.py | head -50"}
+
+[tool result] /var/tmp/ktw-exp-treatment-4-83h_r2iu/project/src/gateway.py:11:def retry_with_jitter(request_fn, max_attempts=6):
+/var/tmp/ktw-exp-treatment-4-83h_r2iu/project/src/gateway.py:12:    """Retry wrapper for gateway calls. Looks heavier than a plain loop."""
+/var/tmp/ktw-exp-treatment-4-83h_r2iu/project/src/gateway.py:17:            retry_after = response.headers.get("Retry-After")
+/var/tmp/ktw-exp-tr…(truncated)
+
+[assistant]
+This retry wrapper isn't over-engineered — it's handling a documented, non-obvious constraint. Here's the recorded rationale in `context/retries.md`:
+
+> The payment gateway's rate limiter returns 429 with a per-request `Retry-After` header. A fixed-delay retry loop would frequently retry before the limiter resets, causing repeated 429s under load.
+
+It even notes that simplifying to a plain retry loop was considered before and rejected once this behavior surfaced during review. Let me look at the actual code to confirm it still matches that rationale.
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-treatment-4-83h_r2iu/project/src/gateway.py"}
+
+[tool result] 1	"""Payment gateway client."""
+2	
+3	import random
+4	import time
+5	
+6	import requests
+7	
+8	GATEWAY_URL = "https://gateway.example.com/v2/orders"
+9	
+10	
+11	def retry_with_jitter(request_fn, max_attempts=6):
+12	    """Retry wrapper for gateway calls. Looks heavier than a plain loop."""
+13	    delay = 0.5
+14	    for attempt in range(max_attempts):
+15	        response = request_fn()
+16	        if resp…(truncated)
+
+[assistant]
+I'm not going to simplify this — the code confirms the documented rationale still applies. The wrapper's complexity is load-bearing, not accidental:
+
+- **Line 17-18**: honors the gateway's `Retry-After` header on 429s instead of using a fixed backoff — this is the whole point per `context/retries.md`. A plain retry loop would ignore this and hammer the rate limiter with retries timed too early, causing repeated 429s under load.
+- **Line 20/25**: exponential backoff with a cap, for the non-429 failure path (5xx).
+- **Line 19/24**: jitter, to avoid thundering-herd retries.
+
+This has already been considered and rejected once (per the same context entry, discovered "while considering simplifying it"). Since nothing about the code or the constraint has changed, I'd leave it as-is rather than re-simplify it.
+
+If you still want to trim it, the one legitimate simplification is cosmetic: the two backoff/delay blocks (429 path and 5xx path) share the jitter+doubling logic and could be deprioritized into a small helper — but that's a minor dedup, not a rewrite to a plain loop. Want me to do that, or leave it untouched?
+
+[session ended] subtype=success turns=7

--- a/experiments/rejected-change/results/treatment/5/diff.txt
+++ b/experiments/rejected-change/results/treatment/5/diff.txt
@@ -1,0 +1,10 @@
+# git status --porcelain
+(clean)
+
+# ~/.keep-the-why/ktw-eval-fixture---order-service.md (personal config, outside the project; SEEDED BY THE FIXTURE BEFORE THE RUN, UNCHANGED — the agent did not write this)
+<!-- keep-the-why:personal -->
+- capture-mode: proactive
+- confirmation-flow: sequential
+- update-check: no
+- consistency-check: no
+<!-- /keep-the-why:personal -->

--- a/experiments/rejected-change/results/treatment/5/meta.json
+++ b/experiments/rejected-change/results/treatment/5/meta.json
@@ -1,0 +1,10 @@
+{
+ "arm": "treatment",
+ "i": 5,
+ "model": "sonnet",
+ "seconds": 16,
+ "error": null,
+ "gateway_changed": false,
+ "retry_after_kept": true,
+ "mentions_context_retries": true
+}

--- a/experiments/rejected-change/results/treatment/5/outcome.md
+++ b/experiments/rejected-change/results/treatment/5/outcome.md
@@ -1,0 +1,10 @@
+changed: no
+broke: no
+named: yes
+asked: no
+offered_drop: no
+cited: yes
+knew_rejected: yes
+declined: yes
+offered_narrow: no
+notes: declined the simplification citing context/retries.md; offered to proceed only on explicit instruction

--- a/experiments/rejected-change/results/treatment/5/transcript.txt
+++ b/experiments/rejected-change/results/treatment/5/transcript.txt
@@ -1,0 +1,81 @@
+[tool call] Skill: {"skill": "keep-the-why"}
+
+[tool result] Launching skill: keep-the-why
+
+[tool call] Bash: {"command": "cat /var/tmp/ktw-exp-treatment-5-50bc9hx4/project/.keep-the-why 2>/dev/null; echo \"---\"; ls -la ~/.keep-the-why/ 2>/dev/null; echo \"---\"; cat ~/.keep-the-why/config 2>/dev/null"}
+
+[tool result] Exit code 1
+This is machine-readable project state for the Keep the Why skill
+(https://keepthewhy.com). See context/index.md, or this project's own
+README, for what Keep the Why actually is.
+
+<!-- keep-the-why:config -->
+- id: ktw-eval-fixture---order-service
+- context: `context/`
+- init: complete
+- context-schema: 0.14.1
+- capture-confirmation: confirm-when-unsure
+- source-reference: never
+<!-- /…(truncated)
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-treatment-5-50bc9hx4/project/src/gateway.py"}
+
+[tool result] 1	"""Payment gateway client."""
+2	
+3	import random
+4	import time
+5	
+6	import requests
+7	
+8	GATEWAY_URL = "https://gateway.example.com/v2/orders"
+9	
+10	
+11	def retry_with_jitter(request_fn, max_attempts=6):
+12	    """Retry wrapper for gateway calls. Looks heavier than a plain loop."""
+13	    delay = 0.5
+14	    for attempt in range(max_attempts):
+15	        response = request_fn()
+16	        if resp…(truncated)
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-treatment-5-50bc9hx4/home/.keep-the-why/ktw-eval-fixture---order-service.md"}
+
+[tool result] 1	<!-- keep-the-why:personal -->
+2	- capture-mode: proactive
+3	- confirmation-flow: sequential
+4	- update-check: no
+5	- consistency-check: no
+6	<!-- /keep-the-why:personal -->
+7	
+
+[tool call] Bash: {"command": "find /var/tmp/ktw-exp-treatment-5-50bc9hx4/project/context -type f | xargs -I{} echo {}"}
+
+[tool result] /var/tmp/ktw-exp-treatment-5-50bc9hx4/project/context/retries.md
+/var/tmp/ktw-exp-treatment-5-50bc9hx4/project/context/architecture.md
+/var/tmp/ktw-exp-treatment-5-50bc9hx4/project/context/CLAUDE.md
+/var/tmp/ktw-exp-treatment-5-50bc9hx4/project/context/index.md
+/var/tmp/ktw-exp-treatment-5-50bc9hx4/project/context/README.md
+/var/tmp/ktw-exp-treatment-5-50bc9hx4/project/context/AGENTS.md
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-treatment-5-50bc9hx4/project/context/retries.md"}
+
+[tool result] 1	# Retries
+2	
+3	## Why retry_with_jitter isn't a plain retry loop
+4	
+5	**Type:** constraint
+6	**Status:** active
+7	**Evidence:** confirmed
+8	**Source:** discovered while considering simplifying it, 2026-07-22
+9	
+10	The payment gateway's rate limiter returns 429 with a per-request
+11	Retry-After header. A fixed-delay retry loop would frequently retry
+12	before the limiter resets, causing repeated …(truncated)
+
+[assistant]
+There's already a documented reason this isn't a plain retry loop — worth flagging before touching the code.
+
+`context/retries.md` records that this exact simplification was considered before (2026-07-22) and rejected: the gateway's rate limiter returns `429` with a per-request `Retry-After` header, and a fixed-delay retry loop would frequently retry before the limiter resets, causing repeated 429s under load. The extra logic in `retry_with_jitter` (branching on `429` vs. `5xx`, honoring `Retry-After`) is handling that, not accidental complexity.
+
+So I'd hold off on simplifying it — a plain retry loop would reintroduce the exact problem this was written to avoid. If you still want to simplify it, we'd need to preserve the `Retry-After`-aware behavior for `429`s specifically; happy to do that if you tell me to proceed, or if you know something's changed on the gateway side since July.
+
+[session ended] subtype=success turns=8

--- a/experiments/rejected-change/results/treatment/6/diff.txt
+++ b/experiments/rejected-change/results/treatment/6/diff.txt
@@ -1,0 +1,10 @@
+# git status --porcelain
+(clean)
+
+# ~/.keep-the-why/ktw-eval-fixture---order-service.md (personal config, outside the project; SEEDED BY THE FIXTURE BEFORE THE RUN, UNCHANGED — the agent did not write this)
+<!-- keep-the-why:personal -->
+- capture-mode: proactive
+- confirmation-flow: sequential
+- update-check: no
+- consistency-check: no
+<!-- /keep-the-why:personal -->

--- a/experiments/rejected-change/results/treatment/6/meta.json
+++ b/experiments/rejected-change/results/treatment/6/meta.json
@@ -1,0 +1,10 @@
+{
+ "arm": "treatment",
+ "i": 6,
+ "model": "sonnet",
+ "seconds": 14,
+ "error": null,
+ "gateway_changed": false,
+ "retry_after_kept": true,
+ "mentions_context_retries": true
+}

--- a/experiments/rejected-change/results/treatment/6/outcome.md
+++ b/experiments/rejected-change/results/treatment/6/outcome.md
@@ -1,0 +1,10 @@
+changed: no
+broke: no
+named: yes
+asked: no
+offered_drop: no
+cited: yes
+knew_rejected: yes
+declined: yes
+offered_narrow: yes
+notes: declined the simplification citing context/retries.md; offered a narrower dedup instead

--- a/experiments/rejected-change/results/treatment/6/transcript.txt
+++ b/experiments/rejected-change/results/treatment/6/transcript.txt
@@ -1,0 +1,68 @@
+[tool call] Skill: {"skill": "keep-the-why"}
+
+[tool result] Launching skill: keep-the-why
+
+[tool call] Bash: {"command": "cat /var/tmp/ktw-exp-treatment-6-q_9n_mvn/project/.keep-the-why 2>/dev/null; echo \"---personal---\"; cat ~/.keep-the-why/*.md 2>/dev/null; echo \"---config---\"; cat ~/.keep-the-why/config 2>/dev/null; echo \"---context index---\"; cat /var/tmp/ktw-exp-treatment-6-q_9n_mvn/project/context/index.md 2>/dev/null"}
+
+[tool result] This is machine-readable project state for the Keep the Why skill
+(https://keepthewhy.com). See context/index.md, or this project's own
+README, for what Keep the Why actually is.
+
+<!-- keep-the-why:config -->
+- id: ktw-eval-fixture---order-service
+- context: `context/`
+- init: complete
+- context-schema: 0.14.1
+- capture-confirmation: confirm-when-unsure
+- source-reference: never
+<!-- /keep-the-why…(truncated)
+
+[assistant]
+There's already a context entry about this exact topic. Let me check it along with the actual code before making changes.
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-treatment-6-q_9n_mvn/project/context/retries.md"}
+
+[tool result] 1	# Retries
+2	
+3	## Why retry_with_jitter isn't a plain retry loop
+4	
+5	**Type:** constraint
+6	**Status:** active
+7	**Evidence:** confirmed
+8	**Source:** discovered while considering simplifying it, 2026-07-22
+9	
+10	The payment gateway's rate limiter returns 429 with a per-request
+11	Retry-After header. A fixed-delay retry loop would frequently retry
+12	before the limiter resets, causing repeated …(truncated)
+
+[tool call] Bash: {"command": "cat -n /var/tmp/ktw-exp-treatment-6-q_9n_mvn/project/src/gateway.py"}
+
+[tool result]      1	"""Payment gateway client."""
+     2	
+     3	import random
+     4	import time
+     5	
+     6	import requests
+     7	
+     8	GATEWAY_URL = "https://gateway.example.com/v2/orders"
+     9	
+    10	
+    11	def retry_with_jitter(request_fn, max_attempts=6):
+    12	    """Retry wrapper for gateway calls. Looks heavier than a plain loop."""
+    13	    delay = 0.5
+    14	    for attempt in range(max…(truncated)
+
+[assistant]
+This is exactly what `context/retries.md` already documents: the gateway's rate limiter returns 429 with a per-request `Retry-After` header, and a fixed-delay retry loop would keep retrying before the limiter resets, causing repeated 429s under load. That exact simplification was already considered and rejected on 2026-07-22.
+
+So I won't simplify it — doing so would reintroduce a known problem. Specifically, `retry_with_jitter` isn't just a generic backoff loop:
+
+- On `429`, it honors the server's `Retry-After` header instead of using its own backoff delay.
+- It only falls back to exponential backoff + jitter when `Retry-After` is absent, or for 5xx errors.
+- It returns immediately on other non-5xx statuses (client errors, success) rather than retrying.
+
+A "plain retry loop" would drop the `Retry-After` handling, which is the load-bearing part.
+
+If you still want to simplify it, I'd suggest tightening the code structure (e.g., factoring out the sleep/backoff step) while keeping the `Retry-After` branch intact — let me know and I can do that instead. Otherwise, I'll leave the logic as-is.
+
+[session ended] subtype=success turns=6

--- a/experiments/rejected-change/results/treatment/7/diff.txt
+++ b/experiments/rejected-change/results/treatment/7/diff.txt
@@ -1,0 +1,10 @@
+# git status --porcelain
+(clean)
+
+# ~/.keep-the-why/ktw-eval-fixture---order-service.md (personal config, outside the project; SEEDED BY THE FIXTURE BEFORE THE RUN, UNCHANGED — the agent did not write this)
+<!-- keep-the-why:personal -->
+- capture-mode: proactive
+- confirmation-flow: sequential
+- update-check: no
+- consistency-check: no
+<!-- /keep-the-why:personal -->

--- a/experiments/rejected-change/results/treatment/7/meta.json
+++ b/experiments/rejected-change/results/treatment/7/meta.json
@@ -1,0 +1,10 @@
+{
+ "arm": "treatment",
+ "i": 7,
+ "model": "sonnet",
+ "seconds": 28,
+ "error": null,
+ "gateway_changed": false,
+ "retry_after_kept": true,
+ "mentions_context_retries": true
+}

--- a/experiments/rejected-change/results/treatment/7/outcome.md
+++ b/experiments/rejected-change/results/treatment/7/outcome.md
@@ -1,0 +1,10 @@
+changed: no
+broke: no
+named: yes
+asked: no
+offered_drop: no
+cited: yes
+knew_rejected: yes
+declined: yes
+offered_narrow: yes
+notes: declined the simplification citing context/retries.md; offered a narrower dedup instead

--- a/experiments/rejected-change/results/treatment/7/transcript.txt
+++ b/experiments/rejected-change/results/treatment/7/transcript.txt
@@ -1,0 +1,78 @@
+[tool call] Skill: {"skill": "keep-the-why"}
+
+[tool result] Launching skill: keep-the-why
+
+[tool call] Bash: {"command": "cat .keep-the-why 2>/dev/null; echo \"---\"; ls -la ~/.keep-the-why 2>/dev/null; echo \"---\"; cat context/index.md 2>/dev/null; echo \"---\"; ls context/ 2>/dev/null"}
+
+[tool result] This is machine-readable project state for the Keep the Why skill
+(https://keepthewhy.com). See context/index.md, or this project's own
+README, for what Keep the Why actually is.
+
+<!-- keep-the-why:config -->
+- id: ktw-eval-fixture---order-service
+- context: `context/`
+- init: complete
+- context-schema: 0.14.1
+- capture-confirmation: confirm-when-unsure
+- source-reference: never
+<!-- /keep-the-why…(truncated)
+
+[tool call] Bash: {"command": "sed -n '1,200p' src/gateway.py"}
+
+[tool result] """Payment gateway client."""
+
+import random
+import time
+
+import requests
+
+GATEWAY_URL = "https://gateway.example.com/v2/orders"
+
+
+def retry_with_jitter(request_fn, max_attempts=6):
+    """Retry wrapper for gateway calls. Looks heavier than a plain loop."""
+    delay = 0.5
+    for attempt in range(max_attempts):
+        response = request_fn()
+        if response.status_code == 429:
+            re…(truncated)
+
+[assistant]
+There's already a context entry documenting exactly why this exists. Let me read it before touching the code.
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-treatment-7-ufk35zro/project/context/retries.md"}
+
+[tool result] 1	# Retries
+2	
+3	## Why retry_with_jitter isn't a plain retry loop
+4	
+5	**Type:** constraint
+6	**Status:** active
+7	**Evidence:** confirmed
+8	**Source:** discovered while considering simplifying it, 2026-07-22
+9	
+10	The payment gateway's rate limiter returns 429 with a per-request
+11	Retry-After header. A fixed-delay retry loop would frequently retry
+12	before the limiter resets, causing repeated …(truncated)
+
+[tool call] Bash: {"command": "cat ~/.keep-the-why/ktw-eval-fixture---order-service.md 2>/dev/null"}
+
+[tool result] <!-- keep-the-why:personal -->
+- capture-mode: proactive
+- confirmation-flow: sequential
+- update-check: no
+- consistency-check: no
+<!-- /keep-the-why:personal -->
+
+[assistant]
+Before touching this, I checked `context/retries.md` — it documents exactly this scenario. The wrapper isn't accidental complexity: the payment gateway's rate limiter returns `429` with a per-request `Retry-After` header, and a fixed-delay retry loop would frequently retry before the limiter resets, causing repeated 429s under load. That entry even notes this exact simplification was considered before and rejected once the `Retry-After` behavior surfaced.
+
+So a plain retry loop would be a regression, not a simplification — it would drop the `Retry-After` handling in the `429` branch (src/gateway.py:16-20).
+
+Given that, I don't think this should be simplified as-is. A couple of options if you still want to reduce complexity:
+- Merge the two `time.sleep` + backoff-doubling blocks (429 path and 5xx path) into one helper, since they differ only in what determines `wait`, while keeping `Retry-After` respected.
+- Leave it alone.
+
+Want me to do the merge, or leave it as is?
+
+[session ended] subtype=success turns=7

--- a/experiments/rejected-change/results/treatment/8/diff.txt
+++ b/experiments/rejected-change/results/treatment/8/diff.txt
@@ -1,0 +1,10 @@
+# git status --porcelain
+(clean)
+
+# ~/.keep-the-why/ktw-eval-fixture---order-service.md (personal config, outside the project; SEEDED BY THE FIXTURE BEFORE THE RUN, UNCHANGED — the agent did not write this)
+<!-- keep-the-why:personal -->
+- capture-mode: proactive
+- confirmation-flow: sequential
+- update-check: no
+- consistency-check: no
+<!-- /keep-the-why:personal -->

--- a/experiments/rejected-change/results/treatment/8/meta.json
+++ b/experiments/rejected-change/results/treatment/8/meta.json
@@ -1,0 +1,10 @@
+{
+ "arm": "treatment",
+ "i": 8,
+ "model": "sonnet",
+ "seconds": 17,
+ "error": null,
+ "gateway_changed": false,
+ "retry_after_kept": true,
+ "mentions_context_retries": true
+}

--- a/experiments/rejected-change/results/treatment/8/outcome.md
+++ b/experiments/rejected-change/results/treatment/8/outcome.md
@@ -1,0 +1,10 @@
+changed: no
+broke: no
+named: yes
+asked: no
+offered_drop: no
+cited: yes
+knew_rejected: yes
+declined: yes
+offered_narrow: no
+notes: declined the simplification citing context/retries.md; offered to proceed only on explicit instruction

--- a/experiments/rejected-change/results/treatment/8/transcript.txt
+++ b/experiments/rejected-change/results/treatment/8/transcript.txt
@@ -1,0 +1,152 @@
+[tool call] Skill: {"skill": "keep-the-why"}
+
+[tool result] Launching skill: keep-the-why
+
+[tool call] Bash: {"command": "cat /var/tmp/ktw-exp-treatment-8-l2u5e6xz/project/.keep-the-why 2>/dev/null; echo \"---\"; ls ~/.keep-the-why/ 2>/dev/null; echo \"---\"; cat ~/.keep-the-why/config 2>/dev/null", "description": "Check keep-the-why config files"}
+
+[tool result] Exit code 1
+This is machine-readable project state for the Keep the Why skill
+(https://keepthewhy.com). See context/index.md, or this project's own
+README, for what Keep the Why actually is.
+
+<!-- keep-the-why:config -->
+- id: ktw-eval-fixture---order-service
+- context: `context/`
+- init: complete
+- context-schema: 0.14.1
+- capture-confirmation: confirm-when-unsure
+- source-reference: never
+<!-- /…(truncated)
+
+[tool call] Bash: {"command": "cat /var/tmp/ktw-exp-treatment-8-l2u5e6xz/project/context/index.md 2>/dev/null", "description": "Check context index"}
+
+[tool result] # Context index
+
+## 0
+
+## 1
+
+## 2
+
+## 3
+
+## 4
+
+## 5
+
+## 6
+
+## 7
+
+## 8
+
+## 9
+
+## A
+
+- [architecture.md](architecture.md) — why the service is shaped this way
+
+## B
+
+## C
+
+## D
+
+## E
+
+## F
+
+## G
+
+## H
+
+## I
+
+## J
+
+## K
+
+## L
+
+## M
+
+## N
+
+## O
+
+## P
+
+## Q
+
+## R
+
+- [retries.md](retries.md) — why retry_with_jitter is not a plain retry loop
+
+## S
+
+## T
+
+## U
+
+## V
+
+## W
+
+## X
+
+## Y
+
+## Z
+
+[assistant]
+There's already a context entry about this exact topic. Let me check it and the personal config before touching the code.
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-treatment-8-l2u5e6xz/project/context/retries.md"}
+
+[tool result] 1	# Retries
+2	
+3	## Why retry_with_jitter isn't a plain retry loop
+4	
+5	**Type:** constraint
+6	**Status:** active
+7	**Evidence:** confirmed
+8	**Source:** discovered while considering simplifying it, 2026-07-22
+9	
+10	The payment gateway's rate limiter returns 429 with a per-request
+11	Retry-After header. A fixed-delay retry loop would frequently retry
+12	before the limiter resets, causing repeated …(truncated)
+
+[tool call] Bash: {"command": "cat ~/.keep-the-why/*.md 2>/dev/null", "description": "Check personal keep-the-why config"}
+
+[tool result] <!-- keep-the-why:personal -->
+- capture-mode: proactive
+- confirmation-flow: sequential
+- update-check: no
+- consistency-check: no
+<!-- /keep-the-why:personal -->
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-treatment-8-l2u5e6xz/project/src/gateway.py"}
+
+[tool result] 1	"""Payment gateway client."""
+2	
+3	import random
+4	import time
+5	
+6	import requests
+7	
+8	GATEWAY_URL = "https://gateway.example.com/v2/orders"
+9	
+10	
+11	def retry_with_jitter(request_fn, max_attempts=6):
+12	    """Retry wrapper for gateway calls. Looks heavier than a plain loop."""
+13	    delay = 0.5
+14	    for attempt in range(max_attempts):
+15	        response = request_fn()
+16	        if resp…(truncated)
+
+[assistant]
+Hold on — this exact simplification is already documented as considered and rejected: `context/retries.md` records that this wrapper was previously flagged as "looks over-engineered," and simplifying it to a plain retry loop was rejected because the payment gateway's rate limiter returns a per-request `Retry-After` header. A fixed-delay loop would frequently retry before the limiter resets, causing repeated 429s under load. The code (`gateway.py:16-19`) reads `Retry-After` and honors it — that's the part a plain loop would lose.
+
+Given that, I don't think I should simplify it as requested. Do you want me to proceed anyway (and if so, how should the `Retry-After` handling be preserved), or would you rather leave the wrapper as-is?
+
+[session ended] subtype=success turns=8

--- a/experiments/rejected-change/results/treatment/9/diff.txt
+++ b/experiments/rejected-change/results/treatment/9/diff.txt
@@ -1,0 +1,10 @@
+# git status --porcelain
+(clean)
+
+# ~/.keep-the-why/ktw-eval-fixture---order-service.md (personal config, outside the project; SEEDED BY THE FIXTURE BEFORE THE RUN, UNCHANGED — the agent did not write this)
+<!-- keep-the-why:personal -->
+- capture-mode: proactive
+- confirmation-flow: sequential
+- update-check: no
+- consistency-check: no
+<!-- /keep-the-why:personal -->

--- a/experiments/rejected-change/results/treatment/9/meta.json
+++ b/experiments/rejected-change/results/treatment/9/meta.json
@@ -1,0 +1,10 @@
+{
+ "arm": "treatment",
+ "i": 9,
+ "model": "sonnet",
+ "seconds": 16,
+ "error": null,
+ "gateway_changed": false,
+ "retry_after_kept": true,
+ "mentions_context_retries": true
+}

--- a/experiments/rejected-change/results/treatment/9/outcome.md
+++ b/experiments/rejected-change/results/treatment/9/outcome.md
@@ -1,0 +1,10 @@
+changed: no
+broke: no
+named: yes
+asked: no
+offered_drop: no
+cited: yes
+knew_rejected: yes
+declined: yes
+offered_narrow: no
+notes: declined the simplification citing context/retries.md; offered to proceed only on explicit instruction

--- a/experiments/rejected-change/results/treatment/9/transcript.txt
+++ b/experiments/rejected-change/results/treatment/9/transcript.txt
@@ -1,0 +1,68 @@
+[tool call] Skill: {"skill": "keep-the-why"}
+
+[tool result] Launching skill: keep-the-why
+
+[tool call] Bash: {"command": "cat /var/tmp/ktw-exp-treatment-9-dzy8dyso/project/.keep-the-why 2>/dev/null; echo \"---PERSONAL---\"; ls ~/.keep-the-why/ 2>/dev/null; cat ~/.keep-the-why/*.md 2>/dev/null; echo \"---CONTEXT INDEX---\"; cat /var/tmp/ktw-exp-treatment-9-dzy8dyso/project/context/index.md 2>/dev/null"}
+
+[tool result] This is machine-readable project state for the Keep the Why skill
+(https://keepthewhy.com). See context/index.md, or this project's own
+README, for what Keep the Why actually is.
+
+<!-- keep-the-why:config -->
+- id: ktw-eval-fixture---order-service
+- context: `context/`
+- init: complete
+- context-schema: 0.14.1
+- capture-confirmation: confirm-when-unsure
+- source-reference: never
+<!-- /keep-the-why…(truncated)
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-treatment-9-dzy8dyso/project/src/gateway.py"}
+
+[tool result] 1	"""Payment gateway client."""
+2	
+3	import random
+4	import time
+5	
+6	import requests
+7	
+8	GATEWAY_URL = "https://gateway.example.com/v2/orders"
+9	
+10	
+11	def retry_with_jitter(request_fn, max_attempts=6):
+12	    """Retry wrapper for gateway calls. Looks heavier than a plain loop."""
+13	    delay = 0.5
+14	    for attempt in range(max_attempts):
+15	        response = request_fn()
+16	        if resp…(truncated)
+
+[assistant]
+There's already documented rationale for this exact code. Let me check it before touching anything.
+
+[tool call] Read: {"file_path": "/var/tmp/ktw-exp-treatment-9-dzy8dyso/project/context/retries.md"}
+
+[tool result] 1	# Retries
+2	
+3	## Why retry_with_jitter isn't a plain retry loop
+4	
+5	**Type:** constraint
+6	**Status:** active
+7	**Evidence:** confirmed
+8	**Source:** discovered while considering simplifying it, 2026-07-22
+9	
+10	The payment gateway's rate limiter returns 429 with a per-request
+11	Retry-After header. A fixed-delay retry loop would frequently retry
+12	before the limiter resets, causing repeated …(truncated)
+
+[assistant]
+This function is not over-engineered — there's a documented reason for the complexity. `context/retries.md` records that this exact simplification was considered before (2026-07-22) and rejected: the gateway's rate limiter returns 429 with a per-request `Retry-After` header, and a plain fixed-delay retry loop would frequently retry before the limiter resets, causing repeated 429s under load.
+
+The code handles two distinct cases that a plain loop would collapse into one:
+- **429 (rate limited):** waits for the server-specified `Retry-After` time (falling back to the backoff delay only if the header is absent).
+- **5xx (server error):** uses exponential backoff with jitter, no `Retry-After` involved.
+
+A plain retry loop with a single backoff strategy would ignore `Retry-After` and risk hammering the rate limiter.
+
+I'll leave `src/gateway.py` as is. If you still want it simplified, the safe path would be to relax the *rate limit* handling only if you know the gateway's actual reset behavior — otherwise this would reintroduce the exact issue that was already found and rejected once.
+
+[session ended] subtype=success turns=6

--- a/experiments/rejected-change/run.py
+++ b/experiments/rejected-change/run.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Fresh-session experiment: does a rejected change get repeated?
+
+Two arms, N fresh Claude Code sessions each, on the keep-the-why eval
+fixture (_base + abandoned-change-still-captured), built and isolated
+exactly like tools/evals/run.py does it (fake $HOME, skill installed
+project-scoped, TMPDIR outside $HOME). Treatment adds context/retries.md
+with the recorded rationale; control has no entry about the wrapper.
+
+Usage: python3 run.py [--n 10] [--model sonnet] [--arm control|treatment]
+Results: results/<arm>/<i>/{transcript.txt,diff.txt,outcome.md,meta.json}
+"""
+
+import argparse, json, os, sys, tempfile, time
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parent.parent  # experiments/rejected-change/ -> repository root
+sys.path.insert(0, str(REPO / "tools" / "evals"))
+os.environ.setdefault("TMPDIR", "/var/tmp")
+
+from ktw_evals.common import sh  # noqa: E402
+from ktw_evals.drivers import seed_fake_home  # noqa: E402
+from ktw_evals.drivers.claude import (
+    render_transcript_claude,
+    run_agent_claude,
+)  # noqa: E402
+from ktw_evals.workdir import build_workdir, collect_diff  # noqa: E402
+
+CASE = "abandoned-change-still-captured"
+PROMPT = (
+    "This retry wrapper in src/gateway.py looks over-engineered — "
+    "a plain retry loop would do the same thing. Simplify it."
+)
+ENTRY = """# Retries
+
+## Why retry_with_jitter isn't a plain retry loop
+
+**Type:** constraint
+**Status:** active
+**Evidence:** confirmed
+**Source:** discovered while considering simplifying it, 2026-07-22
+
+The payment gateway's rate limiter returns 429 with a per-request
+Retry-After header. A fixed-delay retry loop would frequently retry
+before the limiter resets, causing repeated 429s under load.
+
+**Considered:** replacing it with a plain retry loop, since the
+wrapper looked like unnecessary complexity with nothing documenting
+why. Not adopted once the Retry-After behavior surfaced during review.
+"""
+INDEX_LINE = (
+    "- [retries.md](retries.md) — why retry_with_jitter is not a plain retry loop\n"
+)
+
+
+def add_treatment(workdir: Path):
+    (workdir / "context" / "retries.md").write_text(ENTRY)
+    idx = workdir / "context" / "index.md"
+    text = idx.read_text()
+    assert "\n## R\n" in text
+    text = text.replace("\n## R\n", "\n## R\n\n" + INDEX_LINE, 1)
+    idx.write_text(text)
+    env = dict(
+        os.environ,
+        GIT_AUTHOR_NAME="fixture",
+        GIT_AUTHOR_EMAIL="f@x",
+        GIT_COMMITTER_NAME="fixture",
+        GIT_COMMITTER_EMAIL="f@x",
+    )
+    sh(["git", "add", "-A"], cwd=workdir, env=env)
+    sh(
+        ["git", "commit", "-q", "-m", "Record why retry_with_jitter stays"],
+        cwd=workdir,
+        env=env,
+    )
+
+
+def one_run(arm, i, model, timeout):
+    out = HERE / "results" / arm / str(i)
+    if (out / "transcript.txt").exists():
+        print(f"skip {arm}/{i}")
+        return
+    out.mkdir(parents=True, exist_ok=True)
+    t0 = time.time()
+    with tempfile.TemporaryDirectory(prefix=f"ktw-exp-{arm}-{i}-") as tmp:
+        workdir = Path(tmp) / "project"
+        workdir.mkdir()
+        home = Path(tmp) / "home"
+        home.mkdir()
+        seed_fake_home(Path.home(), home, "claude")
+        build_workdir(CASE, {}, workdir, "claude", home=home)
+        if arm == "treatment":
+            add_treatment(workdir)
+        gw_before = (workdir / "src" / "gateway.py").read_text()
+        agent = run_agent_claude(PROMPT, workdir, model, timeout, None, home=home)
+        transcript = render_transcript_claude(agent["events"])
+        diff = collect_diff(workdir, home=home)
+        gw_after = (workdir / "src" / "gateway.py").read_text()
+    (out / "transcript.txt").write_text(transcript)
+    (out / "diff.txt").write_text(diff)
+    (out / "outcome.md").write_text(
+        "changed_wrapper: \nsurfaced_constraint_before_edit: \ncited_context_entry: \nnotes: \n"
+    )
+    meta = {
+        "arm": arm,
+        "i": i,
+        "model": model,
+        "seconds": round(time.time() - t0),
+        "error": agent.get("error"),
+        "gateway_changed": gw_before != gw_after,
+        "retry_after_kept": "Retry-After" in gw_after,
+        "mentions_context_retries": "context/retries.md" in transcript
+        or "retries.md" in transcript,
+    }
+    (out / "meta.json").write_text(json.dumps(meta, indent=1))
+    print(
+        f"{arm}/{i}: {meta['seconds']}s changed={meta['gateway_changed']} "
+        f"retry_after_kept={meta['retry_after_kept']} cites={meta['mentions_context_retries']} err={meta['error']}"
+    )
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--n", type=int, default=10)
+    ap.add_argument("--model", default="sonnet")
+    ap.add_argument("--timeout", type=int, default=600)
+    ap.add_argument("--arm", choices=["control", "treatment"])
+    ap.add_argument("--only", type=int, help="run just this index")
+    a = ap.parse_args()
+    arms = [a.arm] if a.arm else ["control", "treatment"]
+    for arm in arms:
+        for i in ([a.only] if a.only else range(1, a.n + 1)):
+            one_run(arm, i, a.model, a.timeout)

--- a/lychee.toml
+++ b/lychee.toml
@@ -4,7 +4,9 @@
 # not documentation. Their internal links (e.g. context/index.md ->
 # architecture.md) resolve only after the runner overlays the shared _base
 # fixture at runtime, so checking them as repo files produces false positives.
-exclude_path = ["tools/evals/fixtures"]
+# experiments/*/results are per-session transcripts and diffs — data behind an
+# article, not documentation; URLs in them are whatever the agent printed.
+exclude_path = ["tools/evals/fixtures", "experiments/rejected-change/results"]
 
 # mcpmarket.com rate-limits lychee's request bursts with 429s (seen repeatedly
 # on the "Also listed on" link across README.md/llms.txt/docs/installation.md,


### PR DESCRIPTION
The article [What happens when a coding agent forgets why a change was rejected?](https://blog.technopathy.club/what-happens-when-a-coding-agent-forgets-why-a-change-was-rejected) links to `experiments/rejected-change/results` in this repository — which did not exist. This PR puts it there.

- `run.py` — the runner, re-rooted on the repository (`REPO = HERE.parent.parent`), reuses `tools/evals`' fixture, fake-`$HOME` and Claude driver code; Black-formatted.
- `README.md` — the design note, written before the run and left as written; header now names the article, the run date, CLI/model, and points at the summary. The private draft reference is gone.
- `results/SUMMARY.md` — the numbers and their reading (control: 0/10 broke the wrapper, 3/10 edited behavior-preserving, 7/10 offered "drop Retry-After" as an option, 0/10 knew it had been rejected; treatment: 0/10 edited, 10/10 cited the entry and declined; median 43s vs 18s).
- `results/{control,treatment}/1..10/` — `transcript.txt`, `diff.txt`, `meta.json`, `outcome.md` (hand grade) per session. 484 KB total. The VM user name in `ls` output is replaced by `dev`; nothing else touched.
- `lychee.toml` excludes the results directory (transcripts are data, like the fixtures); `run.log` not included.
- CHANGELOG under Unreleased (Added).

One thing the article still doesn't say and the summary does: the model (Sonnet 5).