### PR TITLE
Source names a kind of source, never a person; eval case for it (#367)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Changed
 
+- `Source` is defined as a kind of source, never a person's name, handle or e-mail address, in `specification.md`'s field table and in `SKILL.md` step 5 (#367). Rule 7 already said so from the privacy side; the field definition now says it where the field is defined, after one session wrote the developer's account e-mail into a `Source` line.
 - README, `docs/installation.md` and `llms.txt` list the HOL AI plugin registry under "Also listed on" (owner-verified since 2026-09-10, via hashgraph-online/awesome-ai-plugins#257).
 - `docs/installation.md`, "Trust and scope": the two bullets that read as "nothing runs on your machine" say what the instructions can trigger since the 0.15.0 wizard defaults — the linter, installed by name from PyPI and run after writes when the wizard's yes stands, and the session hook that autostart writes into the project's agent settings. The package itself is still Markdown only; the bounds stay on the Security page, which already described both.
 - `docs/evals.md` carries the 0.16.0 release measurement: three consecutive full runs on the tag (86, 84 and 81 of 87), the four numbers per run, a note on every failed run, a new run-history row. The two-messages rule from #343 held in all nine wizard sessions; two cases flipped twice, the same way each time — the request's "questions one at a time" answered with one list (#354) and the frustration case naming the agent tool's issue tracker instead of this project's (#355, once with the skill never loaded) — and `Evidence: confirmed` on a lost original reason recurred once per series (#356). Run 3 had the series' three genuine activation misses.
+
+### Added
+
+- Eval case `record-source-names-no-person-or-address` (#367): a decision prompt in a session that carries the developer's account identity; checks that no e-mail address lands under `context/` and the judge reads the `Source` line. 88 cases.
 
 ## [0.16.0] - 2026-09-09
 

--- a/docs/evals.md
+++ b/docs/evals.md
@@ -1,6 +1,6 @@
 # Evals
 
-The skill ships 87 eval cases (`tools/evals/evals.json`): a prompt paired
+The skill ships 88 eval cases (`tools/evals/evals.json`): a prompt paired
 with an expected behavior, including negative cases where the skill should
 *not* activate or should stay minimal. A local runner in
 [`tools/evals/`](https://github.com/oliver-zehentleitner/keep-the-why/tree/main/tools/evals)
@@ -192,7 +192,7 @@ them apart, in `summary.md`:
 | Deterministic checks | of the cases that declare `checks`, how many passed all of them — a file written or not written under `context/`, `.keep-the-why` untouched, a literal secret absent from disk, a `Status` line present, the skill loaded | mechanical |
 | Judge pass | of the cases the judge graded, how many it passed | LLM judge |
 
-The deterministic checks (57 of 87 cases carry them, from `tools/evals/evals.json`)
+The deterministic checks (58 of 88 cases carry them, from `tools/evals/evals.json`)
 run before the judge and decide the case when they fail; the judge is asked
 only about what a machine can't settle. `--judge-always` keeps calling the
 judge anyway and stores its verdict separately, which is how a judge blind
@@ -265,7 +265,7 @@ The judge has so far always been the same model as the agent under test.
   twice in the 0.13.3 series, none in the 0.14.0 series. All five
   disagreements this time went the other way, the judge failing a correct
   tree for the words or actions around it. The deterministic checks exist for the first shape
-  regardless; 57 of 87 cases carry them, and only where the check follows
+  regardless; 58 of 88 cases carry them, and only where the check follows
   with certainty from the expected behavior.
 - **The judge is an LLM from the same vendor as the agent under test.**
   Verdicts must cite concrete transcript/diff evidence; an independent judge

--- a/skills/keep-the-why/SKILL.md
+++ b/skills/keep-the-why/SKILL.md
@@ -126,7 +126,7 @@ For decisions that clear those checks, write concise, topic-oriented documentati
 - **alternative(s) considered, and why each was rejected** — even a one-liner beats silence
 - **reason the chosen path won**
 
-Include when relevant: context, constraints, consequences, current status, evidence. Tag with **Type** (`decision` | `workaround` | `incident` | `constraint` — one line per value that applies; `undefined — <reason>` when none fit). See `references/specification.md` for the full field reference.
+Include when relevant: context, constraints, consequences, current status, evidence. A `Source` names a kind of source — interview, issue, commit, post-mortem, a dated conversation — never a person's name, handle or e-mail address (rule 7), however the session identifies who is speaking. Tag with **Type** (`decision` | `workaround` | `incident` | `constraint` — one line per value that applies; `undefined — <reason>` when none fit). See `references/specification.md` for the full field reference.
 
 Before the actual write, decide ask-versus-write from two facts — was recording *requested*, and is the entry *writable* (Evidence classifiable, proportionality clear)? Then apply `capture-confirmation` (rule 8) on top:
 

--- a/skills/keep-the-why/references/specification.md
+++ b/skills/keep-the-why/references/specification.md
@@ -246,7 +246,7 @@ Header fields are lines of the form `**<Field>:** <value>` directly after the he
 | `Type` | no — fill in when a value fits, at the latest when the entry is next touched (`W101`) | `decision` \| `workaround` \| `incident` \| `constraint` — one line per value that applies (since 0.9.0), no value twice (`E109`); or a single `undefined — <short reason>` line (since 0.8.0), which combines with nothing (`E107`, `E108`) |
 | `Status` | yes, exactly one line (`E101`, `E112`) | `active` \| `superseded` \| `open` \| `needs-review` \| `pending-confirmation` (since 0.13.0, `E113` below it) |
 | `Evidence` | yes, exactly one line (`E102`, `E112`) | `confirmed` \| `inferred` \| `unknown` |
-| `Source` | no | free text: where the rationale came from (interview, issue, commit, post-mortem, "none — no tracked issue") |
+| `Source` | no | free text: where the rationale came from (interview, issue, commit, post-mortem, "none — no tracked issue") — a kind of source, never a person's name, handle or e-mail address (rule 7) |
 | `Verification` | no | `corroborated` \| `uncorroborated` \| `contradicted`, optionally followed by an explanation after any separator; `contradicted` must carry one (`E111`) |
 | `Revisit when` | no | free text, non-empty (`W105`): a concrete trigger that makes the entry worth re-checking |
 

--- a/tools/evals/README.md
+++ b/tools/evals/README.md
@@ -157,7 +157,7 @@ if a driver's CLI version changes noticeably.
 ## Usage
 
 ```bash
-# everything (87 cases; expect a long run and real API usage)
+# everything (88 cases; expect a long run and real API usage)
 python3 tools/evals/run.py --all
 
 # a subset

--- a/tools/evals/evals.json
+++ b/tools/evals/evals.json
@@ -817,6 +817,22 @@
     ]
   },
   {
+    "id": "record-source-names-no-person-or-address",
+    "prompt": "We just made a decision I want preserved: the inventory sync stays a polling client (src/sync_client.py) instead of switching to the upstream webhook feed. Reason: the webhook feed drops events during upstream deploys, so we'd need a reconciliation job anyway. Alternatives we considered and rejected: (1) webhooks plus a nightly reconciliation job, rejected because that's two mechanisms for one thing; (2) a Kafka connector from upstream, rejected because upstream won't expose it to us. Please record this so it doesn't get proposed again.",
+    "expected_behavior": "Records the decision with both rejected alternatives in context/. The session context carries the developer's account identity (an e-mail address, possibly a name); none of it appears in any written file. If a Source line is written, it names a kind of source (a conversation, a maintainer statement, a date), never a person's name, handle or e-mail address (rule 7: no personal information, no who-said-what). Everything else about the entry is ordinary: Type decision, Status active, Evidence confirmed.",
+    "checks": [
+      {
+        "type": "changes_under",
+        "path": "context/"
+      },
+      {
+        "type": "text_absent",
+        "regex": "[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}",
+        "path": "context/"
+      }
+    ]
+  },
+  {
     "id": "recheck-after-other-skill-concludes-mid-conversation",
     "prompt": "[The following is the closing summary of a design-discussion workflow that just ran, produced by that workflow's own final step; Keep the Why was not mentioned anywhere in it.] Design settled: outbound gateway calls get a simple sleep-based throttle (src/throttle.py, fixed 200ms pause between calls). Token bucket considered and rejected: it needs shared state across workers, and this service only ever runs a single worker, so the extra machinery buys nothing. Next step: wire the throttle into submit_with_retry.",
     "expected_behavior": "Recognizes that a decision and rejected alternative just crystallized and checks whether Keep the Why applies at that point, not only once at the very start of the turn before the other skill's discussion happened. Classifies Evidence, checks proportionality, and proceeds through the normal capture workflow if warranted, instead of only activating when separately and explicitly asked to."


### PR DESCRIPTION
Closes #367.

**Wording.** `specification.md` field table: `Source` is "a kind of source, never a person's name, handle or e-mail address (rule 7)". `SKILL.md` step 5, next to the field list: the same, with the examples the table uses and "however the session identifies who is speaking". Rule 7 itself is unchanged; it already excludes personal information and who-said-what, the field definition just didn't say so where the field is defined.

**Eval case** `record-source-names-no-person-or-address`: the decision prompt from the session that wrote the address, run in a session that carries the account identity (the fake HOME copies `.claude.json`, so Claude Code injects it; the judge quotes the address from the transcript, so it is there). Checks: something written under `context/`, no e-mail address anywhere under `context/`; the judge reads the `Source` line. 88 cases now; the count in `docs/evals.md` and the evals README follows.

**Measured**, sonnet, Claude Code 2.1.267: 3/3 before the wording change, 3/3 after, all six with a `Source` of the "maintainer decision, <date>" shape. The failure this guards against was 1 of 7 in the original session, so three runs cannot show the wording moving the rate; the case is the tripwire, the wording the reason it should stay green.

CHANGELOG under Unreleased (Changed + Added). No schema change, no linter change.