### PR TITLE
docs: screenshot links open the example in a new tab

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -11,7 +11,7 @@ It connects data that is already lying around. It writes nothing into any projec
 
 <div class="ktw-shot" markdown>
 
-[![The dashboard on this repository's own context/: graph, entry reader with Git history, queues](assets/dashboard-screenschot.png)](https://keepthewhy.com/dashboard/live/)
+[![The dashboard on this repository's own context/: graph, entry reader with Git history, queues](assets/dashboard-screenschot.png)](https://keepthewhy.com/dashboard/live/){ target=_blank rel=noopener }
 
 </div>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,7 +66,7 @@ Decisions that shipped, alternatives that lost, workarounds, constraints — Kee
 
 <div class="ktw-shot" markdown>
 
-[![keep-the-why-dashboard: the graph of a project's context/, an entry with its Git history, and the queues of what still needs a person](assets/dashboard-screenschot.png)](https://keepthewhy.com/dashboard/live/)
+[![keep-the-why-dashboard: the graph of a project's context/, an entry with its Git history, and the queues of what still needs a person](assets/dashboard-screenschot.png)](https://keepthewhy.com/dashboard/live/){ target=_blank rel=noopener }
 
 </div>
 


### PR DESCRIPTION
`{ target=_blank rel=noopener }` on the screenshot link, landing page and Dashboard page (attr_list is on). Rendered anchors verified in the strict build.