### PR TITLE
docs: generate the context/ pages with a MkDocs hook instead of stubs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,7 @@ on:
       - "docs/**"
       - "llms.txt"
       - "mkdocs.yml"
+      - "tools/mkdocs/**"
       - "requirements-docs.txt"
       - ".github/workflows/docs.yml"
   workflow_dispatch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+### Changed
+
+- The site's "Why this project is built this way" section holds one page, "Read this project's context/", which is `context/index.md`; the index links every topic file, so the navigation follows it instead of listing files by hand — the hand-kept list was seven of eight, `issue-triage.md` never added (#375, #377, #379).
+- The `context/` pages are generated at build time by a MkDocs hook, `tools/mkdocs/context_pages.py`, from the topic files themselves; the nine include stubs under `docs/context/` are gone, and a file there fails the build (#380). Recorded in `context/positioning.md`, the stub entry superseded.
+- This repository's `.keep-the-why` sets `capture-confirmation: automatic` (#378).
+
 ## [0.16.1] - 2026-09-10
 
 ### Changed

--- a/context/positioning.md
+++ b/context/positioning.md
@@ -40,9 +40,11 @@ README's and `llms.txt`'s "Related work" don't compare Keep the Why against spec
 ## The project's own `context/` is published on the site through one-line include stubs
 
 **Type:** decision
-**Status:** active
+**Status:** superseded
 **Evidence:** confirmed
 **Source:** how the "Why this project is built this way" nav section has been built since the site exists; the gap noted by Oliver on 2026-09-08 ("are all context files under 'Why this project is built this way'?" — they weren't); the nav change requested on 2026-09-10 (#375, #377)
+
+Superseded on 2026-09-10 by the build-time hook (next entry); kept for how the section got here.
 
 Every topic file in `context/` gets a stub at `docs/context/<name>.md` holding a single `include-markdown` line. The stub is the only way a `context/` file reaches the site — MkDocs only builds what lives under `docs/`, and copying the file would create a second place to edit. The nav section "Why this project is built this way" in `mkdocs.yml` holds one page, titled `context/`, which is the stub for `context/index.md`; the index links every topic file, so the site navigation follows the index instead of duplicating it. That stub includes the index with `rewrite-relative-urls=false`, so the index's relative links (`lint.md` etc.) resolve to the sibling stubs under `docs/context/` rather than to a path outside `docs/`.
 
@@ -51,6 +53,21 @@ Every topic file in `context/` gets a stub at `docs/context/<name>.md` holding a
 **Rejected alternative:** one nav line per topic file, as before. Rejected because nothing kept the list in sync with `context/`. Also rejected: making the section heading itself the link to the index (#375) — a top-level page link renders differently from the "Reference" and "Examples" section headings; a section with a single child page (#377) looks like its neighbours.
 
 **Consequence:** a new topic file is still not on the site until someone adds its stub; nothing checks this. `lint.md` (2026-09-02) and `evals.md` (2026-09-05) were both missed for days and added on 2026-09-08. The nav line is no longer a second thing to forget. When adding a topic file, add the stub in the same change.
+
+## The project's own `context/` is published on the site by a build-time hook, not by stubs
+
+**Type:** decision
+**Status:** active
+**Evidence:** confirmed
+**Source:** maintainer request, 2026-09-10 ("mach den mkdocs hook für die stubs"), after the stub gap kept recurring
+
+`tools/mkdocs/context_pages.py`, wired in through `hooks:` in `mkdocs.yml`, turns every `context/*.md` except `README.md`, `AGENTS.md` and `CLAUDE.md` into the page `/context/<name>/` at build time — the file's content, read as-is, as a generated MkDocs page. Nothing exists under `docs/context/`; a file there fails the build with a message naming the hook, so the stub mechanism cannot quietly come back. The nav section "Why this project is built this way" holds one page, the generated `context/index.md`; the index links every topic file, so the navigation follows the index instead of duplicating it. Relative links between topic files (`lint.md`) resolve to sibling pages because the content is not run through the include plugin's URL rewriting — which is also why the index no longer needs a `rewrite-relative-urls=false` include.
+
+**Reason:** the stub-per-file mechanism (previous entry) had one manual step that nothing checked, and it was missed three times in a week (`lint.md`, `evals.md`, `issue-triage.md`). A hook has no per-file step: a topic file is on the site the moment it exists. Plain `hooks:` rather than a plugin because it is a few dozen lines of project-specific glue with nothing to install.
+
+**Rejected alternative:** keep the stubs and add a CI check that every `context/*.md` has one. Catches the gap, still asks for the stub. Also rejected: `mkdocs-gen-files` — a dependency for what `hooks:` already does in MkDocs 1.6.
+
+**Consequence:** the docs workflow triggers on `tools/mkdocs/**` too. `context/README.md` is deliberately not a page; the index is the section's landing page.
 
 ## The format has a normative specification file, separate from the guidance that shows it in use
 

--- a/docs/context/compatibility.md
+++ b/docs/context/compatibility.md
@@ -1,1 +1,0 @@
-{% include-markdown "../../context/compatibility.md" %}

--- a/docs/context/config-format.md
+++ b/docs/context/config-format.md
@@ -1,1 +1,0 @@
-{% include-markdown "../../context/config-format.md" %}

--- a/docs/context/entry-format.md
+++ b/docs/context/entry-format.md
@@ -1,1 +1,0 @@
-{% include-markdown "../../context/entry-format.md" %}

--- a/docs/context/evals.md
+++ b/docs/context/evals.md
@@ -1,1 +1,0 @@
-{% include-markdown "../../context/evals.md" %}

--- a/docs/context/index.md
+++ b/docs/context/index.md
@@ -1,1 +1,0 @@
-{% include-markdown "../../context/index.md" rewrite-relative-urls=false %}

--- a/docs/context/issue-triage.md
+++ b/docs/context/issue-triage.md
@@ -1,1 +1,0 @@
-{% include-markdown "../../context/issue-triage.md" %}

--- a/docs/context/lint.md
+++ b/docs/context/lint.md
@@ -1,1 +1,0 @@
-{% include-markdown "../../context/lint.md" %}

--- a/docs/context/positioning.md
+++ b/docs/context/positioning.md
@@ -1,1 +1,0 @@
-{% include-markdown "../../context/positioning.md" %}

--- a/docs/context/release-and-distribution.md
+++ b/docs/context/release-and-distribution.md
@@ -1,1 +1,0 @@
-{% include-markdown "../../context/release-and-distribution.md" %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,9 @@ markdown_extensions:
   - md_in_html
   - pymdownx.superfences
 
+hooks:
+  - tools/mkdocs/context_pages.py
+
 extra_css:
   - assets/extra.css
 

--- a/tools/mkdocs/context_pages.py
+++ b/tools/mkdocs/context_pages.py
@@ -1,0 +1,55 @@
+"""MkDocs hook: publish this project's own ``context/`` on the site.
+
+Every topic file in ``context/`` becomes the page ``/context/<name>/``,
+generated at build time from the file itself. There is no stub under
+``docs/`` to add or forget, and no second copy to edit.
+
+The content is read as-is. Relative links between topic files
+(``lint.md``, ``index.md``) resolve to the sibling pages, exactly as they
+do in the repository.
+
+Wired in through ``hooks:`` in ``mkdocs.yml``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from mkdocs.config.defaults import MkDocsConfig
+from mkdocs.exceptions import PluginError
+from mkdocs.structure.files import File, Files
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTEXT_DIR = REPO_ROOT / "context"
+
+# Directory scaffolding, not topic files: the on-disk README, the agent
+# guard and its import. The site's landing page for this section is
+# context/index.md.
+NOT_PAGES = {"README.md", "AGENTS.md", "CLAUDE.md"}
+
+
+def on_config(config: MkDocsConfig) -> MkDocsConfig:
+    # Live reload on ``mkdocs serve`` when a topic file changes.
+    config.watch.append(str(CONTEXT_DIR))
+    return config
+
+
+def on_files(files: Files, config: MkDocsConfig) -> Files:
+    for path in sorted(CONTEXT_DIR.glob("*.md")):
+        if path.name in NOT_PAGES:
+            continue
+        src_uri = f"context/{path.name}"
+        if files.get_file_from_path(src_uri) is not None:
+            raise PluginError(
+                f"docs/{src_uri} exists, but the page /{src_uri[:-3]}/ is generated from "
+                f"{path.relative_to(REPO_ROOT)} by tools/mkdocs/context_pages.py "
+                "- delete the file under docs/."
+            )
+        files.append(
+            File.generated(
+                config,
+                src_uri,
+                content=path.read_text(encoding="utf-8"),
+            )
+        )
+    return files

--- a/tools/mkdocs/context_pages.py
+++ b/tools/mkdocs/context_pages.py
@@ -23,8 +23,10 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 CONTEXT_DIR = REPO_ROOT / "context"
 
 # Directory scaffolding, not topic files: the on-disk README, the agent
-# guard and its import. The site's landing page for this section is
-# context/index.md.
+# guard and its import. Mirrors NON_TOPIC_FILES in lint/ktw_lint/checks.py
+# (minus index.md, which is this section's landing page) - not imported
+# from there, so the docs build does not depend on the linter package.
+# Change both together.
 NOT_PAGES = {"README.md", "AGENTS.md", "CLAUDE.md"}
 
 


### PR DESCRIPTION
Follow-up to #375/#377/#379: the last manual step is gone. A new topic file in `context/` is on the site the moment it exists.

- `tools/mkdocs/context_pages.py`, wired in through `hooks:` in `mkdocs.yml` (plain MkDocs 1.6, no plugin, nothing to install): `on_files` turns every `context/*.md` except `README.md`, `AGENTS.md`, `CLAUDE.md` into a generated page `/context/<name>/` with the file's content as-is; `on_config` adds `context/` to the `mkdocs serve` watch list.
- The nine stubs under `docs/context/` are deleted. A file there now fails the build with a message naming the hook, so the stub mechanism cannot quietly come back.
- Relative links between topic files (`lint.md`) resolve to sibling pages without any URL rewriting, so the index no longer needs the `rewrite-relative-urls=false` special case.
- `docs.yml` also triggers on `tools/mkdocs/**`.
- `context/positioning.md`: the stub entry is `superseded`, a new entry records the hook, its reason and the rejected alternatives (CI check for stubs, `mkdocs-gen-files`).

Verified: `mkdocs build --strict` green, 9 pages under `/context/`, all 8 index links resolve, the `${{ … }}` text in `release-and-distribution.md` renders as before, the fail-loud path tested. `black --check` clean, `ktw-lint` 0 errors / 0 warnings.
