### PR TITLE
docs: arrow on the external nav entry 'See it in the dashboard ↗'

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,4 +93,4 @@ nav:
       - Developer handover: examples/developer-handover.md
   - "Why this project is built this way":
       - "Read this project's context/": context/index.md
-      - "See it in the dashboard": https://keepthewhy.com/dashboard/live/
+      - "See it in the dashboard ↗": https://keepthewhy.com/dashboard/live/


### PR DESCRIPTION
The one nav entry that leaves the docs (and opens in a new tab since #392) now says so: `See it in the dashboard ↗`. The new-tab script matches on the href, so it still applies. `mkdocs build --strict` green.