### PR TITLE
cursor rule: check for .keep-the-why first, without it neither load nor mention the skill

### DIFF
--- a/context/release-and-distribution.md
+++ b/context/release-and-distribution.md
@@ -145,7 +145,7 @@ A third manifest, `.codex-plugin/plugin.json` (the official Codex format: `name`
 **Type:** decision
 **Status:** pending-confirmation
 **Evidence:** confirmed
-**Verification:** uncorroborated — first test in Cursor 3.19.19 (2026-09-10, local install via symlink under `~/.cursor/plugins/local/`): in the project with `.keep-the-why` the skill loaded first and the personal wizard ran, as it should; in a workspace without the file and with a neutral first request the agent still loaded the skill and announced it, no setup offered. The rule's negative case had been implicit ("does nothing") and was read as "load the skill, then do nothing"; reworded to check the file first and, without it, neither load nor mention the skill. Retest pending
+**Verification:** uncorroborated — first test in Cursor 3.19.19 (2026-09-10, local install via symlink under `~/.cursor/plugins/local/`): in the project with `.keep-the-why` the skill loaded first and the personal wizard ran, as it should; the second session, in a workspace without the file, opened with an explicit "load the keep-the-why skill", so it says nothing about the rule — the agent loaded on request and then behaved as the skill prescribes (no setup, no wizard, no timer check without a project id). The rule was reworded anyway to state the negative case first and explicitly, since "does nothing" left room to read it as "load, then do nothing". A session without the file and with a neutral first request is still to be run
 **Source:** maintainer decision, 2026-09-10, after looking at how another skill-shipping project packages for Cursor
 **Revisit when:** Cursor's review objects to the rule, the manifest format changes, or the rule turns out to fire where it should not
 

--- a/context/release-and-distribution.md
+++ b/context/release-and-distribution.md
@@ -145,7 +145,7 @@ A third manifest, `.codex-plugin/plugin.json` (the official Codex format: `name`
 **Type:** decision
 **Status:** pending-confirmation
 **Evidence:** confirmed
-**Verification:** uncorroborated — the manifest and rule follow Cursor's plugin documentation (manifest location, `skills/` and `rules/` at the plugin root, `.mdc` rule with `alwaysApply`), but neither the local install nor the rule has been exercised in Cursor yet; the maintainer's test before the marketplace submission settles it
+**Verification:** uncorroborated — first test in Cursor 3.19.19 (2026-09-10, local install via symlink under `~/.cursor/plugins/local/`): in the project with `.keep-the-why` the skill loaded first and the personal wizard ran, as it should; in a workspace without the file and with a neutral first request the agent still loaded the skill and announced it, no setup offered. The rule's negative case had been implicit ("does nothing") and was read as "load the skill, then do nothing"; reworded to check the file first and, without it, neither load nor mention the skill. Retest pending
 **Source:** maintainer decision, 2026-09-10, after looking at how another skill-shipping project packages for Cursor
 **Revisit when:** Cursor's review objects to the rule, the manifest format changes, or the rule turns out to fire where it should not
 

--- a/rules/keep-the-why.mdc
+++ b/rules/keep-the-why.mdc
@@ -1,6 +1,9 @@
 ---
-description: Load the keep-the-why skill first in a project that uses Keep the Why (a .keep-the-why file at the workspace root).
+description: In a project that uses Keep the Why (a .keep-the-why file at the workspace root), load the keep-the-why skill first. Anywhere else, leave the skill alone.
 alwaysApply: true
 ---
 
-If the workspace root contains a `.keep-the-why` file, this project keeps its reasoning with Keep the Why: load the `keep-the-why` skill before doing anything else in the session, whatever the first request is about. Without that file this rule does nothing — never set Keep the Why up unasked.
+First check whether the workspace root contains a `.keep-the-why` file.
+
+- It does not: do not load the `keep-the-why` skill, do not mention Keep the Why, do not offer to set it up. This rule is finished.
+- It does: this project keeps its reasoning with Keep the Why. Load the `keep-the-why` skill before doing anything else in the session, whatever the first request is about.


### PR DESCRIPTION
Follow-up to #369 from the first test in Cursor 3.19.19 (local install via symlink, model Grok 4.6 Medium):

- Project with `.keep-the-why`: skill loaded before the first answer, personal wizard ran. As intended.
- Workspace without the file (`~/Musik`): the session opened with an explicit "load the keep-the-why skill", so it says nothing about the rule. The agent loaded on request and then did what the skill prescribes: no setup offered, no wizard, no timer check without a project id.

The rule is reworded anyway: check for the file first, then the negative case spelled out (no file: do not load the skill, do not mention Keep the Why, do not offer setup), then the positive case, unchanged. "Without that file this rule does nothing" left room to read it as "load, then do nothing". `context/release-and-distribution.md` records both sessions under Verification; Status stays `pending-confirmation`.

Still to run after merge: `git pull` in the symlinked clone, Developer: Reload Window, one session in a workspace without `.keep-the-why` whose first request is neutral (expected: nothing about Keep the Why), one in the ktw repo (expected: skill loads first).