### PR TITLE
TODO.md: open next steps

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,61 +1,59 @@
 # TODO
 
 Open work that is not a bug and not a design question — those go to
-[issues](https://github.com/oliver-zehentleitner/keep-the-why/issues). Items
-here are known next steps, waiting on a decision, a release, or someone else.
-Last reviewed: 2026-09-08.
+[issues](https://github.com/oliver-zehentleitner/keep-the-why/issues).
+Last reviewed: 2026-09-09.
 
-## Release
+## In progress
 
-- [ ] **Next skill release.** Unreleased on `main`: the Codex plugin manifest and
-  one-plugin marketplace (#340), the HOL scanner workflow (#336, #337), and
-  `experiments/rejected-change/` (#334). The Codex manifest is a new install
-  surface, so this is a minor (0.16.0), not a patch. Checklist in
-  `CONTRIBUTING.md`: linter first, then the tag, then three full eval runs
-  into `docs/evals.md`.
+### Active
 
-## Skill text
+- [ ] **Two wizards are two messages** — the three wizard-presentation flips
+  from the 0.15.0 measurement, fixed in `SKILL.md` step 0,
+  `references/setup.md` and the retrofitting rule in
+  `references/repository-structure.md`, re-measured 9/9 on the three cases
+  (`init-wizard-first-activation`, `wizard-defaults-one-list-per-wizard`,
+  `negative-existing-good-structure-untouched`). Pull request #343, awaiting
+  merge; ships with the next release.
 
-- [ ] **One-list wizard, one message per wizard.** The 0.15.0 measurement
-  (`docs/evals.md`) shows three presentation flips with a clean tree: twice
-  both wizards' lists in one message, once "one question at a time". Decide
-  whether `references/setup.md` needs one more sentence — "the personal list
-  is a second message, after the project answer" — or whether the next
-  series settles it. Eval cases: `init-wizard-first-activation`,
-  `wizard-defaults-one-list-per-wizard`,
-  `negative-existing-good-structure-untouched`.
+### Pending
 
-## Listings
-
-- [ ] **HOL / awesome-ai-plugins**
+- [ ] **Next skill release (0.16.0).** Unreleased on `main`: the Codex plugin
+  manifest and one-plugin marketplace (#340), the HOL scanner workflow (#336,
+  #337), `experiments/rejected-change/` (#334), and #343 once merged. The
+  Codex manifest is a new install surface, so a minor, not a patch. Checklist
+  in `CONTRIBUTING.md`: linter first, then the tag, then three full eval runs
+  into `docs/evals.md`. Waits on the maintainer's call.
+- [ ] **HOL / awesome-ai-plugins listing**
   ([hashgraph-online/awesome-ai-plugins#257](https://github.com/hashgraph-online/awesome-ai-plugins/pull/257)).
-  Contribution check passes; the maintainers' centralized scan still runs the
+  Contribution check passes; the maintainers' centralized scan still runs an
   older scanner release whose secret heuristic flags an eval case id, which
-  is explained in the PR. After merge: claim the listing on hol.org
-  (repository owner), and add the HOL registry to `llms.txt` under "Also
-  Listed On".
+  is explained in the PR. Waits on their rerun or merge. Afterwards: claim
+  the listing on hol.org (repository owner), and add the HOL registry to
+  `llms.txt` under "Also Listed On".
 - [ ] **awesome-copilot**
   ([github/awesome-copilot#2984](https://github.com/github/awesome-copilot/pull/2984)),
-  bump to 0.15.0, waiting on their review. Bump again in place when the next
+  bump to 0.15.0, waits on their review. Bump again in place when the next
   release exists.
-
-## Evals
-
 - [ ] **Agent & model matrix rebuild** (`docs/agent-matrix.md`). The tooling
   (`tools/evals/run.py --matrix`) is ready; the matrix was last built against
-  0.9.x. Before rebuilding: add a Gemini CLI driver under
+  0.9.x. Waits on two decisions: whether `chestertons-fence-guard` is still
+  the representative case, and whether the Mistral column stays given its
+  per-run cost. Before the rebuild, add a Gemini CLI driver under
   `tools/evals/ktw_evals/drivers/` (the matrix has a column for it, the runner
-  has no driver) and verify it on one case; decide whether
-  `chestertons-fence-guard` is still the representative case, and whether the
-  Mistral column stays given its per-run cost. A new driver must use
+  has no driver) and verify it on one case; a new driver uses
   `common.fake_home_env` like the others.
-- [ ] **Codex plugin install as an eval condition.** The Codex driver hands the
-  skill to the agent by path today; with the plugin manifest in place, a
-  variant that installs through `codex plugin add` would measure the
-  documented install route rather than the by-hand one.
 
-## Housekeeping
+## Ideas
 
-- [ ] **Topic-file size threshold** — open as
+- **Codex plugin install as an eval condition.** The Codex driver hands the
+  skill to the agent by path; with the plugin manifest in place, a variant
+  that installs through `codex plugin add` would measure the documented
+  install route rather than the by-hand one.
+- **Topic-file size threshold** — tracked as
   [#256](https://github.com/oliver-zehentleitner/keep-the-why/issues/256):
   learn it from real repositories, don't invent one.
+- **Lean Codex plugin.** The plugin root is the repository root, so
+  `codex plugin add` copies about 13 MB. If Codex honors an ignore file for
+  plugin packaging, the docs, linter, evals and experiments could stay out of
+  the install.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,61 @@
+# TODO
+
+Open work that is not a bug and not a design question — those go to
+[issues](https://github.com/oliver-zehentleitner/keep-the-why/issues). Items
+here are known next steps, waiting on a decision, a release, or someone else.
+Last reviewed: 2026-09-08.
+
+## Release
+
+- [ ] **Next skill release.** Unreleased on `main`: the Codex plugin manifest and
+  one-plugin marketplace (#340), the HOL scanner workflow (#336, #337), and
+  `experiments/rejected-change/` (#334). The Codex manifest is a new install
+  surface, so this is a minor (0.16.0), not a patch. Checklist in
+  `CONTRIBUTING.md`: linter first, then the tag, then three full eval runs
+  into `docs/evals.md`.
+
+## Skill text
+
+- [ ] **One-list wizard, one message per wizard.** The 0.15.0 measurement
+  (`docs/evals.md`) shows three presentation flips with a clean tree: twice
+  both wizards' lists in one message, once "one question at a time". Decide
+  whether `references/setup.md` needs one more sentence — "the personal list
+  is a second message, after the project answer" — or whether the next
+  series settles it. Eval cases: `init-wizard-first-activation`,
+  `wizard-defaults-one-list-per-wizard`,
+  `negative-existing-good-structure-untouched`.
+
+## Listings
+
+- [ ] **HOL / awesome-ai-plugins**
+  ([hashgraph-online/awesome-ai-plugins#257](https://github.com/hashgraph-online/awesome-ai-plugins/pull/257)).
+  Contribution check passes; the maintainers' centralized scan still runs the
+  older scanner release whose secret heuristic flags an eval case id, which
+  is explained in the PR. After merge: claim the listing on hol.org
+  (repository owner), and add the HOL registry to `llms.txt` under "Also
+  Listed On".
+- [ ] **awesome-copilot**
+  ([github/awesome-copilot#2984](https://github.com/github/awesome-copilot/pull/2984)),
+  bump to 0.15.0, waiting on their review. Bump again in place when the next
+  release exists.
+
+## Evals
+
+- [ ] **Agent & model matrix rebuild** (`docs/agent-matrix.md`). The tooling
+  (`tools/evals/run.py --matrix`) is ready; the matrix was last built against
+  0.9.x. Before rebuilding: add a Gemini CLI driver under
+  `tools/evals/ktw_evals/drivers/` (the matrix has a column for it, the runner
+  has no driver) and verify it on one case; decide whether
+  `chestertons-fence-guard` is still the representative case, and whether the
+  Mistral column stays given its per-run cost. A new driver must use
+  `common.fake_home_env` like the others.
+- [ ] **Codex plugin install as an eval condition.** The Codex driver hands the
+  skill to the agent by path today; with the plugin manifest in place, a
+  variant that installs through `codex plugin add` would measure the
+  documented install route rather than the by-hand one.
+
+## Housekeeping
+
+- [ ] **Topic-file size threshold** — open as
+  [#256](https://github.com/oliver-zehentleitner/keep-the-why/issues/256):
+  learn it from real repositories, don't invent one.


### PR DESCRIPTION
Maintainer request: the open work in one file in the repository instead of in a session. Not bugs, not design questions — those stay issues. Sections: release (0.16.0 with the Codex manifest, scanner CI and the experiment), skill text (the one-list wizard flips from the 0.15.0 measurement), listings (HOL #257 follow-ups, awesome-copilot #2984), evals (matrix rebuild with a Gemini CLI driver and its two open decisions, a Codex-plugin install variant), housekeeping (#256). Dated "last reviewed" line at the top.