### PR TITLE
TODO.md: refresh after #343 and the HOL rebase

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,35 +2,31 @@
 
 Open work that is not a bug and not a design question — those go to
 [issues](https://github.com/oliver-zehentleitner/keep-the-why/issues).
-Last reviewed: 2026-09-09.
+Last reviewed: 2026-09-09 (evening).
 
 ## In progress
 
 ### Active
 
-- [ ] **Two wizards are two messages** — the three wizard-presentation flips
-  from the 0.15.0 measurement, fixed in `SKILL.md` step 0,
-  `references/setup.md` and the retrofitting rule in
-  `references/repository-structure.md`, re-measured 9/9 on the three cases
-  (`init-wizard-first-activation`, `wizard-defaults-one-list-per-wizard`,
-  `negative-existing-good-structure-untouched`). Pull request #343, awaiting
-  merge; ships with the next release.
+Nothing at the moment.
 
 ### Pending
 
 - [ ] **Next skill release (0.16.0).** Unreleased on `main`: the Codex plugin
   manifest and one-plugin marketplace (#340), the HOL scanner workflow (#336,
-  #337), `experiments/rejected-change/` (#334), and #343 once merged. The
+  #337), `experiments/rejected-change/` (#334), and the two-messages wizard
+  rule (#343). The
   Codex manifest is a new install surface, so a minor, not a patch. Checklist
   in `CONTRIBUTING.md`: linter first, then the tag, then three full eval runs
   into `docs/evals.md`. Waits on the maintainer's call.
 - [ ] **HOL / awesome-ai-plugins listing**
   ([hashgraph-online/awesome-ai-plugins#257](https://github.com/hashgraph-online/awesome-ai-plugins/pull/257)).
-  Contribution check passes; the maintainers' centralized scan still runs an
-  older scanner release whose secret heuristic flags an eval case id, which
-  is explained in the PR. Waits on their rerun or merge. Afterwards: claim
-  the listing on hol.org (repository owner), and add the HOL registry to
-  `llms.txt` under "Also Listed On".
+  Rebased on their request; all five catalog checks pass, including the
+  source-repository scan. Waits on their merge. Afterwards, two steps: the
+  repository owner claims the listing on hol.org ("Claim this listing" —
+  ownership proof, unlocks managing the registry page: media, first comment,
+  launch day); then add the HOL registry to `llms.txt` under "Also Listed
+  On".
 - [ ] **awesome-copilot**
   ([github/awesome-copilot#2984](https://github.com/github/awesome-copilot/pull/2984)),
   bump to 0.15.0, waits on their review. Bump again in place when the next


### PR DESCRIPTION
Active is empty (#343 merged, now listed under the release's unreleased items). HOL listing: rebased, all five catalog checks green, waits on their merge; the two follow-ups spelled out — the repository owner claims the listing on hol.org (ownership proof, unlocks managing the registry page), then the HOL registry goes into `llms.txt` under "Also Listed On".