### PR TITLE
docs: nav link to the context index reads 'Read this project's context/'

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,4 +82,4 @@ nav:
       - Legacy project: examples/legacy-project.md
       - Developer handover: examples/developer-handover.md
   - "Why this project is built this way":
-      - "context/": context/index.md
+      - "Read this project's context/": context/index.md


### PR DESCRIPTION
Follow-up to #377: the single page under "Why this project is built this way" was titled `context/`; now an invitation, `Read this project's context/`. The page title follows (`<title>`). Strict build green.