### PR TITLE
Prepare 0.16.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "keep-the-why",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Project memory for coding agents and humans: the reasoning behind a codebase as Markdown in the repo, versioned by Git, so nothing rejected is proposed twice.",
   "author": {
     "name": "Oliver Zehentleitner",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "keep-the-why",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Project memory for coding agents and humans: the reasoning behind a codebase as Markdown in the repo, versioned by Git, so nothing rejected is proposed twice.",
   "author": {
     "name": "Oliver Zehentleitner",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "keep-the-why",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Project memory for coding agents and humans: the reasoning behind a codebase as Markdown in the repo, versioned by Git, so nothing rejected is proposed twice.",
   "author": {
     "name": "Oliver Zehentleitner",

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -37,7 +37,7 @@ body:
       label: Version
       description: |
         `ktw-lint --version` for the linter; the `@lint-...` ref for the Action; the skill version (`metadata.version` in `SKILL.md`) or the page URL for the docs.
-      placeholder: "ktw-lint 0.16.1.0"
+      placeholder: "ktw-lint 0.16.2.0"
     validations:
       required: true
 

--- a/.keep-the-why
+++ b/.keep-the-why
@@ -6,7 +6,7 @@ README, for what Keep the Why actually is.
 - id: oliver-zehentleitner---keep-the-why
 - context: `context/`
 - init: complete
-- context-schema: 0.16.1
+- context-schema: 0.16.2
 - capture-confirmation: confirm-always
 - source-reference: never
 <!-- /keep-the-why:config -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+## [0.16.2] - 2026-09-11
+
 ### Added
 
 - The skill names the dashboard: a "Reading it back" section in `SKILL.md` (`pip install keep-the-why-dashboard`, `ktw-dashboard`, https://keepthewhy.com/dashboard/ — never installed or started by the skill), one sentence at the end of the project init wizard in `references/setup.md`, and a *Tools* section in the `context/README.md` the wizard writes — linter and dashboard, what each does, both optional, neither installed by the skill (template, example, this repository's own). The same file's opening paragraphs now carry the project's current positioning — project memory for the people and the coding agents working here, "Keep a Changelog records what changed. Keep the Why preserves why it changed.", one sentence on the schema — instead of "a repo-native convention and agent skill". `references/migrations.md` 0.16.2 (informational).
@@ -13,6 +15,7 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ### Changed
 
+- `keep-the-why-lint` 0.16.2.0: knows schema 0.16.2 — no new gate, nothing changes what `context/` or `.keep-the-why` must look like. Published before the skill tag, per the checklist.
 - `SKILL.md` wording, measured before and after in isolation (6 runs per case, 48/48) and in a full run (86/88, up from 84/86/84 on 0.16.1): the setup check is silent when clean and goes on to the request in the same turn — not as a progress note either — a setup question ends the turn, a flagged value does not, an update check is mentioned only when it fails for the first time (step 0); the `source-reference` question comes before the write and a direct request to record does not skip it (step 4); a procedure is not restated inside a `context/` entry, and `Type` is one line per value, never comma-separated (step 5). Two eval prompts (`source-reference-always-no-ticket-exists`, `source-reference-filtered-matching-criterion`) describe a concrete decision instead of an abstract scenario — the abstract form hid the write-then-ask failure the concrete one exposed. Closes #384.
 - `docs/evals.md` carries the 0.16.1 release measurement: three consecutive full runs on the tag (84, 86 and 84 of 88), the four numbers per run, a note on every failed run, a row for the case added since 0.16.0, a new run-history row. The three cases behind #354–#356 went 3/3 each, the skill loaded in 263 of 264 sessions with no genuine miss, no safety refusal occurred, and the one two-time flip is the one-line `Type` the judge keeps passing and the check keeps failing (#384).
 - The site's "Why this project is built this way" section holds one page, "Read this project's context/", which is `context/index.md`; the index links every topic file, so the navigation follows it instead of listing files by hand — the hand-kept list was seven of eight, `issue-triage.md` never added (#375, #377, #379).
@@ -663,7 +666,8 @@ Initial release.
 - Logo, wordmark, and favicon.
 - `context/repo-conventions.md`, dogfooding the skill on its own repository from day one.
 
-[Unreleased]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.16.1...HEAD
+[Unreleased]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.16.2...HEAD
+[0.16.2]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.16.1...v0.16.2
 [0.16.1]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/oliver-zehentleitner/keep-the-why/compare/v0.14.1...v0.15.0

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -83,7 +83,7 @@ codex plugin marketplace add oliver-zehentleitner/keep-the-why
 codex plugin add keep-the-why@keep-the-why
 ```
 
-Add `--ref v0.16.1` (any [release tag](https://github.com/oliver-zehentleitner/keep-the-why/releases)) to the first command to pin a version; without it Codex snapshots the default branch, and `codex plugin marketplace upgrade` refreshes it. The plugin lands under `~/.codex/plugins/cache/keep-the-why/`, and a new session lists the skill as `keep-the-why:keep-the-why`. Verified 2026-09-08 with Codex CLI 0.149.0, from a local path and from GitHub. `codex plugin remove keep-the-why@keep-the-why` uninstalls it; the skill-directory route below works for Codex too, and does not copy the whole repository.
+Add `--ref v0.16.2` (any [release tag](https://github.com/oliver-zehentleitner/keep-the-why/releases)) to the first command to pin a version; without it Codex snapshots the default branch, and `codex plugin marketplace upgrade` refreshes it. The plugin lands under `~/.codex/plugins/cache/keep-the-why/`, and a new session lists the skill as `keep-the-why:keep-the-why`. Verified 2026-09-08 with Codex CLI 0.149.0, from a local path and from GitHub. `codex plugin remove keep-the-why@keep-the-why` uninstalls it; the skill-directory route below works for Codex too, and does not copy the whole repository.
 
 ## Also installable: Cursor plugin
 

--- a/lint/ktw_lint/__init__.py
+++ b/lint/ktw_lint/__init__.py
@@ -13,6 +13,6 @@ changes. PEP 440, not strict SemVer — PyPI rejects the SemVer build-
 metadata spelling this would otherwise use.
 """
 
-__version__ = "0.16.1.0"
+__version__ = "0.16.2.0"
 
-SUPPORTED_SCHEMA = (0, 16, 1)
+SUPPORTED_SCHEMA = (0, 16, 2)

--- a/llms.txt
+++ b/llms.txt
@@ -42,7 +42,7 @@ get thrown away, not creating separate documentation effort. It isn't magic, tho
 prevents knowledge from decaying on its own. This lowers the friction of the discipline that
 keeps documentation honest; it doesn't replace it.
 
-Version: 0.16.1.
+Version: 0.16.2.
 
 ## Authorship & License
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "keep-the-why",
   "description": "Project memory for coding agents and humans: the reasoning behind a codebase as Markdown in the repo, versioned by Git, so nothing rejected is proposed twice.",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "author": {
     "name": "Oliver Zehentleitner"
   },

--- a/skills/keep-the-why/SKILL.md
+++ b/skills/keep-the-why/SKILL.md
@@ -3,7 +3,7 @@ name: keep-the-why
 description: Extract and preserve the reasoning code cannot explain - decisions, rejected alternatives, workarounds, incidents, constraints - plus project setup and maintainer interviews. Not for what changed (see Keep a Changelog) - only why. Also the place for complaints, feedback and settings changes about this skill itself.
 license: MIT
 metadata:
-  version: "0.16.1"
+  version: "0.16.2"
   repository: "https://github.com/oliver-zehentleitner/keep-the-why"
   author: "Oliver Zehentleitner"
 ---

--- a/skills/keep-the-why/examples/first-time-setup.md
+++ b/skills/keep-the-why/examples/first-time-setup.md
@@ -111,7 +111,7 @@ This names the skill and its purpose directly — not a task that happens to mat
     - id: acme---widget-service
     - context: `context/`
     - init: complete
-    - context-schema: 0.16.1
+    - context-schema: 0.16.2
     - capture-confirmation: confirm-when-unsure
     - source-reference: never
     <!-- /keep-the-why:config -->

--- a/skills/keep-the-why/references/setup.md
+++ b/skills/keep-the-why/references/setup.md
@@ -17,7 +17,7 @@ README, for what Keep the Why actually is.
 - id: oliver-zehentleitner---keep-the-why
 - context: `context/`
 - init: complete
-- context-schema: 0.16.1
+- context-schema: 0.16.2
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->

--- a/skills/keep-the-why/references/specification.md
+++ b/skills/keep-the-why/references/specification.md
@@ -67,7 +67,7 @@ README, for what Keep the Why actually is.
 - id: acme---widget-service
 - context: `context/`
 - init: complete
-- context-schema: 0.16.1
+- context-schema: 0.16.2
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->


### PR DESCRIPTION
Release checklist, prepare phase (steps 1–8), nothing published yet.

- `skills/keep-the-why/SKILL.md` → 0.16.2; `plugin.json`, `.claude-plugin/`, `.codex-plugin/`, `.cursor-plugin/` manifests → 0.16.2; `llms.txt` `Version: 0.16.2.`; this repository's `.keep-the-why` `context-schema: 0.16.2`; the `context-schema` examples in `setup.md`, `specification.md`, `examples/first-time-setup.md`.
- `lint/ktw_lint/__init__.py`: `SUPPORTED_SCHEMA = (0, 16, 2)`, `__version__ = "0.16.2.0"` — no new gate, nothing structural changed (`references/migrations.md` 0.16.2 is informational).
- CHANGELOG: `## [0.16.2] - 2026-09-11` cut from Unreleased with the linter line first; compare links.
- `docs/installation.md` `--ref v0.16.2`, bug-report placeholder `ktw-lint 0.16.2.0`.

Local: `ktw-lint --strict .` from source clean on schema 0.16.2, linter tests OK, black clean. The CI consistency check covers the version-carrying files.

After the merge, in order: `publish-lint.yml` → wait for `pip install keep-the-why-lint==0.16.2.0` to resolve → tag `v0.16.2` → link-check on main → awesome-copilot bump → three full eval runs on the tag → `docs/evals.md`.