### PR TITLE
docs: license page next to the imprint in the site footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
-- keepthewhy.com has an imprint page (`/imprint/`, § 25 Austrian Media Act) linked from the footer of every page; it stays out of the navigation.
+- keepthewhy.com has an imprint page (`/imprint/`, § 25 Austrian Media Act) linked from the footer of every page; it stays out of the navigation (#381). A license page (`/license/`) with the MIT text sits next to it in the footer.
 
 ### Changed
 

--- a/docs/license.md
+++ b/docs/license.md
@@ -1,0 +1,15 @@
+---
+title: License
+description: Keep the Why is published under the MIT License — the full license text.
+---
+
+# License
+
+Keep the Why — the skill, the linter, the documentation and this site — is
+published under the MIT License. The text below is the
+[`LICENSE`](https://github.com/oliver-zehentleitner/keep-the-why/blob/main/LICENSE)
+file of the repository.
+
+```text
+{% include-markdown "../LICENSE" %}
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,10 +40,11 @@ markdown_extensions:
 hooks:
   - tools/mkdocs/context_pages.py
 
-copyright: '<a href="/imprint/">Imprint</a>'
+copyright: '<a href="/imprint/">Imprint</a> · <a href="/license/">License</a>'
 
 not_in_nav: |
   imprint.md
+  license.md
 
 extra_css:
   - assets/extra.css


### PR DESCRIPTION
Follow-up to #381.

- `docs/license.md`: the MIT text, pulled from the repository's `LICENSE` at build time via `include-markdown`, so the page cannot drift from the file. Excluded from the navigation.
- `mkdocs.yml`: footer now reads `Imprint · License`.
- CHANGELOG Unreleased line extended.

`mkdocs build --strict` green locally; rendered footer and license page verified.