### PR TITLE
ci: scanner pin comment says v1.2.651; link check skips pepy.tech until it has indexed keep-the-why-dashboard

### DIFF
--- a/.github/workflows/hol-scanner.yml
+++ b/.github/workflows/hol-scanner.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: hashgraph-online/ai-plugin-scanner-action@bb4f519048c0fd1cd9d7b42056072d6070b8ad7d # v1.2.643 (plugin-scanner 3.0.133)
+      - uses: hashgraph-online/ai-plugin-scanner-action@bb4f519048c0fd1cd9d7b42056072d6070b8ad7d # v1.2.651 (plugin-scanner 3.0.143)
         with:
           plugin_dir: "."
           min_score: 80

--- a/lychee.toml
+++ b/lychee.toml
@@ -26,4 +26,8 @@ exclude = [
   "^https://x\\.com/",
   "^https://keepthewhy\\.com/dashboard/",
   "^https://github\\.com/oliver-zehentleitner/keep-the-why/tree/main/dashboard",
+  # keep-the-why-dashboard reached PyPI on 2026-09-11; pepy.tech indexes a new
+  # package with a delay, and both the badge and the project page 404 until
+  # then. Remove this line once https://pepy.tech/projects/keep-the-why-dashboard resolves.
+  "^https://pepy\\.tech/(badge|project)/keep-the-why-dashboard",
 ]


### PR DESCRIPTION
Rebased onto main after #388 landed the same scanner SHA (bb4f519 = v1.2.651, plugin-scanner 3.0.143). What remains here:

- the version comment next to the pin, which dependabot left at `v1.2.643 (plugin-scanner 3.0.133)` in both #386 and #388 — now `v1.2.651 (plugin-scanner 3.0.143)`. The new scanner against the tree with the dashboard: 94/100, no high findings (run on this branch before the rebase).
- main's link check has been red since #389 because pepy.tech has not indexed `keep-the-why-dashboard` yet (badge and project page 404). Excluded in `lychee.toml` with a note to remove the line once pepy resolves.