### PR TITLE
docs: nav section 'Why this project is built this way' links only context/index.md

### DIFF
--- a/docs/context/index.md
+++ b/docs/context/index.md
@@ -1,0 +1,1 @@
+{% include-markdown "../../context/index.md" rewrite-relative-urls=false %}

--- a/docs/context/issue-triage.md
+++ b/docs/context/issue-triage.md
@@ -1,0 +1,1 @@
+{% include-markdown "../../context/issue-triage.md" %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,11 +81,4 @@ nav:
       - Abandoned change: examples/abandoned-change.md
       - Legacy project: examples/legacy-project.md
       - Developer handover: examples/developer-handover.md
-  - "Why this project is built this way":
-      - Release and distribution: context/release-and-distribution.md
-      - Skill configuration format: context/config-format.md
-      - Entry and layout format: context/entry-format.md
-      - Positioning: context/positioning.md
-      - Compatibility: context/compatibility.md
-      - Linter: context/lint.md
-      - Eval runner and suite: context/evals.md
+  - "Why this project is built this way": context/index.md


### PR DESCRIPTION
The nav section "Why this project is built this way" listed each `context/` topic file by hand and was always behind — seven of eight files, `issue-triage.md` missing entirely.

- `mkdocs.yml`: the section is now a single entry pointing at `context/index.md`, which already links every topic file with a one-line summary.
- `docs/context/index.md`: new include stub with `rewrite-relative-urls=false`, so the index's relative links (`compatibility.md` …) resolve to the sibling stubs under `docs/context/` instead of being rewritten to a path outside `docs/`.
- `docs/context/issue-triage.md`: the missing stub.

The other stubs stay: MkDocs builds them without a nav entry (INFO line, no warning). `mkdocs build --strict` is green; all 8 links on the built `/context/` page resolve.

Still manual: a new topic file needs its stub. The nav line is gone as a second thing to forget.
