### PR TITLE
docs: 'Why this project is built this way' stays a nav section, with 'context/' as its single page

### DIFF
--- a/context/positioning.md
+++ b/context/positioning.md
@@ -42,11 +42,15 @@ README's and `llms.txt`'s "Related work" don't compare Keep the Why against spec
 **Type:** decision
 **Status:** active
 **Evidence:** confirmed
-**Source:** how the "Why this project is built this way" nav section has been built since the site exists; the gap noted by Oliver on 2026-09-08 ("are all context files under 'Why this project is built this way'?" — they weren't)
+**Source:** how the "Why this project is built this way" nav section has been built since the site exists; the gap noted by Oliver on 2026-09-08 ("are all context files under 'Why this project is built this way'?" — they weren't); the nav change requested on 2026-09-10 (#375, #377)
 
-Every topic file in `context/` gets a stub at `docs/context/<name>.md` holding a single `include-markdown` line, and a line in the nav section "Why this project is built this way" in `mkdocs.yml`. The stub is the only way a `context/` file reaches the site — MkDocs only builds what lives under `docs/`, and copying the file would create a second place to edit.
+Every topic file in `context/` gets a stub at `docs/context/<name>.md` holding a single `include-markdown` line. The stub is the only way a `context/` file reaches the site — MkDocs only builds what lives under `docs/`, and copying the file would create a second place to edit. The nav section "Why this project is built this way" in `mkdocs.yml` holds one page, titled `context/`, which is the stub for `context/index.md`; the index links every topic file, so the site navigation follows the index instead of duplicating it. That stub includes the index with `rewrite-relative-urls=false`, so the index's relative links (`lint.md` etc.) resolve to the sibling stubs under `docs/context/` rather than to a path outside `docs/`.
 
-**Consequence:** a new topic file is not on the site until someone adds its stub and nav line; nothing checks this. `lint.md` (2026-09-02) and `evals.md` (2026-09-05) were both missed for days and added on 2026-09-08. When adding a topic file, add the stub and the nav line in the same change.
+**Reason:** the nav section used to list every topic file by hand and was always behind — on 2026-09-10 it showed seven of eight files, `issue-triage.md` had never been added. The index is already the one place that must know every topic file (rule 6 of the skill), so it is the one place the site reads.
+
+**Rejected alternative:** one nav line per topic file, as before. Rejected because nothing kept the list in sync with `context/`. Also rejected: making the section heading itself the link to the index (#375) — a top-level page link renders differently from the "Reference" and "Examples" section headings; a section with a single child page (#377) looks like its neighbours.
+
+**Consequence:** a new topic file is still not on the site until someone adds its stub; nothing checks this. `lint.md` (2026-09-02) and `evals.md` (2026-09-05) were both missed for days and added on 2026-09-08. The nav line is no longer a second thing to forget. When adding a topic file, add the stub in the same change.
 
 ## The format has a normative specification file, separate from the guidance that shows it in use
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,4 +81,5 @@ nav:
       - Abandoned change: examples/abandoned-change.md
       - Legacy project: examples/legacy-project.md
       - Developer handover: examples/developer-handover.md
-  - "Why this project is built this way": context/index.md
+  - "Why this project is built this way":
+      - "context/": context/index.md


### PR DESCRIPTION
Follow-up to #375, replaces #376. "Why this project is built this way" is a non-clickable section heading again, so it renders exactly like "Reference" and "Examples" (the existing `extra.css` rule for section headings applies, no new CSS). Its single child page is titled `context/` and points at `context/index.md`, which links every topic file.

`mkdocs build --strict` green; the built nav shows the section label with the one child link on every page depth.
