### PR TITLE
config: capture-confirmation automatic

### DIFF
--- a/.keep-the-why
+++ b/.keep-the-why
@@ -7,6 +7,6 @@ README, for what Keep the Why actually is.
 - context: `context/`
 - init: complete
 - context-schema: 0.16.1
-- capture-confirmation: confirm-always
+- capture-confirmation: automatic
 - source-reference: never
 <!-- /keep-the-why:config -->


### PR DESCRIPTION
Maintainer request 2026-09-10: no permission question before writing to `context/` any more. `confirm-always` → `automatic` in `.keep-the-why`. Substantive questions (facts, alternatives, proportionality) are unaffected by this setting. `ktw-lint --setup` clean.