### PR TITLE
Prepare 0.16.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "keep-the-why",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Project memory for coding agents and humans: the reasoning behind a codebase as Markdown in the repo, versioned by Git, so nothing rejected is proposed twice.",
   "author": {
     "name": "Oliver Zehentleitner",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "keep-the-why",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Project memory for coding agents and humans: the reasoning behind a codebase as Markdown in the repo, versioned by Git, so nothing rejected is proposed twice.",
   "author": {
     "name": "Oliver Zehentleitner",

--- a/.keep-the-why
+++ b/.keep-the-why
@@ -6,7 +6,7 @@ README, for what Keep the Why actually is.
 - id: oliver-zehentleitner---keep-the-why
 - context: `context/`
 - init: complete
-- context-schema: 0.15.0
+- context-schema: 0.16.0
 - capture-confirmation: confirm-always
 - source-reference: never
 <!-- /keep-the-why:config -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,14 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-09-09
+
 ### Changed
 
 - Landing page, README, `llms.txt` and the site description, one copy pass (#345–#350): the hero's pain line is three staccato fragments plus the agent's wrong turn, with `docs/` named beside code and changelog and one bridge sentence into the summary; the site description is under 160 characters so search results and share cards no longer cut it mid-sentence; the README's "The problem" section sits before "How it works" and its two raw `<img>` tags use absolute URLs (on `/readme/` the relative paths 404ed since #274); `llms.txt` opens with the one-line summary and keeps the full intro as body text. Reasoning in `context/positioning.md`.
 - `plugin.json`, `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json`: the shared description follows the repository's About text again, which is now the one-line site description.
 - Two wizards are two messages, said outright. The 0.15.0 measurement showed the one-list default's failure mode: twice in six first-setup sessions the agent appended the personal wizard's list below the project list in the same message instead of ending the turn on the project list. Step 0 in `SKILL.md`, the project wizard's intro, the personal wizard's intro and the "Both wizards" paragraph in `setup.md` now say it in so many words — the project list ends the turn, the personal list is the next message after the project answer, under `batch` as much as under `sequential`, after "defaults" as much as after a changed value — and that a developer who states in the request how they want to be asked has chosen, over the default. `repository-structure.md`'s retrofitting rule no longer reads as if a `context/` layer were added beside an existing decision folder: when the project keeps decision records already, that folder is the location and no parallel `context/` is created. Eval text: `negative-existing-good-structure-untouched` had been rewritten for the batch default although its prompt says "questions one at a time" — restored to the stated preference (one question, `docs/decisions/` proposed as the location), the 0.15.0 series' run-3 "failure" on it was the agent being right.
+- `keep-the-why-lint` 0.16.0.0: knows schema 0.16.0 — no new gate, nothing changes what `context/` or `.keep-the-why` must look like. Published before the skill tag, per the checklist.
 
 ### Added
 
@@ -627,7 +630,8 @@ Initial release.
 - Logo, wordmark, and favicon.
 - `context/repo-conventions.md`, dogfooding the skill on its own repository from day one.
 
-[Unreleased]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.15.0...HEAD
+[Unreleased]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.16.0...HEAD
+[0.16.0]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.14.1...v0.15.0
 [0.14.1]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.13.3...v0.14.0

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -82,7 +82,7 @@ codex plugin marketplace add oliver-zehentleitner/keep-the-why
 codex plugin add keep-the-why@keep-the-why
 ```
 
-Add `--ref v0.15.0` (any [release tag](https://github.com/oliver-zehentleitner/keep-the-why/releases)) to the first command to pin a version; without it Codex snapshots the default branch, and `codex plugin marketplace upgrade` refreshes it. The plugin lands under `~/.codex/plugins/cache/keep-the-why/`, and a new session lists the skill as `keep-the-why:keep-the-why`. Verified 2026-09-08 with Codex CLI 0.149.0, from a local path and from GitHub. `codex plugin remove keep-the-why@keep-the-why` uninstalls it; the skill-directory route below works for Codex too, and does not copy the whole repository.
+Add `--ref v0.16.0` (any [release tag](https://github.com/oliver-zehentleitner/keep-the-why/releases)) to the first command to pin a version; without it Codex snapshots the default branch, and `codex plugin marketplace upgrade` refreshes it. The plugin lands under `~/.codex/plugins/cache/keep-the-why/`, and a new session lists the skill as `keep-the-why:keep-the-why`. Verified 2026-09-08 with Codex CLI 0.149.0, from a local path and from GitHub. `codex plugin remove keep-the-why@keep-the-why` uninstalls it; the skill-directory route below works for Codex too, and does not copy the whole repository.
 
 ## Fallback: manual clone
 

--- a/lint/ktw_lint/__init__.py
+++ b/lint/ktw_lint/__init__.py
@@ -13,6 +13,6 @@ changes. PEP 440, not strict SemVer — PyPI rejects the SemVer build-
 metadata spelling this would otherwise use.
 """
 
-__version__ = "0.15.0.0"
+__version__ = "0.16.0.0"
 
-SUPPORTED_SCHEMA = (0, 15, 0)
+SUPPORTED_SCHEMA = (0, 16, 0)

--- a/lint/ktw_lint/config.py
+++ b/lint/ktw_lint/config.py
@@ -6,7 +6,7 @@ The config format is a delimited block of `- key: value` lines:
     - id: acme---widget-service
     - context: `context/`
     - init: complete
-    - context-schema: 0.15.0
+    - context-schema: 0.16.0
     - capture-confirmation: confirm-when-unsure
     - source-reference: never
     <!-- /keep-the-why:config -->

--- a/llms.txt
+++ b/llms.txt
@@ -42,7 +42,7 @@ get thrown away, not creating separate documentation effort. It isn't magic, tho
 prevents knowledge from decaying on its own. This lowers the friction of the discipline that
 keeps documentation honest; it doesn't replace it.
 
-Version: 0.15.0.
+Version: 0.16.0.
 
 ## Authorship & License
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "keep-the-why",
   "description": "Project memory for coding agents and humans: the reasoning behind a codebase as Markdown in the repo, versioned by Git, so nothing rejected is proposed twice.",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "author": {
     "name": "Oliver Zehentleitner"
   },

--- a/skills/keep-the-why/SKILL.md
+++ b/skills/keep-the-why/SKILL.md
@@ -3,7 +3,7 @@ name: keep-the-why
 description: Extract and preserve the reasoning code cannot explain - decisions, rejected alternatives, workarounds, incidents, constraints - plus project setup and maintainer interviews. Not for what changed (see Keep a Changelog) - only why.
 license: MIT
 metadata:
-  version: "0.15.0"
+  version: "0.16.0"
   repository: "https://github.com/oliver-zehentleitner/keep-the-why"
   author: "Oliver Zehentleitner"
 ---

--- a/skills/keep-the-why/examples/first-time-setup.md
+++ b/skills/keep-the-why/examples/first-time-setup.md
@@ -96,7 +96,7 @@ This names the skill and its purpose directly — not a task that happens to mat
     - id: acme---widget-service
     - context: `context/`
     - init: complete
-    - context-schema: 0.15.0
+    - context-schema: 0.16.0
     - capture-confirmation: confirm-when-unsure
     - source-reference: never
     <!-- /keep-the-why:config -->

--- a/skills/keep-the-why/references/migrations.md
+++ b/skills/keep-the-why/references/migrations.md
@@ -4,6 +4,12 @@ What changed in each version that an existing project may need to know about or 
 
 Entries below assume 0.2.0 as the starting point — nothing before it tracked a `context-schema` at all, and 0.2.0 itself introduced no `context/` entry format change.
 
+## 0.16.0 — a Codex plugin install route, and the two wizards as two messages (informational, no action required)
+
+**What changed:** the repository is installable as a Codex plugin (`.codex-plugin/plugin.json` plus a one-plugin marketplace), a third install route beside the skill directory and the Claude Code plugin. And the first-setup wizards are stated as two messages: the project list ends the turn, the personal list is the next message after the project answer, under `batch` as under `sequential`.
+
+**Existing projects and developers:** nothing changes. A project set up by any route keeps its `.keep-the-why` and `context/` untouched; the wizards don't run again. A Codex user who installed by path may switch to the plugin route at any time — same skill, same files — but nothing requires it.
+
 ## 0.15.0 — wizard defaults are the fully integrated values (informational, no action required)
 
 **What changed:** three wizard defaults, for new setups only. `confirmation-flow` proposes `batch` instead of `sequential`, so a first setup is one list per wizard with the defaults filled in and one answer, not one question per message. `local-lint` proposes `auto` instead of `ask`: the personal wizard names the install in its question, and the answer — "defaults" included — is the go-ahead, so a default setup installs `keep-the-why-lint` from PyPI in the same turn. The project wizard's activation question defaults to *the project asks* instead of *only when a developer asks*: the "Keep the Why" section goes into the entry-point file, plus the project-scoped hook where `autostart.md` has a verified example for the current platform. Everything else keeps its default — `capture-confirmation` stays `confirm-when-unsure`, `pending-confirmation-check` stays `no`, no `personal-defaults` block unless asked for. The reasoning: the one-word "defaults" answer should be a complete, fully integrated setup, and whoever wants less picks less. "Project init wizard" and "Personal preferences wizard" in `setup.md`.

--- a/skills/keep-the-why/references/setup.md
+++ b/skills/keep-the-why/references/setup.md
@@ -17,7 +17,7 @@ README, for what Keep the Why actually is.
 - id: oliver-zehentleitner---keep-the-why
 - context: `context/`
 - init: complete
-- context-schema: 0.15.0
+- context-schema: 0.16.0
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->

--- a/skills/keep-the-why/references/specification.md
+++ b/skills/keep-the-why/references/specification.md
@@ -67,7 +67,7 @@ README, for what Keep the Why actually is.
 - id: acme---widget-service
 - context: `context/`
 - init: complete
-- context-schema: 0.15.0
+- context-schema: 0.16.0
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->


### PR DESCRIPTION
Release preparation per the CONTRIBUTING checklist, steps 1–8. Nothing in this release changes what `context/` or `.keep-the-why` must look like, so the linter gets a schema bump and no new gate.

- **0.16.0** in `SKILL.md`, the three plugin manifests, `llms.txt`.
- **Linter** `0.16.0.0`: `SUPPORTED_SCHEMA = (0, 16, 0)`, `__version__` to match, the config example in its docstring.
- **CHANGELOG**: `[Unreleased]` renamed to `[0.16.0] - 2026-09-09`, fresh empty `[Unreleased]` above, the `keep-the-why-lint 0.16.0.0` line, compare links in the footer.
- **`migrations.md`**: a 0.16.0 entry, informational — the Codex plugin install route and the two-wizards-as-two-messages rule; nothing for an existing project to do.
- **This repository's `context-schema`** to 0.16.0; the illustrative `context-schema` values in `setup.md`, `specification.md`, `examples/first-time-setup.md`, and the `--ref v0.16.0` example in `docs/installation.md`.

Why a minor: the Codex manifest is a new install surface (see `TODO.md`).

Local checks: Black 26.5.1 clean, linter package tests OK, eval-runner tests OK, `ktw-lint --strict .` 0/0 on schema 0.16.0, `mkdocs build --strict` OK.

After merge: `publish-lint.yml`, wait for PyPI to resolve `keep-the-why-lint==0.16.0.0`, tag `v0.16.0`, re-run Link Check, then three full eval runs into `docs/evals.md`.
