### PR TITLE
docs: installation trust bullets name what the skill can run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Changed
 
+- `docs/installation.md`, "Trust and scope": the two bullets that read as "nothing runs on your machine" say what the instructions can trigger since the 0.15.0 wizard defaults — the linter, installed by name from PyPI and run after writes when the wizard's yes stands, and the session hook that autostart writes into the project's agent settings. The package itself is still Markdown only; the bounds stay on the Security page, which already described both.
 - `docs/evals.md` carries the 0.16.0 release measurement: three consecutive full runs on the tag (86, 84 and 81 of 87), the four numbers per run, a note on every failed run, a new run-history row. The two-messages rule from #343 held in all nine wizard sessions; two cases flipped twice, the same way each time — the request's "questions one at a time" answered with one list (#354) and the frustration case naming the agent tool's issue tracker instead of this project's (#355, once with the skill never loaded) — and `Evidence: confirmed` on a lost original reason recurred once per series (#356). Run 3 had the series' three genuine activation misses.
 
 ## [0.16.0] - 2026-09-09

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,8 +6,8 @@ Keep the Why is a repo-native convention and agent skill; this page installs the
 
 Before installing anything that runs inside an agent, know what you're actually getting:
 
-- **No executable code.** The skill package (`skills/keep-the-why/`) is instructions only — `SKILL.md`, `references/*.md`, `examples/*.md`. No scripts, no binaries.
-- **No network access of its own.** There's nothing to run, so there's nothing that calls out anywhere. Whatever network access exists is your agent's own, not something this skill adds.
+- **The skill package is instructions only.** `skills/keep-the-why/` is `SKILL.md`, `references/*.md`, `examples/*.md` — no scripts, no binaries. What the instructions can trigger is one thing: the linter, `keep-the-why-lint`, installed by its fixed name from PyPI and run after writes when you say yes in the setup wizard (the wizard's default is yes; `no` turns it off). Autostart, if you enable it, writes a session hook into the project's agent settings — a file you see and commit. The exact bounds are on [Security](security.md).
+- **No network access of its own.** The package has nothing that calls out. The one install the skill may ask for is that PyPI package; everything else is your agent's own network access, not something this skill adds.
 - **No external services.** No database, no MCP server, no account, no API key.
 - **Install a tagged release, not `main`.** `main` is where active development happens and isn't guaranteed release-ready at any given moment — installing without pinning tracks it directly. A `latest` tag always points to the newest release, moved automatically by CI whenever one ships. Every install method below shows how to pin to it (or to an exact version, for full reproducibility).
 - **Updating is explicit**, never automatic — see "Updating" below.
@@ -49,7 +49,7 @@ With [`gh`](https://cli.github.com/) v2.90.0 or later — `gh skill` is [in publ
 gh skill preview oliver-zehentleitner/keep-the-why keep-the-why
 ```
 
-GitHub's own guidance: skills aren't verified by GitHub and may contain prompt injections, hidden instructions, or malicious scripts — inspect before installing. Keep the Why ships instructions only, no executable scripts; see [Security](security.md) for what that means in practice, including an independent SkillsLLM scan. Then, pinned to a release:
+GitHub's own guidance: skills aren't verified by GitHub and may contain prompt injections, hidden instructions, or malicious scripts — inspect before installing. The Keep the Why package ships no scripts; the linter it can install is covered on [Security](security.md), along with an independent SkillsLLM scan. Then, pinned to a release:
 
 ```bash
 gh skill install oliver-zehentleitner/keep-the-why keep-the-why@latest

--- a/tools/evals/README.md
+++ b/tools/evals/README.md
@@ -3,7 +3,7 @@
 Runs the skill's eval cases (`tools/evals/evals.json`) against a
 real agent and grades the results. This is a development tool for this
 repository — deliberately **not** part of the installable skill package, which
-ships instructions only, no executable code.
+ships instructions only, no scripts of its own.
 
 ## How it works
 


### PR DESCRIPTION
The "Trust and scope" bullets on `docs/installation.md` said **No executable code** and **there's nothing to run**. Both predate `local-lint` and the 0.15.0 wizard defaults. The package under `skills/keep-the-why/` is still Markdown only, but the instructions now, by default, install `keep-the-why-lint` from PyPI and run it after writes, and autostart writes a `SessionStart` hook into the project's agent settings. A reader taking the bullets at face value expects neither.

- The first bullet becomes **The skill package is instructions only** and names the two things the instructions can trigger, with the wizard's default and the off switch, pointing to Security for the exact bounds (the "The skill installs and runs the linter" section already covers them).
- The network bullet drops "there's nothing to run" and names the one install the skill may ask for.
- The GitHub-guidance sentence above the install commands no longer says "no executable scripts" for the skill as a whole.
- `tools/evals/README.md`: same claim, narrowed to "no scripts of its own".
- CHANGELOG under Unreleased.

No change to the skill, the linter or the Security page.