### PR TITLE
docs: every license link points at keepthewhy.com/license/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Added
 
-- keepthewhy.com has an imprint page (`/imprint/`, § 25 Austrian Media Act) linked from the footer of every page; it stays out of the navigation (#381). A license page (`/license/`) with the MIT text sits next to it in the footer.
+- keepthewhy.com has an imprint page (`/imprint/`, § 25 Austrian Media Act) linked from the footer of every page; it stays out of the navigation (#381). A license page (`/license/`) with the MIT text sits next to it in the footer (#382); every license link on the site, in the README and in the linter's README points there instead of at the file on GitHub.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![GitHub Release](https://img.shields.io/github/v/release/oliver-zehentleitner/keep-the-why?filter=v*&sort=semver&label=github)](https://github.com/oliver-zehentleitner/keep-the-why/releases)
 [![PyPI](https://img.shields.io/pypi/v/keep-the-why-lint.svg?label=pypi%20keep-the-why-lint)](https://pypi.org/project/keep-the-why-lint/)
-[![License](https://img.shields.io/github/license/oliver-zehentleitner/keep-the-why.svg?color=blue)](https://github.com/oliver-zehentleitner/keep-the-why/blob/latest/LICENSE)
+[![License](https://img.shields.io/github/license/oliver-zehentleitner/keep-the-why.svg?color=blue)](https://keepthewhy.com/license/)
 [![Validate Skill](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/validate-skill.yml/badge.svg)](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/validate-skill.yml)
 [![ktw-lint](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/ktw-lint.yml/badge.svg)](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/ktw-lint.yml)
 [![keep-the-why-lint (package)](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/lint-package.yml/badge.svg)](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/lint-package.yml)
@@ -252,4 +252,4 @@ We ♥️ open source!
 
 ## License
 
-[MIT](https://github.com/oliver-zehentleitner/keep-the-why/blob/latest/LICENSE)
+[MIT](https://keepthewhy.com/license/)

--- a/docs/imprint.md
+++ b/docs/imprint.md
@@ -22,7 +22,7 @@ Vienna, Austria
 
 keepthewhy.com documents the open-source project
 [Keep the Why](https://github.com/oliver-zehentleitner/keep-the-why),
-published under the MIT License. The site is non-commercial. It is hosted on
+published under the [MIT License](license.md). The site is non-commercial. It is hosted on
 GitHub Pages, sets no cookies of its own and runs no analytics.
 
 **Liability for links**

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ Keep the Why is the part that remembers. Repo-native project memory for humans a
 [GitHub](https://github.com/oliver-zehentleitner/keep-the-why){ .md-button }
 { .ktw-hero__actions }
 
-Open source under the [MIT license](https://github.com/oliver-zehentleitner/keep-the-why/blob/main/LICENSE) — the skill, the linter, and this site. Nothing to sign up for, nothing that phones home.
+Open source under the [MIT license](https://keepthewhy.com/license/) — the skill, the linter, and this site. Nothing to sign up for, nothing that phones home.
 { .ktw-caption }
 
 </div>
@@ -160,7 +160,7 @@ The full list, and where Keep the Why fits next to ADRs, `AGENTS.md` and Keep a 
 
 <div class="ktw-footer" markdown>
 
-[README](readme.md) · [Installation](installation.md) · [Philosophy](philosophy.md) · [Security](security.md) · [FAQ](faq.md) · [Why I built this](why.md) · [llms.txt](https://keepthewhy.com/llms.txt) for AI agents · [MIT license](https://github.com/oliver-zehentleitner/keep-the-why/blob/main/LICENSE)
+[README](readme.md) · [Installation](installation.md) · [Philosophy](philosophy.md) · [Security](security.md) · [FAQ](faq.md) · [Why I built this](why.md) · [llms.txt](https://keepthewhy.com/llms.txt) for AI agents · [MIT license](https://keepthewhy.com/license/)
 
 </div>
 

--- a/lint/README.md
+++ b/lint/README.md
@@ -1,7 +1,7 @@
 [![PyPI](https://img.shields.io/pypi/v/keep-the-why-lint.svg?label=pypi)](https://pypi.org/project/keep-the-why-lint/)
 [![Python](https://img.shields.io/pypi/pyversions/keep-the-why-lint.svg)](https://pypi.org/project/keep-the-why-lint/)
 [![Downloads](https://pepy.tech/badge/keep-the-why-lint)](https://pepy.tech/project/keep-the-why-lint)
-[![License](https://img.shields.io/github/license/oliver-zehentleitner/keep-the-why.svg?color=blue)](https://github.com/oliver-zehentleitner/keep-the-why/blob/latest/LICENSE)
+[![License](https://img.shields.io/github/license/oliver-zehentleitner/keep-the-why.svg?color=blue)](https://keepthewhy.com/license/)
 [![keep-the-why-lint (package)](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/lint-package.yml/badge.svg)](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/lint-package.yml)
 [![ktw-lint](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/ktw-lint.yml/badge.svg)](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/ktw-lint.yml)
 [![Black](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/black.yml/badge.svg)](https://github.com/oliver-zehentleitner/keep-the-why/actions/workflows/black.yml)
@@ -147,4 +147,4 @@ We ♥️ open source!
 
 ## License
 
-[MIT](https://github.com/oliver-zehentleitner/keep-the-why/blob/latest/LICENSE)
+[MIT](https://keepthewhy.com/license/)


### PR DESCRIPTION
Follow-up to #382.

- `docs/index.md`: both MIT links (trust row and footer line) → https://keepthewhy.com/license/
- `README.md` (badge + License section) and `lint/README.md` (badge + License section): same target — the README is included on the site, the linter README is the PyPI page.
- `docs/imprint.md`: "MIT License" links the page.
- `docs/license.md` keeps its link to the file on GitHub, that is the source it renders.
- CHANGELOG Unreleased line extended.

`mkdocs build --strict` green locally; rendered links verified.