### PR TITLE
docs: move Linting directly under Specification in nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,8 +59,8 @@ nav:
   - Installation: installation.md
   - Repository structure: repository-structure.md
   - Specification: specification.md
-  - Security: security.md
   - Linting: linting.md
+  - Security: security.md
   - Evals: evals.md
   - Badge: badge.md
   - FAQ: faq.md


### PR DESCRIPTION
Reorders the top-level docs nav so Linting follows Specification; Security moves one slot down. No content changes.