### PR TITLE
dashboard: phone layout

### DIFF
--- a/dashboard/ktw_dashboard/web/app.js
+++ b/dashboard/ktw_dashboard/web/app.js
@@ -167,12 +167,12 @@ function viewFindings(main) {
   const f = S.findings;
   main.append(el("h1", {}, "Linter findings"), el("p", { class: "sub" }, `keep-the-why-lint ${S.linter} · ${f.errors} error(s), ${f.warnings} warning(s) · structure only, never content`));
   if (!f.items.length) return main.append(el("p", { class: "center" }, "Clean — nothing to show."));
-  main.append(el("table", { class: "t findings" }, el("thead", {}, el("tr", {}, ["Severity", "Code", "Where", "Message"].map((h) => el("th", {}, h)))),
+  main.append(el("div", { class: "table-wrap" }, el("table", { class: "t findings" }, el("thead", {}, el("tr", {}, ["Severity", "Code", "Where", "Message"].map((h) => el("th", {}, h)))),
     el("tbody", {}, f.items.map((x) => {
       const entry = S.entries.find((e) => `${S.project.context}${e.file}` === x.path && e.line <= x.line && x.line <= e.end_line + 1);
       return el("tr", {}, el("td", {}, pill(x.severity, `sev-${x.severity}`)), el("td", { class: "mono" }, x.code),
         el("td", { class: "mono" }, entry ? el("a", { href: `#entry/${encodeURIComponent(entry.id)}` }, `${x.path}:${x.line}`) : `${x.path}${x.line ? ":" + x.line : ""}`), el("td", {}, x.message));
-    }))));
+    })))));
 }
 
 // ---------------------------------------------------------------- sidebar
@@ -302,7 +302,7 @@ function viewAuthors(main) {
     el("tbody", {}, rows.map((a) => el("tr", { class: `clickable ${filter.author === a.name ? "sel" : ""}`, onclick: () => { filter.author = filter.author === a.name ? "" : a.name; rerender(); } },
       el("td", {}, el("b", {}, a.name)), el("td", {}, a.created), el("td", {}, a.touched), el("td", {}, a.superseded),
       el("td", {}, el("div", { style: "min-width:160px" }, stack(a.evidence, EV_ORDER))), el("td", { class: "mono" }, fmtDate(a.first)), el("td", { class: "mono" }, fmtDate(a.last))))));
-  main.append(tbl, el("p", { class: "note", style: "margin-top:10px" }, "Click a row to filter every view to that author; click again to clear."));
+  main.append(el("div", { class: "table-wrap" }, tbl), el("p", { class: "note", style: "margin-top:10px" }, "Click a row to filter every view to that author; click again to clear."));
   if (filter.author) main.append(el("h2", {}, `Entries created by ${filter.author}`), el("div", { class: "entry-list" }, S.entries.filter((e) => authorOf(e) === filter.author).map(entryRow)));
 }
 
@@ -457,6 +457,27 @@ function runGraph(canvas, g, opts = {}) {
   canvas.onmouseleave = () => { hover = null; };
   canvas.onwheel = (ev) => { ev.preventDefault(); const r = canvas.getBoundingClientRect(); const px = ev.clientX - r.left - W / 2, py = ev.clientY - r.top - H / 2; const f = Math.exp(-ev.deltaY * 0.0012); const ns = Math.min(6, Math.max(0.15, g.scale * f)); const k = ns / g.scale; g.ox = px - (px - g.ox) * k; g.oy = py - (py - g.oy) * k; g.scale = ns; };
   canvas.ondblclick = (ev) => { const r = canvas.getBoundingClientRect(); const n = pick(ev.clientX - r.left, ev.clientY - r.top); if (n) { n.fixed = false; g.alpha = 0.4; } };
+  // touch: one finger drags a node or pans (full view only), two fingers pinch-zoom, a tap opens
+  let pinch = null;
+  const tpos = (t) => { const r = canvas.getBoundingClientRect(); return [t.clientX - r.left, t.clientY - r.top]; };
+  const tdist = (ts) => Math.hypot(ts[0].clientX - ts[1].clientX, ts[0].clientY - ts[1].clientY);
+  canvas.addEventListener("touchstart", (ev) => {
+    if (ev.touches.length === 2) { pinch = { d: tdist(ev.touches), scale: g.scale, ox: g.ox, oy: g.oy }; drag = null; pan = null; return; }
+    const [px, py] = tpos(ev.touches[0]); moved = false; const n = pick(px, py);
+    if (n) drag = n; else if (!mini) pan = { px, py, ox: g.ox, oy: g.oy };
+  }, { passive: true });
+  canvas.addEventListener("touchmove", (ev) => {
+    if (pinch && ev.touches.length === 2) { const k = tdist(ev.touches) / pinch.d; g.scale = Math.min(6, Math.max(0.15, pinch.scale * k)); ev.preventDefault(); return; }
+    if (!ev.touches.length) return;
+    const [px, py] = tpos(ev.touches[0]);
+    if (drag) { const [x, y] = toWorld(px, py); drag.x = x; drag.y = y; drag.vx = drag.vy = 0; drag.fixed = true; g.alpha = Math.max(g.alpha, 0.3); moved = true; ev.preventDefault(); }
+    else if (pan) { g.ox = pan.ox + (px - pan.px); g.oy = pan.oy + (py - pan.py); moved = true; ev.preventDefault(); }
+  }, { passive: false });
+  canvas.addEventListener("touchend", (ev) => {
+    if (pinch) { if (!ev.touches.length) pinch = null; return; }
+    if (drag && !moved) location.hash = drag.href;
+    drag = null; pan = null;
+  });
   const ev = (n) => n.entry.evidence;
   const evColor = { confirmed: color("--confirmed"), inferred: color("--inferred"), unknown: color("--unknown") };
   function step() {
@@ -597,7 +618,7 @@ function applyState(state) {
     el("span", { id: "pkg-lint" }, el("a", { href: "https://pypi.org/project/keep-the-why-lint/", target: "_blank", rel: "noopener", title: "keep-the-why-lint on PyPI" }, `keep-the-why-lint ${S.linter}`)),
     el("span", {}, S.exported ? `exported ${S.generated}` : `state ${S.generated}`),
     el("span", {}, `${S.entries.length} entries · ${S.topics.length} topics · ${S.authors.length} authors`),
-    el("span", { style: "margin-left:auto" }, el("a", { href: "https://keepthewhy.com", target: "_blank", rel: "noopener" }, "keepthewhy.com")));
+    el("span", { class: "grow" }, el("a", { href: "https://keepthewhy.com", target: "_blank", rel: "noopener" }, "keepthewhy.com")));
   const main = $("#main"); const scroll = main.scrollTop;
   rerender();
   main.scrollTop = scroll;
@@ -631,6 +652,12 @@ function connectLive() {
   };
   open();
 }
+const narrow = () => window.matchMedia?.("(max-width: 900px)").matches;
+function setupSideToggle() {
+  const btn = $("#side-toggle"); const app = $("#app");
+  btn.onclick = () => { const open = app.classList.toggle("side-open"); btn.setAttribute("aria-expanded", String(open)); btn.textContent = open ? "Topics ▴" : "Topics ▾"; };
+  window.addEventListener("hashchange", () => { if (narrow() && app.classList.contains("side-open")) btn.click(); });
+}
 function setupTheme() {
   const saved = localStorage.getItem("ktw-theme");
   const prefersLight = window.matchMedia?.("(prefers-color-scheme: light)").matches;
@@ -662,7 +689,7 @@ async function setupProjects() {
   sel.onchange = () => { location.href = `${location.pathname}?project=${encodeURIComponent(sel.value)}${location.hash || "#overview"}`; };
 }
 async function boot() {
-  setupTheme(); setupSearch(); setupProjects();
+  setupTheme(); setupSearch(); setupProjects(); setupSideToggle();
   window.addEventListener("hashchange", render);
   if (window.__KTW_STATE__) applyState(window.__KTW_STATE__);
   else {

--- a/dashboard/ktw_dashboard/web/app.js
+++ b/dashboard/ktw_dashboard/web/app.js
@@ -3,6 +3,7 @@
    embedded as window.__KTW_STATE__ in an export. It renders; it never writes. */
 
 const $ = (sel, root = document) => root.querySelector(sel);
+const narrow = () => !!window.matchMedia?.("(max-width: 900px)").matches;
 const el = (tag, attrs = {}, ...kids) => {
   const n = document.createElement(tag);
   for (const [k, v] of Object.entries(attrs)) {
@@ -312,6 +313,7 @@ function renderDetailsTopic(t) {
   d.append(el("h3", {}, "Topic"), el("div", { class: "kv" }, el("span", { class: "k" }, "file"), el("span", { class: "v mono" }, t.file), el("span", { class: "k" }, "entries"), el("span", { class: "v" }, t.entries)));
   d.append(el("h3", {}, `References out (${t.refs_out.length})`), ...(t.refs_out.length ? t.refs_out.map((f) => el("a", { class: "backlink", href: `#topic/${f}` }, topicOf(f)?.title || f)) : [el("p", { class: "empty" }, "none")]));
   d.append(el("h3", {}, `Referenced by (${t.refs_in.length})`), ...(t.refs_in.length ? t.refs_in.map((f) => el("a", { class: "backlink", href: `#topic/${f}` }, topicOf(f)?.title || f)) : [el("p", { class: "empty" }, "none")]));
+  if (narrow()) { d.append(el("h3", {}, "Graph"), el("a", { class: "backlink", href: "#graph" }, "Open the project graph →")); return; }
   const box = el("div", { class: "mini tall" }, el("span", { class: "mini-title" }, "neighbourhood"), el("span", { class: "mini-hint" }, "click to open"));
   const canvas = el("canvas"); box.prepend(canvas);
   d.append(el("h3", {}, "Graph"), box);
@@ -357,6 +359,7 @@ function renderDetailsDefault() {
       el("h3", {}, "Keys"), el("p", { class: "note" }, el("kbd", {}, "/"), " search · ", el("kbd", {}, "g"), " graph · ", el("kbd", {}, "o"), " overview · ", el("kbd", {}, "q"), " queues · ", el("kbd", {}, "t"), " timeline · ", el("kbd", {}, "a"), " authors"));
     return;
   }
+  if (narrow()) { d.append(el("h3", {}, "Graph"), el("a", { class: "backlink", href: "#graph" }, "Open the project graph →")); return; }
   const box = el("div", { class: "mini fill" }, el("span", { class: "mini-title" }, "graph"), el("span", { class: "mini-hint" }, "hover · click · g for the full view"));
   const canvas = el("canvas"); box.prepend(canvas);
   d.append(box);
@@ -364,6 +367,7 @@ function renderDetailsDefault() {
 }
 function renderDetailsNeighbourhood(e) {
   const d = $("#details");
+  if (narrow()) { d.append(el("h3", {}, "Graph"), el("a", { class: "backlink", href: "#graph" }, "Open the project graph →")); return; }
   const box = el("div", { class: "mini tall" }, el("span", { class: "mini-title" }, "neighbourhood"), el("span", { class: "mini-hint" }, "click to open"));
   const canvas = el("canvas"); box.prepend(canvas);
   d.append(el("h3", {}, "Graph"), box);
@@ -419,9 +423,9 @@ function viewGraph(main) {
   const wrap = el("div", { class: "graph-wrap" });
   const canvas = el("canvas");
   const ui = el("div", { class: "graph-ui" },
-    el("label", {}, el("input", { type: "checkbox", checked: g.showEntries, onchange: (ev) => { g.showEntries = ev.target.checked; g.alpha = 0.5; } }), "entries"),
-    el("label", {}, el("input", { type: "checkbox", checked: g.showLabels, onchange: (ev) => { g.showLabels = ev.target.checked; } }), "labels"),
-    el("button", { class: "link-btn", onclick: () => { g.scale = 1; g.ox = 0; g.oy = 0; for (const n of g.nodes) { n.fixed = false; } g.alpha = 1; } }, "reset"),
+    el("label", {}, el("input", { type: "checkbox", checked: g.showEntries, onchange: (ev) => { g.showEntries = ev.target.checked; g.alpha = 0.5; g.wake?.(); } }), "entries"),
+    el("label", {}, el("input", { type: "checkbox", checked: g.showLabels, onchange: (ev) => { g.showLabels = ev.target.checked; g.wake?.(); } }), "labels"),
+    el("button", { class: "link-btn", onclick: () => { g.scale = 1; g.ox = 0; g.oy = 0; for (const n of g.nodes) { n.fixed = false; } g.alpha = 1; g.wake?.(); } }, "reset"),
   );
   const legend = el("div", { class: "graph-legend" },
     el("span", {}, el("i", { class: "dot", style: "background:var(--accent);width:12px;height:12px" }), "topic (size = entries)"),
@@ -531,8 +535,16 @@ function runGraph(canvas, g, opts = {}) {
       }
     }
     ctx.restore();
-    if (canvas.isConnected) g.raf = requestAnimationFrame(step); else ro.disconnect();
+    if (!canvas.isConnected) { ro.disconnect(); g.raf = null; return; }
+    const busy = g.alpha > 0.003 || drag || pan || pinch || hover;
+    g.raf = busy ? requestAnimationFrame(step) : null; // idle: no frames until something happens
   }
+  const wake = () => { if (!g.raf && canvas.isConnected) g.raf = requestAnimationFrame(step); };
+  for (const evn of ["mousemove", "mousedown", "wheel", "dblclick", "touchstart", "touchmove", "mouseleave"]) canvas.addEventListener(evn, wake, { passive: true });
+  window.addEventListener("mouseup", wake);
+  g.wake = wake;
+  ro.observe(canvas); // re-observe after the resize handler above; a resize wakes the loop
+  const ro2 = new ResizeObserver(() => { resize(); if (g.alpha < 0.05) g.alpha = 0.05; wake(); }); ro2.observe(canvas);
   if (g.raf) cancelAnimationFrame(g.raf);
   g.raf = requestAnimationFrame(step);
 }
@@ -605,7 +617,7 @@ function render() {
   else if (route.startsWith("entry/")) viewEntry(main, decodeURIComponent(route.slice(6)));
   else { viewOverview(main); renderDetailsDefault(); }
   markActive();
-  if (!route.startsWith("graph")) main.scrollTop = 0;
+  if (!route.startsWith("graph")) { main.scrollTop = 0; if (narrow()) window.scrollTo(0, Math.max(0, main.getBoundingClientRect().top + window.scrollY - 4)); }
 }
 function rerender() { renderSidebar(); renderStrip(); render(); }
 function applyState(state) {
@@ -652,7 +664,6 @@ function connectLive() {
   };
   open();
 }
-const narrow = () => window.matchMedia?.("(max-width: 900px)").matches;
 function setupSideToggle() {
   const btn = $("#side-toggle"); const app = $("#app");
   btn.onclick = () => { const open = app.classList.toggle("side-open"); btn.setAttribute("aria-expanded", String(open)); btn.textContent = open ? "Topics ▴" : "Topics ▾"; };
@@ -662,7 +673,7 @@ function setupTheme() {
   const saved = localStorage.getItem("ktw-theme");
   const prefersLight = window.matchMedia?.("(prefers-color-scheme: light)").matches;
   if (saved === "light" || (!saved && prefersLight)) document.documentElement.dataset.theme = "light";
-  $("#theme").onclick = () => { const light = document.documentElement.dataset.theme === "light"; if (light) delete document.documentElement.dataset.theme; else document.documentElement.dataset.theme = "light"; localStorage.setItem("ktw-theme", light ? "dark" : "light"); if (graph) graph.alpha = Math.max(graph.alpha, 0.05); };
+  $("#theme").onclick = () => { const light = document.documentElement.dataset.theme === "light"; if (light) delete document.documentElement.dataset.theme; else document.documentElement.dataset.theme = "light"; localStorage.setItem("ktw-theme", light ? "dark" : "light"); if (graph) { graph.alpha = Math.max(graph.alpha, 0.05); graph.wake?.(); } };
 }
 function fitSelect(sel) {
   // size the select to its current option's text, not the browser's default width

--- a/dashboard/ktw_dashboard/web/app.js
+++ b/dashboard/ktw_dashboard/web/app.js
@@ -617,7 +617,7 @@ function render() {
   else if (route.startsWith("entry/")) viewEntry(main, decodeURIComponent(route.slice(6)));
   else { viewOverview(main); renderDetailsDefault(); }
   markActive();
-  if (!route.startsWith("graph")) { main.scrollTop = 0; if (narrow()) window.scrollTo(0, Math.max(0, main.getBoundingClientRect().top + window.scrollY - 4)); }
+  if (!route.startsWith("graph")) { main.scrollTop = 0; if (narrow()) { const stuck = $("#sidebar").getBoundingClientRect().height; window.scrollTo(0, Math.max(0, main.getBoundingClientRect().top + window.scrollY - stuck - 8)); } }
 }
 function rerender() { renderSidebar(); renderStrip(); render(); }
 function applyState(state) {

--- a/dashboard/ktw_dashboard/web/index.html
+++ b/dashboard/ktw_dashboard/web/index.html
@@ -30,6 +30,7 @@
       <a href="#timeline" data-route="timeline">Timeline</a>
       <a href="#authors" data-route="authors">Authors</a>
       <a href="#queues" data-route="queues">Queues <span id="queue-count" class="count"></span></a>
+      <button id="side-toggle" class="nav-toggle" type="button" aria-expanded="false">Topics ▾</button>
     </div>
     <div class="filters" id="filters">
       <select id="f-status"><option value="">status: all</option></select>

--- a/dashboard/ktw_dashboard/web/style.css
+++ b/dashboard/ktw_dashboard/web/style.css
@@ -192,7 +192,7 @@ table.t tr.clickable { cursor: pointer; }
 .details h3:first-child { margin-top: 0; }
 .details .fill { flex: 1; min-height: 0; }
 .details .mini { position: relative; min-height: 220px; height: 100%; border: 1px solid var(--line); border-radius: var(--radius); background: var(--bg); overflow: hidden; }
-.details .mini canvas { width: 100%; height: 100%; display: block; }
+.details .mini canvas { width: 100%; height: 100%; display: block; touch-action: pan-y; }
 .details .mini.tall { height: 320px; flex: none; }
 .details .mini .mini-hint { position: absolute; bottom: 6px; right: 8px; font-size: 10px; color: var(--fg3); pointer-events: none; }
 .details .mini .mini-title { position: absolute; top: 6px; left: 8px; font-size: 10px; color: var(--fg3); text-transform: uppercase; letter-spacing: .06em; pointer-events: none; }
@@ -211,7 +211,7 @@ table.t.findings td { font-size: 12.5px; } table.t.findings .mono { white-space:
 .details .finding { font-size: 12px; margin-bottom: 6px; color: var(--fg2); }
 
 .graph-wrap { position: relative; height: calc(100vh - 48px - 24px - 48px); margin: -24px -32px -60px; }
-.graph-wrap canvas { display: block; width: 100%; height: 100%; cursor: grab; }
+.graph-wrap canvas { display: block; width: 100%; height: 100%; cursor: grab; touch-action: none; }
 .graph-wrap canvas.grabbing { cursor: grabbing; }
 .graph-ui { position: absolute; top: 14px; left: 18px; display: flex; gap: 10px; align-items: center; font-size: 12px; color: var(--fg2); background: color-mix(in srgb, var(--bg2) 85%, transparent); padding: 6px 10px; border-radius: 6px; border: 1px solid var(--line); }
 .graph-ui label { display: flex; gap: 5px; align-items: center; cursor: pointer; }
@@ -234,13 +234,55 @@ table.t.findings td { font-size: 12.5px; } table.t.findings .mono { white-space:
 .note { color: var(--fg3); font-size: 12px; }
 .center { text-align: center; color: var(--fg3); padding: 60px 0; }
 kbd { font-family: var(--mono); font-size: 11px; background: var(--bg3); border: 1px solid var(--line); border-radius: 4px; padding: 0 5px; }
+.nav-toggle { display: none; background: transparent; border: 1px solid var(--line); border-radius: 999px; padding: 5px 10px; color: var(--fg2); cursor: pointer; white-space: nowrap; margin-left: 4px; }
+.table-wrap { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+.statusbar .grow { margin-left: auto; }
+
+/* ---- phones and small tablets: one column, the sidebar becomes a nav row with a Topics drawer ---- */
 @media (max-width: 900px) {
-  .app { grid-template-columns: 1fr; grid-template-rows: 48px auto auto 1fr auto 24px; grid-template-areas: "top" "strip" "side" "main" "details" "status"; height: auto; min-height: 100vh; }
-  .details .mini { height: 260px; }
-  .sidebar { max-height: 40vh; border-right: 0; border-bottom: 1px solid var(--line); }
-  .details { border-left: 0; border-top: 1px solid var(--line); }
-  #search { width: 160px; }
-  .search-results { right: 0; width: 90vw; }
-  .graph-wrap { height: 70vh; margin: -24px -16px; }
-  .main { padding: 16px; }
+  .app { grid-template-columns: 1fr; grid-template-rows: auto auto auto 1fr auto auto; grid-template-areas: "top" "strip" "side" "main" "details" "status"; height: auto; min-height: 100vh; }
+  .topbar { height: auto; min-height: 48px; flex-wrap: wrap; padding: 6px 10px; gap: 8px 10px; }
+  .topbar .project { display: none; }
+  .topbar-right { margin-left: auto; gap: 8px; }
+  .project-select { max-width: 46vw; font-size: 13px; padding: 4px 6px; }
+  .brand .wordmark { height: 24px; }
+  #search { width: 150px; }
+  .search-results { right: 0; width: min(92vw, 480px); max-height: 50vh; }
+  .strip { height: auto; flex-wrap: wrap; padding: 6px 10px; gap: 6px; white-space: normal; overflow: visible; }
+  .strip .sep { display: none; }
+  .strip .lbl { flex-basis: 100%; margin-top: 2px; }
+  .sidebar { padding: 0; max-height: none; border-right: 0; border-bottom: 1px solid var(--line); overflow: visible; }
+  .nav { display: flex; align-items: center; overflow-x: auto; gap: 2px; padding: 6px 8px; scrollbar-width: none; }
+  .nav::-webkit-scrollbar { display: none; }
+  .nav a { padding: 6px 10px; white-space: nowrap; border-radius: 999px; gap: 6px; }
+  .nav a.active { box-shadow: none; background: var(--bg3); color: var(--fg); }
+  .nav-toggle { display: inline-flex; flex: none; margin-left: auto; }
+  .app.side-open .nav-toggle { color: var(--fg); border-color: var(--accent); }
+  .filters, .tree-head, .tree { display: none; }
+  .app.side-open .filters { display: flex; padding: 8px 10px 4px; border-top: 1px solid var(--line); margin-top: 0; }
+  .app.side-open .filters select { flex: 1 1 30%; }
+  .app.side-open .tree-head { display: block; }
+  .app.side-open .tree { display: block; max-height: 55vh; overflow: auto; padding-bottom: 6px; }
+  .main { padding: 16px 14px 32px; }
+  .details { border-left: 0; border-top: 1px solid var(--line); padding: 14px; }
+  .details .mini { min-height: 240px; height: 240px; }
+  .details .mini.tall { height: 280px; }
+  .graph-wrap { height: 72vh; margin: -16px -14px -32px; }
+  .graph-ui { top: 10px; left: 10px; font-size: 11px; gap: 8px; padding: 5px 8px; }
+  .graph-legend { left: 10px; right: 10px; bottom: 10px; flex-wrap: wrap; gap: 6px 10px; }
+  .graph-hint { display: none; }
+  .statusbar { height: auto; flex-wrap: wrap; padding: 6px 10px; gap: 4px 12px; line-height: 1.4; }
+  .statusbar .grow { margin-left: 0; flex-basis: 100%; }
+  .reader h1 { font-size: 20px; }
+  .reader .body p, .reader .body ul, .reader .body ol { font-size: 14.5px; }
+  .reader .pager { flex-wrap: wrap; gap: 8px; }
+  .topic-cards { grid-template-columns: 1fr; }
+  h1 { font-size: 20px; }
+}
+@media (max-width: 600px) {
+  .topbar-right { flex: 1 1 100%; margin-left: 0; }
+  #search { flex: 1; width: auto; min-width: 0; }
+  .search-results { left: 0; right: 0; width: auto; }
+  .project-select { max-width: calc(100vw - 150px); }
+  .strip a.stat { font-size: 11px; padding: 1px 7px; }
 }

--- a/dashboard/ktw_dashboard/web/style.css
+++ b/dashboard/ktw_dashboard/web/style.css
@@ -280,9 +280,18 @@ kbd { font-family: var(--mono); font-size: 11px; background: var(--bg3); border:
   h1 { font-size: 20px; }
 }
 @media (max-width: 600px) {
+  body { font-size: 15px; }
+  .nav a, .nav-toggle { padding: 9px 12px; font-size: 14px; }
+  .strip a.stat { font-size: 12px; padding: 3px 9px; line-height: 20px; }
+  .strip .lbl { font-size: 11px; }
+  .entry-list .row .rt { font-size: 15px; } .entry-list .row .rs { font-size: 13.5px; }
+  .tree .leaf { padding: 7px 16px 7px 28px; font-size: 14px; }
+  .tree summary { padding: 8px 16px; }
+  .details { font-size: 14px; }
+  .statusbar { font-size: 12px; }
+  .filters select { font-size: 14px; padding: 7px 8px; }
   .topbar-right { flex: 1 1 100%; margin-left: 0; }
   #search { flex: 1; width: auto; min-width: 0; }
   .search-results { left: 0; right: 0; width: auto; }
   .project-select { max-width: calc(100vw - 150px); }
-  .strip a.stat { font-size: 11px; padding: 1px 7px; }
 }

--- a/dashboard/ktw_dashboard/web/style.css
+++ b/dashboard/ktw_dashboard/web/style.css
@@ -251,7 +251,7 @@ kbd { font-family: var(--mono); font-size: 11px; background: var(--bg3); border:
   .strip { height: auto; flex-wrap: wrap; padding: 6px 10px; gap: 6px; white-space: normal; overflow: visible; }
   .strip .sep { display: none; }
   .strip .lbl { flex-basis: 100%; margin-top: 2px; }
-  .sidebar { padding: 0; max-height: none; border-right: 0; border-bottom: 1px solid var(--line); overflow: visible; }
+  .sidebar { padding: 0; max-height: none; border-right: 0; border-bottom: 1px solid var(--line); overflow: visible; position: sticky; top: 0; z-index: 5; }
   .nav { display: flex; align-items: center; overflow-x: auto; gap: 2px; padding: 6px 8px; scrollbar-width: none; }
   .nav::-webkit-scrollbar { display: none; }
   .nav a { padding: 6px 10px; white-space: nowrap; border-radius: 999px; gap: 6px; }


### PR DESCRIPTION
The page was a three-column desktop grid squeezed into one column with the whole sidebar tree between the strip and the content. Now, below 900px:

- **Top bar** wraps; the schema/branch pills are hidden (they live in the overview subtitle); the project menu is capped at ~46vw; below 600px the search gets its own full-width row.
- **Strip** wraps into rows instead of scrolling sideways; section labels sit on their own line.
- **Sidebar** becomes a horizontal, swipeable nav row (Overview · Graph · Timeline · Authors · Queues) plus a **Topics ▾** button that opens filters and the topic tree as a drawer (max 55vh, scrolls); it closes again when you navigate.
- **Content** in one column: overview grid and topic cards stack, the reader's type is a notch smaller, tables (Authors, Findings) scroll inside a wrapper, the status bar wraps.
- **Graph** takes touch: one finger drags a node or pans (full view), two fingers pinch-zoom, a tap opens; `touch-action: none` on the full canvas, `pan-y` on the small ones so the page still scrolls past them. Legend wraps, hint hidden.

Desktop is unchanged. Smoke test green; live on :8765 for a phone check on the LAN.