### PR TITLE
TODO after the 0.16.0 tag: measurement open, awesome-copilot #2998, .codexignore note

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,14 +12,15 @@ Nothing in flight.
 
 ### Pending
 
-- [ ] **0.16.0 release measurement.** The skill is tagged (`v0.16.0`,
-  2026-09-09; linter 0.16.0.0 on PyPI first, per the checklist). What is
-  still open is the measurement: three consecutive full eval runs on the tag
-  (`--all --parallel 2 --judge-always --retry-until-complete`, TMPDIR outside
-  the home directory, Claude Code CLI 2.1.266) into `docs/evals.md` — the
-  four numbers per run, a note on every failed run, a run-history row. The
-  series is running; results land in `tools/evals/results/full-v0.16.0-r1`
-  to `-r3`.
+- [ ] **0.16.0 release measurement** — done, in pull request #357:
+  three full runs on the tag, 86, 84 and 81 of 87. Two cases flipped twice,
+  the same way each time, and are issues rather than caveats: #354 (the
+  request's "questions one at a time" answered with one list — the half of
+  #343 that did not hold), #355 (the frustration case naming the agent
+  tool's issue tracker; once with the skill never loaded). #356 is the
+  `Evidence: confirmed` flip that now recurs once per series, with the
+  linter's E104 in the path. Each of the three wants a wording decision
+  before a patch release; none changes what the skill writes to disk.
 - [ ] **HOL / awesome-ai-plugins listing**
   ([hashgraph-online/awesome-ai-plugins#257](https://github.com/hashgraph-online/awesome-ai-plugins/pull/257)).
   Rebased on their request; all five catalog checks pass, including the

--- a/TODO.md
+++ b/TODO.md
@@ -12,13 +12,14 @@ Nothing in flight.
 
 ### Pending
 
-- [ ] **Next skill release (0.16.0).** Unreleased on `main`: the Codex plugin
-  manifest and one-plugin marketplace (#340), the HOL scanner workflow (#336,
-  #337), `experiments/rejected-change/` (#334), the two-wizards fix (#343), the
-  copy pass on landing page, README and `llms.txt` (#345–#350) and
-  `.codexignore`. The Codex manifest is a new install surface, so a minor, not a patch. Checklist
-  in `CONTRIBUTING.md`: linter first, then the tag, then three full eval runs
-  into `docs/evals.md`. Waits on the maintainer's call.
+- [ ] **0.16.0 release measurement.** The skill is tagged (`v0.16.0`,
+  2026-09-09; linter 0.16.0.0 on PyPI first, per the checklist). What is
+  still open is the measurement: three consecutive full eval runs on the tag
+  (`--all --parallel 2 --judge-always --retry-until-complete`, TMPDIR outside
+  the home directory, Claude Code CLI 2.1.266) into `docs/evals.md` — the
+  four numbers per run, a note on every failed run, a run-history row. The
+  series is running; results land in `tools/evals/results/full-v0.16.0-r1`
+  to `-r3`.
 - [ ] **HOL / awesome-ai-plugins listing**
   ([hashgraph-online/awesome-ai-plugins#257](https://github.com/hashgraph-online/awesome-ai-plugins/pull/257)).
   Contribution check passes; the maintainers' centralized scan still runs an
@@ -27,9 +28,9 @@ Nothing in flight.
   the listing on hol.org (repository owner), and add the HOL registry to
   `llms.txt` under "Also Listed On".
 - [ ] **awesome-copilot**
-  ([github/awesome-copilot#2984](https://github.com/github/awesome-copilot/pull/2984)),
-  bump to 0.15.0, waits on their review. Bump again in place when the next
-  release exists.
+  ([github/awesome-copilot#2998](https://github.com/github/awesome-copilot/pull/2998)),
+  bump to 0.16.0, waits on their review; #2984 (0.15.0) is merged. Every
+  release gets its own bump PR there.
 - [ ] **Agent & model matrix rebuild** (`docs/agent-matrix.md`). The tooling
   (`tools/evals/run.py --matrix`) is ready; the matrix was last built against
   0.9.x. Waits on two decisions: whether `chestertons-fence-guard` is still
@@ -51,4 +52,7 @@ Nothing in flight.
 - **Lean Codex plugin.** The plugin root is the repository root, so
   `codex plugin add` copies about 13 MB. If Codex honors an ignore file for
   plugin packaging, the docs, linter, evals and experiments could stay out of
-  the install.
+  the install. A `.codexignore` exists since #351, for the HOL scanner's
+  best-practice check; whether Codex reads it is unverified (see
+  `context/release-and-distribution.md`), so it lists local state only, not
+  the docs or the evals.

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,8 @@
 
 Open work that is not a bug and not a design question — those go to
 [issues](https://github.com/oliver-zehentleitner/keep-the-why/issues).
-Last reviewed: 2026-09-09.
+Last reviewed: 2026-09-09 (evening: measurement merged, issue forms and
+`context/issue-triage.md` in, labels `skill-wording` and `evals` created).
 
 ## In progress
 
@@ -12,15 +13,17 @@ Nothing in flight.
 
 ### Pending
 
-- [ ] **0.16.0 release measurement** — done, in pull request #357:
-  three full runs on the tag, 86, 84 and 81 of 87. Two cases flipped twice,
-  the same way each time, and are issues rather than caveats: #354 (the
-  request's "questions one at a time" answered with one list — the half of
-  #343 that did not hold), #355 (the frustration case naming the agent
-  tool's issue tracker; once with the skill never loaded). #356 is the
-  `Evidence: confirmed` flip that now recurs once per series, with the
-  linter's E104 in the path. Each of the three wants a wording decision
-  before a patch release; none changes what the skill writes to disk.
+- [ ] **Patch release after the 0.16.0 series.** The measurement is in
+  `docs/evals.md` (#357, 86, 84 and 81 of 87). Three findings are issues,
+  each waiting on a wording decision by the maintainer before anything is
+  patched: #354 (the request's "questions one at a time" answered with one
+  list), #355 (the frustration case naming the agent tool's issue tracker;
+  before deciding, one run of that case on Claude Code CLI 2.1.263 to
+  confirm or drop the CLI-version hypothesis), #356 (`Evidence: confirmed`
+  on a lost original reason — a `question`, the two readings are in the
+  issue). None of them changes what the skill writes to disk. Release
+  order as in `CONTRIBUTING.md`: linter first if a gate changes, then the
+  skill tag, then three runs into `docs/evals.md`.
 - [ ] **HOL / awesome-ai-plugins listing**
   ([hashgraph-online/awesome-ai-plugins#257](https://github.com/hashgraph-online/awesome-ai-plugins/pull/257)).
   Rebased on their request; all five catalog checks pass, including the

--- a/TODO.md
+++ b/TODO.md
@@ -22,11 +22,12 @@ Nothing in flight.
   to `-r3`.
 - [ ] **HOL / awesome-ai-plugins listing**
   ([hashgraph-online/awesome-ai-plugins#257](https://github.com/hashgraph-online/awesome-ai-plugins/pull/257)).
-  Contribution check passes; the maintainers' centralized scan still runs an
-  older scanner release whose secret heuristic flags an eval case id, which
-  is explained in the PR. Waits on their rerun or merge. Afterwards: claim
-  the listing on hol.org (repository owner), and add the HOL registry to
-  `llms.txt` under "Also Listed On".
+  Rebased on their request; all five catalog checks pass, including the
+  source-repository scan. Waits on their merge. Afterwards, two steps: the
+  repository owner claims the listing on hol.org ("Claim this listing" —
+  ownership proof, unlocks managing the registry page: media, first comment,
+  launch day); then add the HOL registry to `llms.txt` under "Also Listed
+  On".
 - [ ] **awesome-copilot**
   ([github/awesome-copilot#2998](https://github.com/github/awesome-copilot/pull/2998)),
   bump to 0.16.0, waits on their review; #2984 (0.15.0) is merged. Every


### PR DESCRIPTION
`TODO.md` after the 0.16.0 tag:

- The release item becomes the measurement item: three full eval runs on `v0.16.0` into `docs/evals.md`, series running.
- awesome-copilot: #2984 (0.15.0) is merged; the 0.16.0 bump is github/awesome-copilot#2998, waiting on review.
- Lean-Codex-plugin idea: notes that `.codexignore` exists since #351 and what it does not do.
