### PR TITLE
docs: dashboard screenshot on the landing page and the Dashboard page

### DIFF
--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -62,6 +62,19 @@
   padding: 2rem 0;
   border-top: 1px solid var(--ktw-border);
 }
+.ktw-shot {
+  margin: 1rem 0 .8rem;
+}
+.ktw-shot img {
+  display: block;
+  width: 100%;
+  border-radius: .5rem;
+  border: 1px solid var(--ktw-border);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, .18);
+}
+.ktw-shot a:hover img {
+  border-color: var(--md-accent-fg-color);
+}
 .ktw-entry {
   background: var(--md-code-bg-color);
   border: 1px solid var(--ktw-border);

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -9,7 +9,13 @@ description: keep-the-why-dashboard — a read-only live view over a project's c
 
 It connects data that is already lying around. It writes nothing into any project, runs no daemon beyond the terminal you start it in, and is never a source of truth: delete it and nothing is lost. The one file it keeps is `~/.keep-the-why/dashboard-history.json` — the projects you opened, with their paths, so the project menu can offer them again. That is what keeps it inside this project's own rule — [no new platform, database, daemon, account, or workflow](philosophy.md) — a lens on Markdown and Git, not a place where anything lives.
 
-**Live example:** [this repository's own `context/`](https://keepthewhy.com/dashboard/live/), exported on every docs build.
+<div class="ktw-shot" markdown>
+
+[![The dashboard on this repository's own context/: graph, entry reader with Git history, queues](assets/dashboard-screenschot.png)](https://keepthewhy.com/dashboard/live/)
+
+</div>
+
+**Live example:** [this repository's own `context/`](https://keepthewhy.com/dashboard/live/), exported on every docs build — the screenshot above is a click away from the real thing.
 
 ## Run it
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -110,6 +110,20 @@ The next session — yours, a colleague's, an agent's — loads the index first 
 
 </div>
 
+<div class="ktw-section" markdown>
+
+## See it
+
+<div class="ktw-shot" markdown>
+
+[![keep-the-why-dashboard: the graph of a project's context/, an entry with its Git history, and the queues of what still needs a person](assets/dashboard-screenschot.png)](dashboard.md)
+
+</div>
+
+The dashboard — a read-only view over `context/` and its Git history: who recorded what, when a status changed, what still needs a person. [Dashboard →](dashboard.md) · [Live example →](https://keepthewhy.com/dashboard/live/)
+
+</div>
+
 <div class="ktw-section ktw-trust" markdown>
 
 ## Tested, measured, stated plainly


### PR DESCRIPTION
- Landing page: new section **See it** between *How it works* and *Tested, measured, stated plainly* — the screenshot (`docs/assets/dashboard-screenschot.png`) links to /dashboard/, one line of caption with links to the Dashboard page and the live example.
- Dashboard page: the same screenshot above the *Live example* line, linking to https://keepthewhy.com/dashboard/live/.
- `extra.css`: `.ktw-shot` — full width, rounded, thin border, soft shadow, accent border on hover.

`mkdocs build --strict` green.