### PR TITLE
dashboard: prepare 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+### Added
+
+- `keep-the-why-dashboard` 0.1.2: a phone layout — below 900px the top bar and the strip wrap, the sidebar becomes a horizontal nav row with a *Topics* drawer that closes on navigation and sticks to the top, content is one column with scrollable tables and larger type and touch targets under 600px, navigation scrolls the content to its top below the sticky row; the graph takes touch (drag, pan, pinch-zoom, tap to open) and its loop idles when nothing moves, on every screen size; on phones the side pane links the graph instead of running small ones.
+
 ### Changed
 
 - `docs/evals.md` carries the 0.16.2 release measurement: three consecutive full runs on the tag (86, 86 and 86 of 88), the four numbers per run, a note on every failed run, a new run-history row. All eight cases that flipped once on 0.16.1 went 3/3; deterministic checks 58/58 in every run; judge and checks agreed on all 264 gradings; no safety refusal. One two-time flip, every candidate listed before the first question under `sequential` (#414), four one-time flips.

--- a/dashboard/ktw_dashboard/__init__.py
+++ b/dashboard/ktw_dashboard/__init__.py
@@ -4,4 +4,4 @@ Own version counter, like the linter's: the dashboard releases on its own
 cadence and reads whatever context-schema the installed linter understands.
 """
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"


### PR DESCRIPTION
Version bump `0.1.1` → `0.1.2` and the CHANGELOG line. Content since 0.1.1: the phone layout (#413) — wrapping top bar and strip, nav row with a Topics drawer, one column, scroll-to-content on navigation, touch on the graph, idle graph loop. After the merge I run `publish-dashboard.yml`, which publishes to PyPI and tags `dashboard-v0.1.2`.