### PR TITLE
docs: nav entry 'See it in the dashboard' under the context section

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,3 +93,4 @@ nav:
       - Developer handover: examples/developer-handover.md
   - "Why this project is built this way":
       - "Read this project's context/": context/index.md
+      - "See it in the dashboard": https://keepthewhy.com/dashboard/live/


### PR DESCRIPTION
Under "Why this project is built this way", after "Read this project's context/": **See it in the dashboard** → https://keepthewhy.com/dashboard/live/ (the export the docs workflow writes on every build). `mkdocs build --strict` green.