### PR TITLE
dashboard: wordmark only in the top bar

### DIFF
--- a/dashboard/ktw_dashboard/web/index.html
+++ b/dashboard/ktw_dashboard/web/index.html
@@ -11,7 +11,6 @@
 <div id="app" class="app">
   <header class="topbar">
     <a class="brand" href="#overview" title="Overview">
-      <img src="/static/icon.png" alt="" width="24" height="24">
       <img src="/static/wordmark.png" alt="Keep the Why" height="22" class="wordmark">
     </a>
     <select id="project-select" class="project-select" hidden title="Project"></select>


### PR DESCRIPTION
The top bar showed the icon and the wordmark side by side; now only the wordmark. The icon stays as the favicon (and inlined in the export for it).