### PR TITLE
docs: HOL AI plugin registry under Also listed on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Changed
 
+- README, `docs/installation.md` and `llms.txt` list the HOL AI plugin registry under "Also listed on" (owner-verified since 2026-09-10, via hashgraph-online/awesome-ai-plugins#257).
 - `docs/installation.md`, "Trust and scope": the two bullets that read as "nothing runs on your machine" say what the instructions can trigger since the 0.15.0 wizard defaults — the linter, installed by name from PyPI and run after writes when the wizard's yes stands, and the session hook that autostart writes into the project's agent settings. The package itself is still Markdown only; the bounds stay on the Security page, which already described both.
 - `docs/evals.md` carries the 0.16.0 release measurement: three consecutive full runs on the tag (86, 84 and 81 of 87), the four numbers per run, a note on every failed run, a new run-history row. The two-messages rule from #343 held in all nine wizard sessions; two cases flipped twice, the same way each time — the request's "questions one at a time" answered with one list (#354) and the frustration case naming the agent tool's issue tracker instead of this project's (#355, once with the skill never loaded) — and `Evidence: confirmed` on a lost original reason recurred once per series (#356). Run 3 had the series' three genuine activation misses.
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Full install detail for every method, including tools without a skill runtime at
 - [ASM](https://luongnv.com/asm/#/skills/oliver-zehentleitner%2Fkeep-the-why%3A%3Askills%2Fkeep-the-why%3A%3Akeep-the-why)
 - [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills#context-engineering)
 - [GitHub Copilot plugin marketplace](https://awesome-copilot.github.com/plugin/keep-the-why/)
+- [HOL AI plugin registry](https://hol.org/registry/plugins/oliver-zehentleitner%2Fkeep-the-why)
 - [MCP Market](https://mcpmarket.com/tools/skills/keep-the-why)
 - [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why)
 - [SkillsLLM](https://skillsllm.com/skill/keep-the-why)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,6 +37,7 @@ Either form prompts for which of its 70+ supported agents (Claude Code, Codex, O
 | [ASM](https://luongnv.com/asm/#/skills/oliver-zehentleitner%2Fkeep-the-why%3A%3Askills%2Fkeep-the-why%3A%3Akeep-the-why) | Curated skill index for the `asm` CLI; installable via `asm install keep-the-why` |
 | [awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills#context-engineering) | Listed under "Context Engineering" |
 | [GitHub Copilot plugin marketplace](https://awesome-copilot.github.com/plugin/keep-the-why/) | Installable via `copilot plugin install keep-the-why@awesome-copilot` |
+| [HOL AI plugin registry](https://hol.org/registry/plugins/oliver-zehentleitner%2Fkeep-the-why) | Owner-verified listing; the registry's scanner is the one this repository runs itself, see [Security](security.md) |
 | [MCP Market](https://mcpmarket.com/tools/skills/keep-the-why) | Skill marketplace listing |
 | [skills.sh](https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why) | Backs the `npx skills add` install method above |
 | [SkillsLLM](https://skillsllm.com/skill/keep-the-why) | Verified, passed [SkillsLLM's security scan](https://skillsllm.com/security-check/IPmNycVdbOyq) |

--- a/llms.txt
+++ b/llms.txt
@@ -117,6 +117,7 @@ the project back up without needing to be told again.
   https://github.com/VoltAgent/awesome-agent-skills#context-engineering
 - GitHub Copilot plugin marketplace: installable via `copilot plugin install
   keep-the-why@awesome-copilot` — https://awesome-copilot.github.com/plugin/keep-the-why/
+- HOL AI plugin registry: owner-verified listing — https://hol.org/registry/plugins/oliver-zehentleitner%2Fkeep-the-why
 - MCP Market: skill marketplace listing — https://mcpmarket.com/tools/skills/keep-the-why
 - skills.sh: https://skills.sh/oliver-zehentleitner/keep-the-why/keep-the-why — backs
   the `npx skills add` method above


### PR DESCRIPTION
The HOL registry page is live and owner-verified (https://hol.org/registry/plugins/oliver-zehentleitner%2Fkeep-the-why), the last step of the awesome-ai-plugins listing (hashgraph-online/awesome-ai-plugins#257).

- README "Also listed on": one line, alphabetical between GitHub Copilot and MCP Market.
- `docs/installation.md` table: same, with the note that the registry's scanner is the one this repository already runs (Security page).
- `llms.txt` "Also Listed On": same line.
- CHANGELOG under Unreleased.

No other change.