### PR TITLE
Prepare 0.16.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "keep-the-why",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Project memory for coding agents and humans: the reasoning behind a codebase as Markdown in the repo, versioned by Git, so nothing rejected is proposed twice.",
   "author": {
     "name": "Oliver Zehentleitner",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "keep-the-why",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Project memory for coding agents and humans: the reasoning behind a codebase as Markdown in the repo, versioned by Git, so nothing rejected is proposed twice.",
   "author": {
     "name": "Oliver Zehentleitner",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "keep-the-why",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Project memory for coding agents and humans: the reasoning behind a codebase as Markdown in the repo, versioned by Git, so nothing rejected is proposed twice.",
   "author": {
     "name": "Oliver Zehentleitner",

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -37,7 +37,7 @@ body:
       label: Version
       description: |
         `ktw-lint --version` for the linter; the `@lint-...` ref for the Action; the skill version (`metadata.version` in `SKILL.md`) or the page URL for the docs.
-      placeholder: "ktw-lint 0.16.0.0"
+      placeholder: "ktw-lint 0.16.1.0"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/skill_behavior.yml
+++ b/.github/ISSUE_TEMPLATE/skill_behavior.yml
@@ -27,7 +27,7 @@ body:
       label: Skill version
       description: |
         The `version` line in the installed `SKILL.md` frontmatter (`metadata.version`). Not the `context-schema` of your project — that is what the project was last migrated to, not what the agent ran.
-      placeholder: "0.16.0"
+      placeholder: "0.16.1"
     validations:
       required: true
 

--- a/.keep-the-why
+++ b/.keep-the-why
@@ -6,7 +6,7 @@ README, for what Keep the Why actually is.
 - id: oliver-zehentleitner---keep-the-why
 - context: `context/`
 - init: complete
-- context-schema: 0.16.0
+- context-schema: 0.16.1
 - capture-confirmation: confirm-always
 - source-reference: never
 <!-- /keep-the-why:config -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+## [0.16.1] - 2026-09-10
+
 ### Changed
 
+- `keep-the-why-lint` 0.16.1.0: knows schema 0.16.1 — no new gate, nothing changes what `context/` or `.keep-the-why` must look like. Published before the skill tag, per the checklist.
 - A presentation preference stated in the request ("questions one at a time", "just give me the list") governs both wizards, the project list included: `SKILL.md` step 0 says so where the wizards are described, `setup.md`'s "Both wizards" paragraph spells out that "one at a time" opens the project wizard with its first question (#354). Measured on `negative-existing-good-structure-untouched`: 2 of 3 before, 3 of 3 after.
 - The feedback sentence in `SKILL.md` says the tracker is this skill's own, not the agent tool's; and the skill's frontmatter description names complaints, feedback and settings changes about the skill itself, so a harness matching on the description loads it for exactly that request (#355). Measured on `user-frustration-surfaces-feedback-link`: the failures were all sessions with the skill never loaded; 5 of 5 with the description extended. Reasoning in `context/`.
 - One `Evidence` word per entry: when parts stand differently, the weakest grade wins and the body says which part is which — `specification.md` beside the field definition, `SKILL.md` rule 2 in one sentence (#356). Measured on `capture-confirmation-automatic-unclear-evidence`: 2 of 3 before, 3 of 3 after. Reasoning in `context/entry-format.md`.
@@ -645,7 +648,8 @@ Initial release.
 - Logo, wordmark, and favicon.
 - `context/repo-conventions.md`, dogfooding the skill on its own repository from day one.
 
-[Unreleased]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.16.0...HEAD
+[Unreleased]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.16.1...HEAD
+[0.16.1]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.14.1...v0.15.0
 [0.14.1]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.14.0...v0.14.1

--- a/TODO.md
+++ b/TODO.md
@@ -12,17 +12,6 @@ Nothing in flight.
 
 ### Pending
 
-- [ ] **Patch release after the 0.16.0 series.** The measurement is in
-  `docs/evals.md` (#357, 86, 84 and 81 of 87). Three findings are issues,
-  each waiting on a wording decision by the maintainer before anything is
-  patched: #354 (the request's "questions one at a time" answered with one
-  list), #355 (the frustration case naming the agent tool's issue tracker;
-  before deciding, one run of that case on Claude Code CLI 2.1.263 to
-  confirm or drop the CLI-version hypothesis), #356 (`Evidence: confirmed`
-  on a lost original reason — a `question`, the two readings are in the
-  issue). None of them changes what the skill writes to disk. Release
-  order as in `CONTRIBUTING.md`: linter first if a gate changes, then the
-  skill tag, then three runs into `docs/evals.md`.
 - [ ] **awesome-copilot**
   ([github/awesome-copilot#2998](https://github.com/github/awesome-copilot/pull/2998)),
   bump to 0.16.0, waits on their review; #2984 (0.15.0) is merged. Every

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -83,7 +83,7 @@ codex plugin marketplace add oliver-zehentleitner/keep-the-why
 codex plugin add keep-the-why@keep-the-why
 ```
 
-Add `--ref v0.16.0` (any [release tag](https://github.com/oliver-zehentleitner/keep-the-why/releases)) to the first command to pin a version; without it Codex snapshots the default branch, and `codex plugin marketplace upgrade` refreshes it. The plugin lands under `~/.codex/plugins/cache/keep-the-why/`, and a new session lists the skill as `keep-the-why:keep-the-why`. Verified 2026-09-08 with Codex CLI 0.149.0, from a local path and from GitHub. `codex plugin remove keep-the-why@keep-the-why` uninstalls it; the skill-directory route below works for Codex too, and does not copy the whole repository.
+Add `--ref v0.16.1` (any [release tag](https://github.com/oliver-zehentleitner/keep-the-why/releases)) to the first command to pin a version; without it Codex snapshots the default branch, and `codex plugin marketplace upgrade` refreshes it. The plugin lands under `~/.codex/plugins/cache/keep-the-why/`, and a new session lists the skill as `keep-the-why:keep-the-why`. Verified 2026-09-08 with Codex CLI 0.149.0, from a local path and from GitHub. `codex plugin remove keep-the-why@keep-the-why` uninstalls it; the skill-directory route below works for Codex too, and does not copy the whole repository.
 
 ## Also installable: Cursor plugin
 

--- a/lint/ktw_lint/__init__.py
+++ b/lint/ktw_lint/__init__.py
@@ -13,6 +13,6 @@ changes. PEP 440, not strict SemVer — PyPI rejects the SemVer build-
 metadata spelling this would otherwise use.
 """
 
-__version__ = "0.16.0.0"
+__version__ = "0.16.1.0"
 
-SUPPORTED_SCHEMA = (0, 16, 0)
+SUPPORTED_SCHEMA = (0, 16, 1)

--- a/lint/ktw_lint/config.py
+++ b/lint/ktw_lint/config.py
@@ -6,7 +6,7 @@ The config format is a delimited block of `- key: value` lines:
     - id: acme---widget-service
     - context: `context/`
     - init: complete
-    - context-schema: 0.16.0
+    - context-schema: 0.16.1
     - capture-confirmation: confirm-when-unsure
     - source-reference: never
     <!-- /keep-the-why:config -->

--- a/llms.txt
+++ b/llms.txt
@@ -42,7 +42,7 @@ get thrown away, not creating separate documentation effort. It isn't magic, tho
 prevents knowledge from decaying on its own. This lowers the friction of the discipline that
 keeps documentation honest; it doesn't replace it.
 
-Version: 0.16.0.
+Version: 0.16.1.
 
 ## Authorship & License
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "keep-the-why",
   "description": "Project memory for coding agents and humans: the reasoning behind a codebase as Markdown in the repo, versioned by Git, so nothing rejected is proposed twice.",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "author": {
     "name": "Oliver Zehentleitner"
   },

--- a/skills/keep-the-why/SKILL.md
+++ b/skills/keep-the-why/SKILL.md
@@ -3,7 +3,7 @@ name: keep-the-why
 description: Extract and preserve the reasoning code cannot explain - decisions, rejected alternatives, workarounds, incidents, constraints - plus project setup and maintainer interviews. Not for what changed (see Keep a Changelog) - only why. Also the place for complaints, feedback and settings changes about this skill itself.
 license: MIT
 metadata:
-  version: "0.16.0"
+  version: "0.16.1"
   repository: "https://github.com/oliver-zehentleitner/keep-the-why"
   author: "Oliver Zehentleitner"
 ---

--- a/skills/keep-the-why/examples/first-time-setup.md
+++ b/skills/keep-the-why/examples/first-time-setup.md
@@ -96,7 +96,7 @@ This names the skill and its purpose directly — not a task that happens to mat
     - id: acme---widget-service
     - context: `context/`
     - init: complete
-    - context-schema: 0.16.0
+    - context-schema: 0.16.1
     - capture-confirmation: confirm-when-unsure
     - source-reference: never
     <!-- /keep-the-why:config -->

--- a/skills/keep-the-why/references/migrations.md
+++ b/skills/keep-the-why/references/migrations.md
@@ -4,6 +4,12 @@ What changed in each version that an existing project may need to know about or 
 
 Entries below assume 0.2.0 as the starting point — nothing before it tracked a `context-schema` at all, and 0.2.0 itself introduced no `context/` entry format change.
 
+## 0.16.1 — one `Evidence` word, `Source` without persons, a Cursor plugin (informational, no action required)
+
+**What changed:** the specification says what was implicit: `Evidence` is one word per entry, and when an entry's parts stand differently (a confirmed new reason beside a lost original one) the weakest grade wins and the body says which part is which; `Source` names a kind of source, never a person's name, handle or e-mail address. The repository is also installable as a Cursor plugin (`.cursor-plugin/plugin.json` plus one rule that loads the skill in a workspace carrying `.keep-the-why`), and the skill's description names complaints and settings changes about the skill itself so a session about those loads it.
+
+**Existing projects:** nothing to migrate mechanically. An existing entry whose `Evidence` overstates a mixed standing, or whose `Source` names a person, is corrected when next touched — the linter has no gate for either, since both are judgement, not format. Advance `context-schema` to 0.16.1 as usual.
+
 ## 0.16.0 — a Codex plugin install route, and the two wizards as two messages (informational, no action required)
 
 **What changed:** the repository is installable as a Codex plugin (`.codex-plugin/plugin.json` plus a one-plugin marketplace), a third install route beside the skill directory and the Claude Code plugin. And the first-setup wizards are stated as two messages: the project list ends the turn, the personal list is the next message after the project answer, under `batch` as under `sequential`.

--- a/skills/keep-the-why/references/setup.md
+++ b/skills/keep-the-why/references/setup.md
@@ -17,7 +17,7 @@ README, for what Keep the Why actually is.
 - id: oliver-zehentleitner---keep-the-why
 - context: `context/`
 - init: complete
-- context-schema: 0.16.0
+- context-schema: 0.16.1
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->

--- a/skills/keep-the-why/references/specification.md
+++ b/skills/keep-the-why/references/specification.md
@@ -67,7 +67,7 @@ README, for what Keep the Why actually is.
 - id: acme---widget-service
 - context: `context/`
 - init: complete
-- context-schema: 0.16.0
+- context-schema: 0.16.1
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->


### PR DESCRIPTION
Release checklist steps 1–8 (CONTRIBUTING.md), nothing published yet.

- Skill `0.16.1` (`SKILL.md`), `llms.txt`, the four plugin manifests, this repository's `context-schema`, the example config blocks in `setup.md`, `specification.md`, `first-time-setup.md` and the linter's docstring, the `--ref` example on the installation page, the issue-form placeholders.
- Linter `0.16.1.0`, `SUPPORTED_SCHEMA (0, 16, 1)`, no new gate (77 tests pass). CHANGELOG line says so.
- CHANGELOG: `[0.16.1] - 2026-09-10` with everything since 0.16.0 (Source definition, Evidence weakest grade, the three wording fixes, Cursor plugin, HOL listing, installation trust bullets, the new eval case), fresh empty `[Unreleased]`, compare links.
- `migrations.md`: 0.16.1 informational, nothing mechanical.
- TODO.md: the "Patch release after the 0.16.0 series" item is this release, removed.

After merge, in order: `publish-lint.yml`, wait for `pip install keep-the-why-lint==0.16.1.0` to resolve, tag `v0.16.1`, re-run Link Check on main, awesome-copilot bump PR. The three full eval runs follow in a separate session, on request. If the tag lands on a later day than today, the CHANGELOG date moves with it.