### PR TITLE
dashboard: schema and branch@commit pills in the top bar are links

### DIFF
--- a/dashboard/ktw_dashboard/gitinfo.py
+++ b/dashboard/ktw_dashboard/gitinfo.py
@@ -50,6 +50,7 @@ class Repo:
     head: str
     branch: str
     remote: str  # host/path, credentials and scheme stripped; "" when none
+    head_full: str = ""
 
     def rel(self, path: str) -> str:
         return os.path.relpath(path, self.root)
@@ -61,13 +62,14 @@ def open_repo(project_root: str) -> Repo | None:
         return None
     top = top.strip()
     head = (_run(["rev-parse", "--short", "HEAD"], top) or "").strip()
+    head_full = (_run(["rev-parse", "HEAD"], top) or "").strip()
     branch = (_run(["rev-parse", "--abbrev-ref", "HEAD"], top) or "").strip()
     remote = (_run(["remote", "get-url", "origin"], top) or "").strip()
     remote = _CRED_RE.sub("//", remote)
     remote = re.sub(r"^[a-z+]+://", "", remote)
     remote = re.sub(r"^git@([^:]+):", r"\1/", remote)
     remote = re.sub(r"\.git$", "", remote)
-    return Repo(root=top, head=head, branch=branch, remote=remote)
+    return Repo(root=top, head=head, branch=branch, remote=remote, head_full=head_full)
 
 
 def fingerprint(project_root: str, context_dir: str, repo: Repo | None) -> str:

--- a/dashboard/ktw_dashboard/state.py
+++ b/dashboard/ktw_dashboard/state.py
@@ -204,6 +204,7 @@ class StateBuilder:
         return {
             "available": True,
             "head": repo.head,
+            "head_full": repo.head_full,
             "branch": repo.branch,
             "remote": repo.remote,
             "project_subdir": (

--- a/dashboard/ktw_dashboard/web/app.js
+++ b/dashboard/ktw_dashboard/web/app.js
@@ -19,6 +19,17 @@ const setKids = (node, ...kids) => node.replaceChildren(...kids.flat(Infinity).f
 const esc = (s) => String(s ?? "").replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
 const fmtDate = (d) => d || "—";
 const remoteLink = (remote) => el("a", { class: "gh", href: `https://${remote}`, target: "_blank", rel: "noopener" }, remote);
+const onGitHub = (g) => !!g?.remote && /^github\.com\//.test(g.remote);
+const schemaPill = (p) => el("span", { class: "pill" }, el("a", { class: "gh", href: `https://github.com/oliver-zehentleitner/keep-the-why/releases/tag/v${p.schema}`, target: "_blank", rel: "noopener", title: `context-schema ${p.schema} — the Keep the Why release this context/ was last checked against` }, `schema ${p.schema}`));
+const headPill = (g) => {
+  if (!g?.available) return null;
+  const branch = g.branch && g.branch !== "HEAD" ? g.branch : null;
+  if (!onGitHub(g)) return el("span", { class: "pill", title: g.remote || "" }, `${branch || "detached"}@${g.head}`);
+  const base = `https://${g.remote}`;
+  return el("span", { class: "pill", title: "branch and commit on GitHub" },
+    branch ? el("a", { class: "gh", href: `${base}/tree/${encodeURIComponent(branch)}`, target: "_blank", rel: "noopener" }, branch) : "detached", "@",
+    el("a", { class: "gh", href: `${base}/commit/${g.head_full || g.head}`, target: "_blank", rel: "noopener", title: g.head_full || g.head }, g.head));
+};
 const plural = (n, w) => `${n} ${w}${n === 1 ? "" : "s"}`;
 
 // ---------------------------------------------------------------- state
@@ -212,7 +223,7 @@ function viewOverview(main) {
   main.append(
     el("h1", {}, p.id || p.name),
     el("p", { class: "sub" }, `${p.context} · schema ${p.schema} · ${p.config["capture-confirmation"] || "?"} · source-reference ${p.config["source-reference"] || "?"}`,
-      g?.available ? [` · ${g.branch}@${g.head}`, g.remote ? [" · ", remoteLink(g.remote)] : null] : " · no Git"),
+      g?.available ? [" · ", headPill(g), g.remote ? [" · ", remoteLink(g.remote)] : null] : " · no Git"),
     el("div", { class: "grid2" },
       el("div", { class: "card" }, el("h3", {}, "Type"), bars(typeCounts(list), ["decision", "constraint", "workaround", "incident"])),
       el("div", { class: "card" }, el("h3", {}, "Status"), bars(count(list, "status"), STATUS_ORDER)),
@@ -579,7 +590,7 @@ function rerender() { renderSidebar(); renderStrip(); render(); }
 function applyState(state) {
   S = state;
   const p = S.project;
-  setKids($("#project-title"), $("#project-select").hidden ? el("b", {}, p.id || p.name) : null, el("span", { class: "pill" }, `schema ${p.schema}`), p.git?.available ? el("span", { class: "pill", title: p.git.remote }, `${p.git.branch}@${p.git.head}`) : null, p.git?.remote ? el("span", { class: "pill" }, remoteLink(p.git.remote)) : null);
+  setKids($("#project-title"), $("#project-select").hidden ? el("b", {}, p.id || p.name) : null, schemaPill(p), headPill(p.git), p.git?.remote ? el("span", { class: "pill" }, remoteLink(p.git.remote)) : null);
   document.title = `${p.id || p.name} — Keep the Why`;
   setKids($("#statusbar"),
     el("span", {}, `keep-the-why-dashboard ${S.dashboard}`), el("span", {}, `keep-the-why-lint ${S.linter}`),

--- a/dashboard/tests/web/smoke.mjs
+++ b/dashboard/tests/web/smoke.mjs
@@ -52,6 +52,8 @@ if (report.entryMiniGraph !== 1 || report.topicMiniGraph !== 1 || report.default
 if (window.document.body.textContent.includes("[object ")) errors.push("[object ...] leaked into the page text");
 if (/\bnull\b/.test(window.document.getElementById("project-title").textContent + window.document.getElementById("statusbar").textContent)) errors.push("null leaked into the top bar or status bar");
 report.details = window.document.getElementById("details").textContent.trim().length;
+report.topbarLinks = { schema: window.document.querySelectorAll('#project-title a[href*="/releases/tag/v"]').length, commit: window.document.querySelectorAll('#project-title a[href*="/commit/"]').length };
+if (S.project.git?.available && /^github\.com\//.test(S.project.git.remote || "") && (report.topbarLinks.schema !== 1 || report.topbarLinks.commit !== 1)) errors.push("top bar links missing: " + JSON.stringify(report.topbarLinks));
 const input = window.document.getElementById("search"); input.value = "retry"; input.dispatchEvent(new window.Event("input"));
 await tick(50);
 report.search = window.document.querySelectorAll("#search-results a").length;


### PR DESCRIPTION
- `schema 0.16.1` → the Keep the Why release the project's `context-schema` names (https://github.com/oliver-zehentleitner/keep-the-why/releases/tag/v0.16.1), with a title explaining what the number is.
- `main@233e6a5` → branch name links `tree/<branch>` and the short sha links `commit/<full sha>` on the project's own GitHub remote; the state now carries `head_full` for that. Non-GitHub remotes keep plain text; a detached HEAD shows `detached@<sha>`.
- Same pill in the overview's subtitle line. jsdom smoke test asserts both links.