### PR TITLE
Issue templates: rewritten for Keep the Why

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,154 +1,96 @@
 name: Bug report
-description: Report a bug with this library.
+description: The linter, the GitHub Action, the docs, or the evals tooling does something wrong.
 labels: bug
 assignees:
   - oliver-zehentleitner
 body:
   - type: markdown
     attributes:
-      value: | 
-        Please post here only issues concerning this repository and follow the [Issue-Guidelines](https://github.com/oliver-zehentleitner/unicorn-binance-suite/wiki/Issue-Guidelines). 
-        
-        Most of these fields are not mandatory, but please provide as much information as possible.
+      value: |
+        Use this for anything in this repository that runs as code or is published as text: `ktw-lint`, the `keep-the-why-lint` GitHub Action, the documentation at keepthewhy.com, the evals runner in `tools/evals/`. If the agent behaved differently than the skill describes, use the *Skill behavior report* template instead.
 
   - type: checkboxes
-    id: Confirmation
+    id: confirmation
     attributes:
-      label: Solution to Issue cannot be found in the documentation or other Issues and also occurs in the latest version of this library.
-      description: |
-        I have searched for other Issues with the same problem or similar feature requests and have looked in the documentation. This issue also affects the latest version of this library.
+      label: Before you file
       options:
-        - label: I checked the documentation and other Issues. I am using the latest version of this library.
+        - label: I searched the existing issues and the documentation. The problem still occurs on the latest release.
           required: true
 
-  - type: textarea
-    id: Version
-    attributes:
-      label: Version of this library.
-      description: |
-        Please control what version you are using with [this script](https://github.com/oliver-zehentleitner/unicorn-binance-suite/blob/master/tools/get_versions_of_unicorn_packages.py) and post the output:
-    validations:
-      required: true
-
   - type: dropdown
-    id: Hardware
+    id: component
     attributes:
-      label: Hardware?
-      description: |
-        In which hardware environment is the code executed?
+      label: Component
       options:
-        - Local server/workstation
-        - Raspberry Pi
-        - VPS or other cloud hosting
+        - ktw-lint (local run)
+        - GitHub Action (oliver-zehentleitner/keep-the-why@lint-...)
+        - Documentation (keepthewhy.com or the Markdown in the repository)
+        - Evals tooling (tools/evals/)
+        - Repository structure / specification
+        - Other (please explain below)
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: |
+        `ktw-lint --version` for the linter; the `@lint-...` ref for the Action; the skill version (`metadata.version` in `SKILL.md`) or the page URL for the docs.
+      placeholder: "ktw-lint 0.16.0.0"
     validations:
       required: true
 
   - type: dropdown
-    id: OS
+    id: os
     attributes:
-      label: Operating System?
-      description: |
-        In which operating system is the code executed?
+      label: Operating system
       options:
         - Linux
         - macOS
         - Windows
-        - Other (please explain)
+        - GitHub-hosted runner
+        - Other (please explain below)
     validations:
-      required: true
+      required: false
 
   - type: dropdown
-    id: Python
+    id: python
     attributes:
-      label: Python version?
-      description: |
-        In which Python version is the code executed?
+      label: Python version
+      description: Only for the linter and the evals tooling.
       options:
-        - Python3.9
-        - Python3.10
-        - Python3.11
-        - Python3.12
-        - Python3.13
-        - Python3.14
+        - Python 3.10
+        - Python 3.11
+        - Python 3.12
+        - Python 3.13
+        - Python 3.14
     validations:
-      required: true
+      required: false
 
   - type: textarea
-    id: WheelInfo
+    id: command
     attributes:
-      label: Installed wheel files
+      label: Command and output
       description: |
-        Please share your installed wheel files of this library. Run `pip show unicorn-binance-rest-api --files | 
-        grep '  '` or `conda list -f unicorn-binance-rest-api | grep '  '` and post the result:
+        The exact command or workflow step, and its full output. For the Action, the job log of the failing step. Remove anything confidential.
       render: shell
     validations:
       required: false
 
   - type: textarea
-    id: Packages
+    id: input_files
     attributes:
-      label: Installed packages
+      label: Input that triggers it
       description: |
-        Please share your installed packages by running `pip list` or `conda list` and entering the output below:
-      render: shell
+        For linter findings you consider wrong: the `context/` entry or `.keep-the-why` line the finding points at, and the finding code (`E104`, `W003`, ...). Project and personal `.keep-the-why` settings if they matter.
+      render: markdown
     validations:
       required: false
 
   - type: textarea
-    id: Log
+    id: issue
     attributes:
-      label: Logging output
-      description: |
-        Please share the logging output here (REMOVE API_KEY, API_SECRET, LISTEN_KEY!!):
-        _Note:_ This will be automatically formatted as code.
-      placeholder: "logfile"
-      render: shell
-    validations:
-      required: false
-
-  - type: dropdown
-    id: Processing
-    attributes:
-      label: Processing method?
-      description: |
-        Are you using the `stream_buffer` or the `process_stream_data`-callback function?
-      options:
-        - process_asyncio_queue
-        - process_stream_data
-        - process_stream_data_async
-        - stream_buffer
-    validations:
-      required: true
-
-  - type: dropdown
-    id: Endpoint
-    attributes:
-      label: Used endpoint?
-      description: |
-        To which endpoint do you connect?
-      options:
-        - concerns all
-        - binance.com
-        - binance.com-testnet
-        - binance.com-margin
-        - binance.com-margin-testnet
-        - binance.com-isolated_margin
-        - binance.com-isolated_margin-testnet
-        - binance.com-futures
-        - binance.com-futures-testnet
-        - binance.com-coin_futures
-        - binance.com-vanilla-options
-        - binance.com-vanilla-options-testnet
-        - binance.us
-        - trbinance.com
-    validations:
-      required: true
-
-  - type: textarea
-    id: Issue
-    attributes:
-      label: Issue
-      description: |
-        Please describe the issue you are experiencing:
+      label: What happens, and what you expected instead
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,14 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Keep The Why Discussions
+  - name: Questions and ideas — Discussions
     url: https://github.com/oliver-zehentleitner/keep-the-why/discussions
-    about: Ask general questions.
-  - name: Keep The Why docs
+    about: Not sure it's a bug, or want to talk a design question through first? Start a discussion.
+  - name: Documentation — keepthewhy.com
     url: https://keepthewhy.com/
-    about: The complete UNICORN Binance WebSocket API documentation.
-  - name: UNICORN Devs Chat
+    about: Installation, the specification, linting, evals, the agent and model matrix.
+  - name: Security
+    url: https://github.com/oliver-zehentleitner/keep-the-why/blob/main/SECURITY.md
+    about: How to report a security issue privately instead of in a public issue.
+  - name: Community chat — Telegram
     url: https://t.me/unicorndevs
-    about: Chat with the community about Keep The Why and ask general questions.
+    about: Chat with the maintainer and other users.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,52 +1,63 @@
 name: Feature request
-description: Suggest an idea for this library.
-labels: enhancement 
+description: Suggest a change to the skill, the specification, the linter, or the docs.
+labels: enhancement
 assignees:
   - oliver-zehentleitner
 body:
   - type: markdown
     attributes:
       value: |
-        Please post here only issues concerning this repository and follow the [Issue-Guidelines](https://github.com/oliver-zehentleitner/unicorn-binance-suite/wiki/Issue-Guidelines). 
-        
-        Most of these fields are not mandatory, but please provide as much information as possible.
-  - type: textarea
-    id: Problem
+        Before proposing, have a look at this repository's own [`context/`](https://github.com/oliver-zehentleitner/keep-the-why/tree/main/context) — it records the decisions behind the skill, including alternatives that were considered and rejected, and why. If your idea is one of them, say what has changed since.
+
+        For anything beyond a small fix, an issue first is appreciated so the direction can be discussed before code or wording is written (see [CONTRIBUTING.md](https://github.com/oliver-zehentleitner/keep-the-why/blob/main/CONTRIBUTING.md)).
+
+  - type: dropdown
+    id: area
     attributes:
-      label: Is your feature request related to a problem? Please describe.
-      description: |
-        A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
-      placeholder: 
+      label: Which part
+      options:
+        - Skill behavior (SKILL.md, references)
+        - Specification / entry format / repository structure
+        - Linter (ktw-lint) or GitHub Action
+        - Setup wizards and settings
+        - Documentation
+        - Evals
+        - Other
     validations:
-      required: false
-      
+      required: true
+
   - type: textarea
-    id: Solution
+    id: problem
     attributes:
-      label: Describe the solution you'd like.
+      label: What problem does this solve?
       description: |
-        A clear and concise description of what you want to happen.
-      placeholder: 
+        The situation where the current behavior gets in the way, as concretely as you can. "When the agent ... I have to ..." beats a general wish.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: What should happen instead?
+      description: |
+        The behavior or change you would like. For skill behavior, the sentence you would expect to find in `SKILL.md` is a fine way to put it.
     validations:
       required: false
 
   - type: textarea
-    id: Alternatives
+    id: alternatives
     attributes:
-      label: Describe alternatives you've considered
+      label: Alternatives you considered
       description: |
-        A clear and concise description of any alternative solutions or features you've considered.
-      placeholder: 
+        Other ways to get there, and why you prefer the one above. Rejected alternatives are part of the record here — they end up in `context/` if the change lands.
     validations:
       required: false
 
   - type: textarea
-    id: Additional
+    id: additional
     attributes:
       label: Additional context
       description: |
-        Add any other context or screenshots about the feature request here.
-      placeholder: 
+        Agent tool, model, install route, links, transcript excerpts — whatever helps.
     validations:
       required: false
-

--- a/.github/ISSUE_TEMPLATE/skill_behavior.yml
+++ b/.github/ISSUE_TEMPLATE/skill_behavior.yml
@@ -1,0 +1,133 @@
+name: Skill behavior report
+description: The agent did something the skill says it should not, or skipped something it should have done.
+labels: skill-wording
+assignees:
+  - oliver-zehentleitner
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this when the skill was loaded and the agent still deviated from what `SKILL.md` or the references describe — it wrote an entry without asking when it should have asked, invented a reason, skipped the setup wizard, ignored a setting, and so on. For the linter, the GitHub Action or the docs use the *Bug report* template instead.
+
+        Most fields are optional, but the more of them you fill in, the better the chance the behavior can be reproduced. The single most useful thing is the transcript excerpt.
+
+  - type: checkboxes
+    id: confirmation
+    attributes:
+      label: Before you file
+      options:
+        - label: I searched the existing issues and the documentation for this behavior.
+          required: true
+        - label: The skill was actually loaded in the session (the agent read `SKILL.md`, not just the `.keep-the-why` file or a "Keep the Why" section in `AGENTS.md`). If you are not sure, say so below — an activation miss is a different problem and worth knowing too.
+          required: false
+
+  - type: input
+    id: skill_version
+    attributes:
+      label: Skill version
+      description: |
+        The `version` line in the installed `SKILL.md` frontmatter (`metadata.version`). Not the `context-schema` of your project — that is what the project was last migrated to, not what the agent ran.
+      placeholder: "0.16.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install_route
+    attributes:
+      label: Install route
+      options:
+        - skills CLI (npx skills add ...)
+        - GitHub CLI (gh ...)
+        - asm
+        - Codex plugin (codex plugin add ...)
+        - GitHub Copilot plugin marketplace
+        - Manual clone / vendored copy in the repository
+        - Other (please explain below)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: agent
+    attributes:
+      label: Agent tool
+      options:
+        - Claude Code
+        - Codex CLI
+        - Gemini CLI
+        - GitHub Copilot
+        - Cline
+        - opencode
+        - Hermes
+        - Kimi Code
+        - Pi / oh-my-pi
+        - Other (please explain below)
+    validations:
+      required: true
+
+  - type: input
+    id: agent_version
+    attributes:
+      label: Agent tool version and model
+      description: |
+        For example `Claude Code 2.1.266, Claude Sonnet 5` or `Codex CLI 0.48, GPT-5.2 via OpenRouter`. Local models: name and quantization.
+      placeholder: "Claude Code 2.1.266, Claude Sonnet 5"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: frequency
+    attributes:
+      label: How often does it happen?
+      options:
+        - Every time I try
+        - Sometimes (please say roughly how often below)
+        - Once so far
+    validations:
+      required: true
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Project and personal settings
+      description: |
+        The content of the project's `.keep-the-why` file, and the relevant lines of your personal file (`~/.keep-the-why/<id>.md`) — `capture-mode`, `capture-confirmation`, `confirmation-flow`, `local-lint`, and anything else you changed from the default. Leave out what you consider private.
+      render: yaml
+    validations:
+      required: false
+
+  - type: textarea
+    id: what_you_asked
+    attributes:
+      label: What you asked the agent
+      description: |
+        The request or the situation that triggered the skill — as close to verbatim as you can.
+    validations:
+      required: true
+
+  - type: textarea
+    id: what_happened
+    attributes:
+      label: What the agent did
+      description: |
+        What happened, including what it wrote to disk (file names are enough; the entry itself is welcome if it is not confidential).
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What the skill says should have happened
+      description: |
+        The rule you expected to apply, with the section of `SKILL.md` or the reference file if you know it. If you are not sure what the skill says, describe what you expected and why.
+    validations:
+      required: true
+
+  - type: textarea
+    id: transcript
+    attributes:
+      label: Transcript excerpt
+      description: |
+        The relevant part of the session, ideally including the agent's own explanation of why it acted as it did. Remove API keys, tokens, and anything confidential from your project. Paths and file names are fine and help.
+      render: text
+    validations:
+      required: false


### PR DESCRIPTION
Reworks the three forms uploaded in 22eb9ad, which were the UNICORN Binance Suite templates (Binance endpoints, stream processing, wheel files, UBS wiki guidelines, UBWA docs description in the contact links).

**Three forms instead of two**, because the information needed differs:

- **Skill behavior report** (`skill-wording`): the agent deviated from what `SKILL.md` describes. Skill version (`metadata.version`, explicitly not `context-schema`), install route, agent tool + version + model, how often, project/personal settings, what was asked / what the agent did / what the skill says, transcript excerpt. A second, optional checkbox asks whether the skill was actually loaded — an activation miss is a different problem.
- **Bug report** (`bug`): ktw-lint, the Action, docs, evals tooling. Component, version, OS incl. GitHub-hosted runner, Python 3.10–3.14 (the linter's floor), command + output, the triggering input and finding code.
- **Feature request** (`enhancement`): sends people to this repository's own `context/` first for rejected alternatives, area dropdown, problem before solution.

**config.yml:** Discussions for questions, keepthewhy.com with a correct description, SECURITY.md for private reports, Telegram kept (it is the community badge in the README). Blank issues stay enabled.

Labels `skill-wording` and `evals` exist since today (#354–#356). The skill-behavior form auto-labels `skill-wording` on the assumption that most such reports are that; a deterministic one gets relabeled `bug` at triage.