### PR TITLE
docs: imprint page linked from the site footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+### Added
+
+- keepthewhy.com has an imprint page (`/imprint/`, § 25 Austrian Media Act) linked from the footer of every page; it stays out of the navigation.
+
 ### Changed
 
 - The site's "Why this project is built this way" section holds one page, "Read this project's context/", which is `context/index.md`; the index links every topic file, so the navigation follows it instead of listing files by hand — the hand-kept list was seven of eight, `issue-triage.md` never added (#375, #377, #379).

--- a/docs/imprint.md
+++ b/docs/imprint.md
@@ -1,0 +1,33 @@
+---
+title: Imprint
+description: Legal notice for keepthewhy.com — who publishes this site and how to reach them.
+---
+
+# Imprint
+
+Information according to § 25 Austrian Media Act (Mediengesetz).
+
+**Publisher and responsible for the content**
+
+Oliver Zehentleitner
+Vienna, Austria
+
+**Contact**
+
+- [Open an issue](https://github.com/oliver-zehentleitner/keep-the-why/issues/new)
+  on the project's GitHub repository
+- [Telegram: @unicorndevs](https://t.me/unicorndevs)
+
+**About this site**
+
+keepthewhy.com documents the open-source project
+[Keep the Why](https://github.com/oliver-zehentleitner/keep-the-why),
+published under the MIT License. The site is non-commercial. It is hosted on
+GitHub Pages, sets no cookies of its own and runs no analytics.
+
+**Liability for links**
+
+This site links to external websites. Their content is the responsibility of
+their respective operators; it was checked for legal concerns at the time of
+linking. If a linked page turns out to be problematic, please report it via
+one of the contact channels above and the link will be removed.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,11 @@ markdown_extensions:
 hooks:
   - tools/mkdocs/context_pages.py
 
+copyright: '<a href="/imprint/">Imprint</a>'
+
+not_in_nav: |
+  imprint.md
+
 extra_css:
   - assets/extra.css
 


### PR DESCRIPTION
keepthewhy.com had no legal notice.

- `docs/imprint.md`: publisher, contact channels (GitHub issues, Telegram), nature of the site (non-commercial, MIT, GitHub Pages, no cookies/analytics), link liability. Excluded from the navigation via `not_in_nav`.
- `mkdocs.yml`: Material's `copyright` slot renders `Imprint` in the footer of every page, next to the social icons. No template override needed.
- CHANGELOG Unreleased.

`mkdocs build --strict` green locally; rendered footer verified.