### PR TITLE
docs: colour the 'Why this project is built this way' nav entry like the section headings

### DIFF
--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -5,6 +5,16 @@
   color: #845bed;
 }
 
+/* "Why this project is built this way" (context/index.md) is a page link,
+   not a section, but sits at the same level as "Reference" and "Examples"
+   and gets the same look. Its href is relative and varies per page ("./",
+   "../", "../context/"), so the rule matches by position: it is the LAST
+   top-level nav entry in mkdocs.yml. Keep it last, or update this rule. */
+.md-nav--primary > .md-nav__list > .md-nav__item:last-child > .md-nav__link,
+.md-nav--primary > .md-nav__list > .md-nav__item:last-child > .md-nav__link .md-ellipsis {
+  color: #845bed;
+}
+
 /* Same heading repeated at the top of the expanded section panel. */
 .md-nav--secondary .md-nav__title,
 .md-nav:not(.md-nav--primary) > .md-nav__title {


### PR DESCRIPTION
Follow-up to #375. The nav entry "Why this project is built this way" is now a page link, not a section, so the existing rule in `extra.css` that colours "Reference" and "Examples" no longer reaches it. This adds a rule giving it the same colour (`#845bed`), no bold.

Matched by position (`:last-child` of the top-level nav list) rather than by href: the href is relative and varies per page (`./` on the page itself, `../` on its subpages, `../context/` elsewhere), and `./` / `../` collide with the Home link. The CSS comment states the assumption: the entry must stay the last top-level item in `mkdocs.yml`.

Verified on the built site that the last top-level `.md-nav__item` is this entry on `/`, `/context/`, `/context/lint/` and `/setup/`. `mkdocs build --strict` green.
