### PR TITLE
dashboard: status bar versions link PyPI

### DIFF
--- a/dashboard/ktw_dashboard/web/app.js
+++ b/dashboard/ktw_dashboard/web/app.js
@@ -593,7 +593,8 @@ function applyState(state) {
   setKids($("#project-title"), $("#project-select").hidden ? el("b", {}, p.id || p.name) : null, schemaPill(p), headPill(p.git), p.git?.remote ? el("span", { class: "pill" }, remoteLink(p.git.remote)) : null);
   document.title = `${p.id || p.name} — Keep the Why`;
   setKids($("#statusbar"),
-    el("span", {}, `keep-the-why-dashboard ${S.dashboard}`), el("span", {}, `keep-the-why-lint ${S.linter}`),
+    el("span", {}, el("a", { href: "https://pypi.org/project/keep-the-why-dashboard/", target: "_blank", rel: "noopener", title: "keep-the-why-dashboard on PyPI" }, `keep-the-why-dashboard ${S.dashboard}`)),
+    el("span", {}, el("a", { href: "https://pypi.org/project/keep-the-why-lint/", target: "_blank", rel: "noopener", title: "keep-the-why-lint on PyPI" }, `keep-the-why-lint ${S.linter}`)),
     el("span", {}, S.exported ? `exported ${S.generated}` : `state ${S.generated}`),
     el("span", {}, `${S.entries.length} entries · ${S.topics.length} topics · ${S.authors.length} authors`),
     el("span", { style: "margin-left:auto" }, el("a", { href: "https://keepthewhy.com", target: "_blank", rel: "noopener" }, "keepthewhy.com")));

--- a/dashboard/ktw_dashboard/web/style.css
+++ b/dashboard/ktw_dashboard/web/style.css
@@ -105,6 +105,7 @@ button { font: inherit; color: inherit; }
 .main { grid-area: main; overflow: auto; padding: 24px 32px 60px; }
 .details { grid-area: details; overflow: auto; display: flex; flex-direction: column; background: var(--bg2); border-left: 1px solid var(--line); padding: 16px; font-size: 13px; }
 .statusbar { grid-area: status; display: flex; gap: 18px; align-items: center; padding: 0 14px; font-size: 11px; color: var(--fg3); background: var(--bg2); border-top: 1px solid var(--line); }
+.statusbar a { color: var(--fg2); } .statusbar a:hover { color: var(--fg); }
 
 h1 { font-size: 22px; margin: 0 0 4px; font-weight: 650; }
 h2 { font-size: 17px; margin: 24px 0 10px; font-weight: 600; }


### PR DESCRIPTION
`keep-the-why-dashboard <version>` → https://pypi.org/project/keep-the-why-dashboard/ and `keep-the-why-lint <version>` → https://pypi.org/project/keep-the-why-lint/ in the bottom status bar, new tab. Smoke test green.