### PR TITLE
Issue templates: drop the duplicate Security contact link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,9 +6,6 @@ contact_links:
   - name: Documentation — keepthewhy.com
     url: https://keepthewhy.com/
     about: Installation, the specification, linting, evals, the agent and model matrix.
-  - name: Security
-    url: https://github.com/oliver-zehentleitner/keep-the-why/blob/main/SECURITY.md
-    about: How to report a security issue privately instead of in a public issue.
   - name: Community chat — Telegram
     url: https://t.me/unicorndevs
     about: Chat with the maintainer and other users.


### PR DESCRIPTION
GitHub renders a "Report a security vulnerability" link in the issue chooser on its own whenever `SECURITY.md` exists; that one cannot be removed from `config.yml`. The hand-written Security contact link from #358 duplicated it, so it goes. Discussions, docs and Telegram stay.